### PR TITLE
feat(story-5.5): enhance artist and album detail pages with navigation

### DIFF
--- a/src/components/ui/__tests__/breadcrumb.test.tsx
+++ b/src/components/ui/__tests__/breadcrumb.test.tsx
@@ -1,0 +1,170 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { Breadcrumb, breadcrumbItems, BreadcrumbItem } from '../breadcrumb';
+import { Home } from 'lucide-react';
+
+// Mock TanStack Router Link
+vi.mock('@tanstack/react-router', () => ({
+  Link: ({ children, to, ...props }: { children: React.ReactNode; to: string; [key: string]: unknown }) => (
+    <a href={to} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+describe('Breadcrumb', () => {
+  describe('rendering', () => {
+    it('renders nothing when items array is empty', () => {
+      const { container } = render(<Breadcrumb items={[]} />);
+      expect(container.firstChild).toBeNull();
+    });
+
+    it('renders a single breadcrumb item', () => {
+      const items: BreadcrumbItem[] = [{ label: 'Home' }];
+      render(<Breadcrumb items={items} />);
+
+      expect(screen.getByText('Home')).toBeInTheDocument();
+    });
+
+    it('renders multiple breadcrumb items with separators', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Artists', href: '/library/artists' },
+        { label: 'The Beatles' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      expect(screen.getByText('Dashboard')).toBeInTheDocument();
+      expect(screen.getByText('Artists')).toBeInTheDocument();
+      expect(screen.getByText('The Beatles')).toBeInTheDocument();
+    });
+
+    it('renders links for items with href', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Current Page' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      const dashboardLink = screen.getByRole('link', { name: /Dashboard/i });
+      expect(dashboardLink).toHaveAttribute('href', '/dashboard');
+    });
+
+    it('renders the last item as text (not a link)', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Current Page' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      const currentPage = screen.getByText('Current Page');
+      expect(currentPage.tagName).not.toBe('A');
+    });
+
+    it('renders icons when provided', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Home', href: '/', icon: <Home data-testid="home-icon" /> },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      expect(screen.getByTestId('home-icon')).toBeInTheDocument();
+    });
+  });
+
+  describe('accessibility', () => {
+    it('has proper nav aria-label', () => {
+      const items: BreadcrumbItem[] = [{ label: 'Home' }];
+      render(<Breadcrumb items={items} />);
+
+      const nav = screen.getByRole('navigation', { name: /breadcrumb/i });
+      expect(nav).toBeInTheDocument();
+    });
+
+    it('marks the last item with aria-current="page"', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Current Page' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      // The aria-current is on the outer span (parent of the truncate span containing text)
+      const textSpan = screen.getByText('Current Page');
+      const outerSpan = textSpan.parentElement;
+      expect(outerSpan).toHaveAttribute('aria-current', 'page');
+    });
+
+    it('does not mark intermediate items with aria-current', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Artists', href: '/library/artists' },
+        { label: 'Current Page' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      const dashboardLink = screen.getByRole('link', { name: /Dashboard/i });
+      expect(dashboardLink).not.toHaveAttribute('aria-current');
+    });
+
+    it('renders list with proper role', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'Dashboard', href: '/dashboard' },
+        { label: 'Current' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      const list = screen.getByRole('list');
+      expect(list).toBeInTheDocument();
+    });
+  });
+
+  describe('styling', () => {
+    it('applies custom className', () => {
+      const items: BreadcrumbItem[] = [{ label: 'Home' }];
+      render(<Breadcrumb items={items} className="custom-class" />);
+
+      const nav = screen.getByRole('navigation');
+      expect(nav).toHaveClass('custom-class');
+    });
+
+    it('truncates long labels on small screens', () => {
+      const items: BreadcrumbItem[] = [
+        { label: 'This is a very long breadcrumb label that should be truncated' },
+      ];
+      render(<Breadcrumb items={items} />);
+
+      const label = screen.getByText('This is a very long breadcrumb label that should be truncated');
+      expect(label).toHaveClass('truncate');
+    });
+  });
+
+  describe('breadcrumbItems presets', () => {
+    it('has dashboard preset with correct properties', () => {
+      expect(breadcrumbItems.dashboard).toEqual({
+        label: 'Dashboard',
+        href: '/dashboard',
+        icon: expect.anything(),
+      });
+    });
+
+    it('has artists preset with correct properties', () => {
+      expect(breadcrumbItems.artists).toEqual({
+        label: 'Artists',
+        href: '/library/artists',
+      });
+    });
+
+    it('has playlists preset with correct properties', () => {
+      expect(breadcrumbItems.playlists).toEqual({
+        label: 'Playlists',
+        href: '/playlists',
+      });
+    });
+
+    it('has settings preset with correct properties', () => {
+      expect(breadcrumbItems.settings).toEqual({
+        label: 'Settings',
+        href: '/settings',
+      });
+    });
+  });
+});

--- a/src/components/ui/breadcrumb.tsx
+++ b/src/components/ui/breadcrumb.tsx
@@ -1,0 +1,93 @@
+import { Link } from '@tanstack/react-router';
+import { ChevronRight, Home } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export interface BreadcrumbItem {
+  label: string;
+  href?: string;
+  icon?: React.ReactNode;
+}
+
+interface BreadcrumbProps {
+  items: BreadcrumbItem[];
+  className?: string;
+}
+
+/**
+ * Breadcrumb navigation component
+ * Provides hierarchical navigation with proper accessibility support
+ */
+export function Breadcrumb({ items, className }: BreadcrumbProps) {
+  if (items.length === 0) return null;
+
+  return (
+    <nav
+      aria-label="Breadcrumb navigation"
+      className={cn('flex items-center text-sm', className)}
+    >
+      <ol className="flex items-center flex-wrap gap-1" role="list">
+        {items.map((item, index) => {
+          const isLast = index === items.length - 1;
+          const isFirst = index === 0;
+
+          return (
+            <li key={item.href || item.label} className="flex items-center">
+              {/* Separator (not for first item) */}
+              {!isFirst && (
+                <ChevronRight
+                  className="h-4 w-4 text-muted-foreground mx-1 flex-shrink-0"
+                  aria-hidden="true"
+                />
+              )}
+
+              {/* Breadcrumb link or current page */}
+              {isLast || !item.href ? (
+                <span
+                  className={cn(
+                    'flex items-center gap-1.5 font-medium',
+                    isLast
+                      ? 'text-foreground'
+                      : 'text-muted-foreground'
+                  )}
+                  aria-current={isLast ? 'page' : undefined}
+                >
+                  {item.icon}
+                  <span className="truncate max-w-[200px] sm:max-w-[300px]">
+                    {item.label}
+                  </span>
+                </span>
+              ) : (
+                <Link
+                  to={item.href}
+                  className={cn(
+                    'flex items-center gap-1.5 text-muted-foreground hover:text-foreground',
+                    'transition-colors min-h-[44px] px-1 -mx-1',
+                    'focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 rounded-sm'
+                  )}
+                >
+                  {item.icon}
+                  <span className="truncate max-w-[150px] sm:max-w-[200px]">
+                    {item.label}
+                  </span>
+                </Link>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+    </nav>
+  );
+}
+
+/**
+ * Pre-built breadcrumb items for common navigation paths
+ */
+export const breadcrumbItems = {
+  dashboard: { label: 'Dashboard', href: '/dashboard', icon: <Home className="h-4 w-4" /> },
+  library: { label: 'Library', href: '/library' },
+  artists: { label: 'Artists', href: '/library/artists' },
+  albums: { label: 'Albums' },
+  playlists: { label: 'Playlists', href: '/playlists' },
+  settings: { label: 'Settings', href: '/settings' },
+  search: { label: 'Search', href: '/library/search' },
+};

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -77,10 +77,16 @@ import { ServerRoute as ApiPlaylistsSmartIndexServerRouteImport } from "./routes
 import { ServerRoute as ApiPlaylistsSmartPreviewServerRouteImport } from "./routes/api/playlists/smart/preview";
 import { ServerRoute as ApiPlaylistsLikedSongsSyncServerRouteImport } from "./routes/api/playlists/liked-songs/sync";
 import { ServerRoute as ApiNavidromeStreamIdServerRouteImport } from "./routes/api/navidrome/stream/$id";
+import { ServerRoute as ApiNavidromeAuthLoginServerRouteImport } from "./routes/api/navidrome/auth/login";
+import { ServerRoute as ApiNavidromeApiSongServerRouteImport } from "./routes/api/navidrome/api/song";
+import { ServerRoute as ApiNavidromeApiArtistServerRouteImport } from "./routes/api/navidrome/api/artist";
+import { ServerRoute as ApiNavidromeApiAlbumServerRouteImport } from "./routes/api/navidrome/api/album";
 import { ServerRoute as ApiNavidromeChar91DotPathChar93ServerRouteImport } from "./routes/api/navidrome/[...path]";
 import { ServerRoute as ApiPlaylistsIdSongsIndexServerRouteImport } from "./routes/api/playlists/$id/songs/index";
 import { ServerRoute as ApiPlaylistsIdSongsSongIdServerRouteImport } from "./routes/api/playlists/$id/songs/$songId";
 import { ServerRoute as ApiNavidromeStreamIdIdServerRouteImport } from "./routes/api/navidrome/stream/[id]/[id]";
+import { ServerRoute as ApiNavidromeApiArtistIdServerRouteImport } from "./routes/api/navidrome/api/artist/$id";
+import { ServerRoute as ApiNavidromeApiAlbumIdServerRouteImport } from "./routes/api/navidrome/api/album/$id";
 
 const rootServerRouteImport = createServerRootRoute();
 
@@ -429,6 +435,30 @@ const ApiNavidromeStreamIdServerRoute =
     path: "/api/navidrome/stream/$id",
     getParentRoute: () => rootServerRouteImport,
   } as any);
+const ApiNavidromeAuthLoginServerRoute =
+  ApiNavidromeAuthLoginServerRouteImport.update({
+    id: "/api/navidrome/auth/login",
+    path: "/api/navidrome/auth/login",
+    getParentRoute: () => rootServerRouteImport,
+  } as any);
+const ApiNavidromeApiSongServerRoute =
+  ApiNavidromeApiSongServerRouteImport.update({
+    id: "/api/navidrome/api/song",
+    path: "/api/navidrome/api/song",
+    getParentRoute: () => rootServerRouteImport,
+  } as any);
+const ApiNavidromeApiArtistServerRoute =
+  ApiNavidromeApiArtistServerRouteImport.update({
+    id: "/api/navidrome/api/artist",
+    path: "/api/navidrome/api/artist",
+    getParentRoute: () => rootServerRouteImport,
+  } as any);
+const ApiNavidromeApiAlbumServerRoute =
+  ApiNavidromeApiAlbumServerRouteImport.update({
+    id: "/api/navidrome/api/album",
+    path: "/api/navidrome/api/album",
+    getParentRoute: () => rootServerRouteImport,
+  } as any);
 const ApiNavidromeChar91DotPathChar93ServerRoute =
   ApiNavidromeChar91DotPathChar93ServerRouteImport.update({
     id: "/api/navidrome/[./path]",
@@ -452,6 +482,18 @@ const ApiNavidromeStreamIdIdServerRoute =
     id: "/api/navidrome/stream/id/id",
     path: "/api/navidrome/stream/id/id",
     getParentRoute: () => rootServerRouteImport,
+  } as any);
+const ApiNavidromeApiArtistIdServerRoute =
+  ApiNavidromeApiArtistIdServerRouteImport.update({
+    id: "/$id",
+    path: "/$id",
+    getParentRoute: () => ApiNavidromeApiArtistServerRoute,
+  } as any);
+const ApiNavidromeApiAlbumIdServerRoute =
+  ApiNavidromeApiAlbumIdServerRouteImport.update({
+    id: "/$id",
+    path: "/$id",
+    getParentRoute: () => ApiNavidromeApiAlbumServerRoute,
   } as any);
 
 export interface FileRoutesByFullPath {
@@ -736,10 +778,16 @@ export interface FileServerRoutesByFullPath {
   "/api/recommendations/seasonal-playlist": typeof ApiRecommendationsSeasonalPlaylistServerRoute;
   "/api/playlists": typeof ApiPlaylistsIndexServerRoute;
   "/api/navidrome/[./path]": typeof ApiNavidromeChar91DotPathChar93ServerRoute;
+  "/api/navidrome/api/album": typeof ApiNavidromeApiAlbumServerRouteWithChildren;
+  "/api/navidrome/api/artist": typeof ApiNavidromeApiArtistServerRouteWithChildren;
+  "/api/navidrome/api/song": typeof ApiNavidromeApiSongServerRoute;
+  "/api/navidrome/auth/login": typeof ApiNavidromeAuthLoginServerRoute;
   "/api/navidrome/stream/$id": typeof ApiNavidromeStreamIdServerRoute;
   "/api/playlists/liked-songs/sync": typeof ApiPlaylistsLikedSongsSyncServerRoute;
   "/api/playlists/smart/preview": typeof ApiPlaylistsSmartPreviewServerRoute;
   "/api/playlists/smart": typeof ApiPlaylistsSmartIndexServerRoute;
+  "/api/navidrome/api/album/$id": typeof ApiNavidromeApiAlbumIdServerRoute;
+  "/api/navidrome/api/artist/$id": typeof ApiNavidromeApiArtistIdServerRoute;
   "/api/navidrome/stream/id/id": typeof ApiNavidromeStreamIdIdServerRoute;
   "/api/playlists/$id/songs/$songId": typeof ApiPlaylistsIdSongsSongIdServerRoute;
   "/api/playlists/$id/songs": typeof ApiPlaylistsIdSongsIndexServerRoute;
@@ -772,10 +820,16 @@ export interface FileServerRoutesByTo {
   "/api/recommendations/seasonal-playlist": typeof ApiRecommendationsSeasonalPlaylistServerRoute;
   "/api/playlists": typeof ApiPlaylistsIndexServerRoute;
   "/api/navidrome/[./path]": typeof ApiNavidromeChar91DotPathChar93ServerRoute;
+  "/api/navidrome/api/album": typeof ApiNavidromeApiAlbumServerRouteWithChildren;
+  "/api/navidrome/api/artist": typeof ApiNavidromeApiArtistServerRouteWithChildren;
+  "/api/navidrome/api/song": typeof ApiNavidromeApiSongServerRoute;
+  "/api/navidrome/auth/login": typeof ApiNavidromeAuthLoginServerRoute;
   "/api/navidrome/stream/$id": typeof ApiNavidromeStreamIdServerRoute;
   "/api/playlists/liked-songs/sync": typeof ApiPlaylistsLikedSongsSyncServerRoute;
   "/api/playlists/smart/preview": typeof ApiPlaylistsSmartPreviewServerRoute;
   "/api/playlists/smart": typeof ApiPlaylistsSmartIndexServerRoute;
+  "/api/navidrome/api/album/$id": typeof ApiNavidromeApiAlbumIdServerRoute;
+  "/api/navidrome/api/artist/$id": typeof ApiNavidromeApiArtistIdServerRoute;
   "/api/navidrome/stream/id/id": typeof ApiNavidromeStreamIdIdServerRoute;
   "/api/playlists/$id/songs/$songId": typeof ApiPlaylistsIdSongsSongIdServerRoute;
   "/api/playlists/$id/songs": typeof ApiPlaylistsIdSongsIndexServerRoute;
@@ -809,10 +863,16 @@ export interface FileServerRoutesById {
   "/api/recommendations/seasonal-playlist": typeof ApiRecommendationsSeasonalPlaylistServerRoute;
   "/api/playlists/": typeof ApiPlaylistsIndexServerRoute;
   "/api/navidrome/[./path]": typeof ApiNavidromeChar91DotPathChar93ServerRoute;
+  "/api/navidrome/api/album": typeof ApiNavidromeApiAlbumServerRouteWithChildren;
+  "/api/navidrome/api/artist": typeof ApiNavidromeApiArtistServerRouteWithChildren;
+  "/api/navidrome/api/song": typeof ApiNavidromeApiSongServerRoute;
+  "/api/navidrome/auth/login": typeof ApiNavidromeAuthLoginServerRoute;
   "/api/navidrome/stream/$id": typeof ApiNavidromeStreamIdServerRoute;
   "/api/playlists/liked-songs/sync": typeof ApiPlaylistsLikedSongsSyncServerRoute;
   "/api/playlists/smart/preview": typeof ApiPlaylistsSmartPreviewServerRoute;
   "/api/playlists/smart/": typeof ApiPlaylistsSmartIndexServerRoute;
+  "/api/navidrome/api/album/$id": typeof ApiNavidromeApiAlbumIdServerRoute;
+  "/api/navidrome/api/artist/$id": typeof ApiNavidromeApiArtistIdServerRoute;
   "/api/navidrome/stream/id/id": typeof ApiNavidromeStreamIdIdServerRoute;
   "/api/playlists/$id/songs/$songId": typeof ApiPlaylistsIdSongsSongIdServerRoute;
   "/api/playlists/$id/songs/": typeof ApiPlaylistsIdSongsIndexServerRoute;
@@ -847,10 +907,16 @@ export interface FileServerRouteTypes {
     | "/api/recommendations/seasonal-playlist"
     | "/api/playlists"
     | "/api/navidrome/[./path]"
+    | "/api/navidrome/api/album"
+    | "/api/navidrome/api/artist"
+    | "/api/navidrome/api/song"
+    | "/api/navidrome/auth/login"
     | "/api/navidrome/stream/$id"
     | "/api/playlists/liked-songs/sync"
     | "/api/playlists/smart/preview"
     | "/api/playlists/smart"
+    | "/api/navidrome/api/album/$id"
+    | "/api/navidrome/api/artist/$id"
     | "/api/navidrome/stream/id/id"
     | "/api/playlists/$id/songs/$songId"
     | "/api/playlists/$id/songs";
@@ -883,10 +949,16 @@ export interface FileServerRouteTypes {
     | "/api/recommendations/seasonal-playlist"
     | "/api/playlists"
     | "/api/navidrome/[./path]"
+    | "/api/navidrome/api/album"
+    | "/api/navidrome/api/artist"
+    | "/api/navidrome/api/song"
+    | "/api/navidrome/auth/login"
     | "/api/navidrome/stream/$id"
     | "/api/playlists/liked-songs/sync"
     | "/api/playlists/smart/preview"
     | "/api/playlists/smart"
+    | "/api/navidrome/api/album/$id"
+    | "/api/navidrome/api/artist/$id"
     | "/api/navidrome/stream/id/id"
     | "/api/playlists/$id/songs/$songId"
     | "/api/playlists/$id/songs";
@@ -919,10 +991,16 @@ export interface FileServerRouteTypes {
     | "/api/recommendations/seasonal-playlist"
     | "/api/playlists/"
     | "/api/navidrome/[./path]"
+    | "/api/navidrome/api/album"
+    | "/api/navidrome/api/artist"
+    | "/api/navidrome/api/song"
+    | "/api/navidrome/auth/login"
     | "/api/navidrome/stream/$id"
     | "/api/playlists/liked-songs/sync"
     | "/api/playlists/smart/preview"
     | "/api/playlists/smart/"
+    | "/api/navidrome/api/album/$id"
+    | "/api/navidrome/api/artist/$id"
     | "/api/navidrome/stream/id/id"
     | "/api/playlists/$id/songs/$songId"
     | "/api/playlists/$id/songs/";
@@ -950,6 +1028,10 @@ export interface RootServerRouteChildren {
   ApiPlaylistsSyncServerRoute: typeof ApiPlaylistsSyncServerRoute;
   ApiPlaylistsIndexServerRoute: typeof ApiPlaylistsIndexServerRoute;
   ApiNavidromeChar91DotPathChar93ServerRoute: typeof ApiNavidromeChar91DotPathChar93ServerRoute;
+  ApiNavidromeApiAlbumServerRoute: typeof ApiNavidromeApiAlbumServerRouteWithChildren;
+  ApiNavidromeApiArtistServerRoute: typeof ApiNavidromeApiArtistServerRouteWithChildren;
+  ApiNavidromeApiSongServerRoute: typeof ApiNavidromeApiSongServerRoute;
+  ApiNavidromeAuthLoginServerRoute: typeof ApiNavidromeAuthLoginServerRoute;
   ApiNavidromeStreamIdServerRoute: typeof ApiNavidromeStreamIdServerRoute;
   ApiPlaylistsLikedSongsSyncServerRoute: typeof ApiPlaylistsLikedSongsSyncServerRoute;
   ApiPlaylistsSmartPreviewServerRoute: typeof ApiPlaylistsSmartPreviewServerRoute;
@@ -1425,6 +1507,34 @@ declare module "@tanstack/react-start/server" {
       preLoaderRoute: typeof ApiNavidromeStreamIdServerRouteImport;
       parentRoute: typeof rootServerRouteImport;
     };
+    "/api/navidrome/auth/login": {
+      id: "/api/navidrome/auth/login";
+      path: "/api/navidrome/auth/login";
+      fullPath: "/api/navidrome/auth/login";
+      preLoaderRoute: typeof ApiNavidromeAuthLoginServerRouteImport;
+      parentRoute: typeof rootServerRouteImport;
+    };
+    "/api/navidrome/api/song": {
+      id: "/api/navidrome/api/song";
+      path: "/api/navidrome/api/song";
+      fullPath: "/api/navidrome/api/song";
+      preLoaderRoute: typeof ApiNavidromeApiSongServerRouteImport;
+      parentRoute: typeof rootServerRouteImport;
+    };
+    "/api/navidrome/api/artist": {
+      id: "/api/navidrome/api/artist";
+      path: "/api/navidrome/api/artist";
+      fullPath: "/api/navidrome/api/artist";
+      preLoaderRoute: typeof ApiNavidromeApiArtistServerRouteImport;
+      parentRoute: typeof rootServerRouteImport;
+    };
+    "/api/navidrome/api/album": {
+      id: "/api/navidrome/api/album";
+      path: "/api/navidrome/api/album";
+      fullPath: "/api/navidrome/api/album";
+      preLoaderRoute: typeof ApiNavidromeApiAlbumServerRouteImport;
+      parentRoute: typeof rootServerRouteImport;
+    };
     "/api/navidrome/[./path]": {
       id: "/api/navidrome/[./path]";
       path: "/api/navidrome/[./path]";
@@ -1452,6 +1562,20 @@ declare module "@tanstack/react-start/server" {
       fullPath: "/api/navidrome/stream/id/id";
       preLoaderRoute: typeof ApiNavidromeStreamIdIdServerRouteImport;
       parentRoute: typeof rootServerRouteImport;
+    };
+    "/api/navidrome/api/artist/$id": {
+      id: "/api/navidrome/api/artist/$id";
+      path: "/$id";
+      fullPath: "/api/navidrome/api/artist/$id";
+      preLoaderRoute: typeof ApiNavidromeApiArtistIdServerRouteImport;
+      parentRoute: typeof ApiNavidromeApiArtistServerRoute;
+    };
+    "/api/navidrome/api/album/$id": {
+      id: "/api/navidrome/api/album/$id";
+      path: "/$id";
+      fullPath: "/api/navidrome/api/album/$id";
+      preLoaderRoute: typeof ApiNavidromeApiAlbumIdServerRouteImport;
+      parentRoute: typeof ApiNavidromeApiAlbumServerRoute;
     };
   }
 }
@@ -1552,6 +1676,34 @@ const ApiPlaylistsIdServerRouteChildren: ApiPlaylistsIdServerRouteChildren = {
 const ApiPlaylistsIdServerRouteWithChildren =
   ApiPlaylistsIdServerRoute._addFileChildren(ApiPlaylistsIdServerRouteChildren);
 
+interface ApiNavidromeApiAlbumServerRouteChildren {
+  ApiNavidromeApiAlbumIdServerRoute: typeof ApiNavidromeApiAlbumIdServerRoute;
+}
+
+const ApiNavidromeApiAlbumServerRouteChildren: ApiNavidromeApiAlbumServerRouteChildren =
+  {
+    ApiNavidromeApiAlbumIdServerRoute: ApiNavidromeApiAlbumIdServerRoute,
+  };
+
+const ApiNavidromeApiAlbumServerRouteWithChildren =
+  ApiNavidromeApiAlbumServerRoute._addFileChildren(
+    ApiNavidromeApiAlbumServerRouteChildren,
+  );
+
+interface ApiNavidromeApiArtistServerRouteChildren {
+  ApiNavidromeApiArtistIdServerRoute: typeof ApiNavidromeApiArtistIdServerRoute;
+}
+
+const ApiNavidromeApiArtistServerRouteChildren: ApiNavidromeApiArtistServerRouteChildren =
+  {
+    ApiNavidromeApiArtistIdServerRoute: ApiNavidromeApiArtistIdServerRoute,
+  };
+
+const ApiNavidromeApiArtistServerRouteWithChildren =
+  ApiNavidromeApiArtistServerRoute._addFileChildren(
+    ApiNavidromeApiArtistServerRouteChildren,
+  );
+
 const rootRouteChildren: RootRouteChildren = {
   IndexRoute: IndexRoute,
   authRouteRoute: authRouteRouteWithChildren,
@@ -1608,6 +1760,11 @@ const rootServerRouteChildren: RootServerRouteChildren = {
   ApiPlaylistsIndexServerRoute: ApiPlaylistsIndexServerRoute,
   ApiNavidromeChar91DotPathChar93ServerRoute:
     ApiNavidromeChar91DotPathChar93ServerRoute,
+  ApiNavidromeApiAlbumServerRoute: ApiNavidromeApiAlbumServerRouteWithChildren,
+  ApiNavidromeApiArtistServerRoute:
+    ApiNavidromeApiArtistServerRouteWithChildren,
+  ApiNavidromeApiSongServerRoute: ApiNavidromeApiSongServerRoute,
+  ApiNavidromeAuthLoginServerRoute: ApiNavidromeAuthLoginServerRoute,
   ApiNavidromeStreamIdServerRoute: ApiNavidromeStreamIdServerRoute,
   ApiPlaylistsLikedSongsSyncServerRoute: ApiPlaylistsLikedSongsSyncServerRoute,
   ApiPlaylistsSmartPreviewServerRoute: ApiPlaylistsSmartPreviewServerRoute,

--- a/src/routes/api/navidrome/[...path].ts
+++ b/src/routes/api/navidrome/[...path].ts
@@ -15,15 +15,14 @@ export const ServerRoute = createServerFileRoute('/api/navidrome/[./path]').meth
 
       // @ts-expect-error Params path joining for catch-all routing
       const path = params.path.join('/');
-      
+
       // Skip stream paths - let specific route handle /api/navidrome/stream/[id]
       if (path.split('/')[0] === 'stream') {
         console.log('Catch-all skipping stream path:', path, '- handled by specific route');
         return new Response('Stream path handled by specific route', { status: 404 });
       }
-      
+
       const url = new URL(`${config.navidromeUrl}/${path}`);
-      url.search = new URL(request.url).search;
       url.search = new URL(request.url).search;
 
       const headers = new Headers(request.headers);
@@ -47,7 +46,6 @@ export const ServerRoute = createServerFileRoute('/api/navidrome/[./path]').meth
       clonedHeaders.set('Access-Control-Allow-Headers', '*');
 
       const contentType = response.headers.get('content-type');
-      console.log('Catch-all response content-type:', contentType); // Debug
       if (contentType && contentType.includes('application/json')) {
         const data = await response.json();
         return new Response(JSON.stringify(data), {
@@ -64,6 +62,81 @@ export const ServerRoute = createServerFileRoute('/api/navidrome/[./path]').meth
       }
     } catch (error: unknown) {
       console.error('Navidrome proxy failed:', error);
+      let code = 'GENERAL_API_ERROR';
+      let message = 'Navidrome proxy error';
+      if (error instanceof ServiceError) {
+        code = error.code;
+        message = error.message;
+      } else if (error instanceof Error) {
+        message = error.message;
+      }
+      return new Response(JSON.stringify({ code, message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' }
+      });
+    }
+  },
+
+  POST: async ({ params, request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response('Navidrome not configured', { status: 500 });
+      }
+
+      // @ts-expect-error Params path joining for catch-all routing
+      const path = params.path.join('/');
+
+      // Auth endpoint doesn't require existing auth
+      const isAuthEndpoint = path === 'auth/login';
+
+      if (!isAuthEndpoint) {
+        // For non-auth endpoints, ensure we have auth
+        await getAuthToken();
+      }
+
+      const url = new URL(`${config.navidromeUrl}/${path}`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      headers.set('Content-Type', 'application/json');
+
+      // Add Navidrome auth headers for non-auth endpoints
+      if (!isAuthEndpoint && token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      // Get request body
+      const body = await request.text();
+
+      const response = await fetch(url.toString(), {
+        method: 'POST',
+        headers,
+        body,
+      });
+
+      const clonedHeaders = new Headers(response.headers);
+      clonedHeaders.set('Access-Control-Allow-Origin', '*');
+      clonedHeaders.set('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
+      clonedHeaders.set('Access-Control-Allow-Headers', '*');
+
+      const contentType = response.headers.get('content-type');
+      if (contentType && contentType.includes('application/json')) {
+        const data = await response.json();
+        return new Response(JSON.stringify(data), {
+          status: response.status,
+          headers: clonedHeaders,
+        });
+      } else {
+        const buffer = await response.arrayBuffer();
+        return new Response(buffer, {
+          status: response.status,
+          headers: clonedHeaders,
+        });
+      }
+    } catch (error: unknown) {
+      console.error('Navidrome proxy POST failed:', error);
       let code = 'GENERAL_API_ERROR';
       let message = 'Navidrome proxy error';
       if (error instanceof ServiceError) {

--- a/src/routes/api/navidrome/api/album.ts
+++ b/src/routes/api/navidrome/api/album.ts
@@ -1,0 +1,51 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+import { getAuthToken, token, clientId } from '@/lib/services/navidrome';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/api/album').methods({
+  GET: async ({ request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await getAuthToken();
+
+      const url = new URL(`${config.navidromeUrl}/api/album`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      if (token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      const responseHeaders = new Headers();
+      responseHeaders.set('Content-Type', 'application/json');
+      responseHeaders.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome album proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/api/navidrome/api/album/$id.ts
+++ b/src/routes/api/navidrome/api/album/$id.ts
@@ -1,0 +1,52 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+import { getAuthToken, token, clientId } from '@/lib/services/navidrome';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/api/album/$id').methods({
+  GET: async ({ params, request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await getAuthToken();
+
+      const albumId = params.id;
+      const url = new URL(`${config.navidromeUrl}/api/album/${albumId}`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      if (token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      const responseHeaders = new Headers();
+      responseHeaders.set('Content-Type', 'application/json');
+      responseHeaders.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome album detail proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/api/navidrome/api/artist.ts
+++ b/src/routes/api/navidrome/api/artist.ts
@@ -1,0 +1,51 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+import { getAuthToken, token, clientId } from '@/lib/services/navidrome';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/api/artist').methods({
+  GET: async ({ request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await getAuthToken();
+
+      const url = new URL(`${config.navidromeUrl}/api/artist`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      if (token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      const responseHeaders = new Headers();
+      responseHeaders.set('Content-Type', 'application/json');
+      responseHeaders.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome artist proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/api/navidrome/api/artist/$id.ts
+++ b/src/routes/api/navidrome/api/artist/$id.ts
@@ -1,0 +1,52 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+import { getAuthToken, token, clientId } from '@/lib/services/navidrome';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/api/artist/$id').methods({
+  GET: async ({ params, request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await getAuthToken();
+
+      const artistId = params.id;
+      const url = new URL(`${config.navidromeUrl}/api/artist/${artistId}`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      if (token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      const responseHeaders = new Headers();
+      responseHeaders.set('Content-Type', 'application/json');
+      responseHeaders.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome artist detail proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/api/navidrome/api/song.ts
+++ b/src/routes/api/navidrome/api/song.ts
@@ -1,0 +1,51 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+import { getAuthToken, token, clientId } from '@/lib/services/navidrome';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/api/song').methods({
+  GET: async ({ request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      await getAuthToken();
+
+      const url = new URL(`${config.navidromeUrl}/api/song`);
+      url.search = new URL(request.url).search;
+
+      const headers = new Headers();
+      if (token && clientId) {
+        headers.set('x-nd-authorization', `Bearer ${token}`);
+        headers.set('x-nd-client-unique-id', clientId);
+      }
+
+      const response = await fetch(url.toString(), {
+        method: 'GET',
+        headers,
+      });
+
+      const data = await response.json();
+
+      const responseHeaders = new Headers();
+      responseHeaders.set('Content-Type', 'application/json');
+      responseHeaders.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers: responseHeaders,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome song proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/api/navidrome/auth/login.ts
+++ b/src/routes/api/navidrome/auth/login.ts
@@ -1,0 +1,44 @@
+import { createServerFileRoute } from '@tanstack/react-start/server';
+import { getConfig } from '@/lib/config/config';
+
+export const ServerRoute = createServerFileRoute('/api/navidrome/auth/login').methods({
+  POST: async ({ request }) => {
+    try {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        return new Response(JSON.stringify({ error: 'Navidrome not configured' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      // Get request body
+      const body = await request.text();
+
+      // Forward to Navidrome
+      const response = await fetch(`${config.navidromeUrl}/auth/login`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body,
+      });
+
+      const data = await response.json();
+
+      const headers = new Headers();
+      headers.set('Content-Type', 'application/json');
+      headers.set('Access-Control-Allow-Origin', '*');
+
+      return new Response(JSON.stringify(data), {
+        status: response.status,
+        headers,
+      });
+    } catch (error: unknown) {
+      console.error('Navidrome auth proxy failed:', error);
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      return new Response(JSON.stringify({ error: message }), {
+        status: 500,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    }
+  },
+});

--- a/src/routes/library/artists/$id.tsx
+++ b/src/routes/library/artists/$id.tsx
@@ -1,8 +1,23 @@
 import { createFileRoute, Link, useParams, useNavigate, redirect } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
-import { getAlbums } from '@/lib/services/navidrome';
-import { Loader2, Music } from 'lucide-react';
+import { useState } from 'react';
+import { getAlbums, getArtistDetail, getSongsByArtist } from '@/lib/services/navidrome';
+import { useAudioStore } from '@/lib/stores/audio';
+import { Loader2, Music, ArrowLeft, Disc, ListMusic, Play, Plus, ListPlus } from 'lucide-react';
 import { Card, CardContent } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Breadcrumb, breadcrumbItems } from '@/components/ui/breadcrumb';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { toast } from 'sonner';
+import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
+import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
 
 export const Route = createFileRoute('/library/artists/$id')({
   beforeLoad: async ({ context }) => {
@@ -10,119 +25,432 @@ export const Route = createFileRoute('/library/artists/$id')({
       throw redirect({ to: '/login' });
     }
   },
-  component: ArtistAlbums,
+  component: ArtistDetail,
 });
 
-function ArtistAlbums() {
+function ArtistDetail() {
   const { id } = useParams({ from: '/library/artists/$id' }) as { id: string };
   const navigate = useNavigate();
+  const [activeTab, setActiveTab] = useState<'all' | 'albums' | 'songs'>('all');
+  const { playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress } = useAudioStore();
 
-  const { data: albums = [], isLoading: loadingAlbums, error } = useQuery({
+  // Fetch artist details for the header
+  const {
+    data: artist,
+    isLoading: loadingArtist,
+    error: artistError,
+  } = useQuery({
+    queryKey: ['artist', id],
+    queryFn: () => getArtistDetail(id),
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  // Fetch albums for this artist
+  const {
+    data: albums = [],
+    isLoading: loadingAlbums,
+    error: albumsError,
+  } = useQuery({
     queryKey: ['albums', id],
     queryFn: () => getAlbums(id, 0, 50),
     retry: 1,
     refetchOnWindowFocus: false,
   });
 
-  console.log('Artist ID:', id);
-  console.log('Albums:', albums);
-  console.log('Loading:', loadingAlbums);
-  console.log('Error:', error);
+  // Fetch songs for this artist
+  const {
+    data: songs = [],
+    isLoading: loadingSongs,
+    error: songsError,
+  } = useQuery({
+    queryKey: ['artistSongs', id],
+    queryFn: () => getSongsByArtist(id, 0, 100),
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  // Fetch feedback for all songs
+  const songIds = songs.map(song => song.id);
+  const { data: feedbackData } = useSongFeedback(songIds);
+  const feedback = feedbackData?.feedback || {};
+
+  const error = artistError || albumsError || songsError;
+  const isLoading = loadingArtist || loadingAlbums || loadingSongs;
+
+  // Build breadcrumb items
+  const breadcrumbPath = [
+    breadcrumbItems.dashboard,
+    breadcrumbItems.artists,
+    {
+      label: artist?.name || 'Loading...',
+    },
+  ];
+
+  const handleSongClick = (songId: string) => {
+    playSong(songId, songs);
+  };
+
+  const handleAddToQueue = (song: typeof songs[0], position: 'now' | 'next' | 'end') => {
+    const songName = song.name || song.title || 'Unknown';
+    const audioSong = {
+      id: song.id,
+      name: songName,
+      title: songName,
+      artist: song.artist,
+      album: song.album,
+      albumId: song.albumId,
+      url: `/api/navidrome/stream/${song.id}`,
+      duration: song.duration,
+      track: song.track,
+    };
+
+    if (position === 'now') {
+      playSong(song.id, songs);
+      setIsPlaying(true);
+      toast.success(`Now playing "${songName}"`);
+    } else if (position === 'next') {
+      setAIUserActionInProgress(true);
+      addToQueueNext([audioSong]);
+      toast.success(`Added "${songName}" to play next`);
+      setTimeout(() => setAIUserActionInProgress(false), 2000);
+    } else {
+      setAIUserActionInProgress(true);
+      addToQueueEnd([audioSong]);
+      toast.success(`Added "${songName}" to end of queue`);
+      setTimeout(() => setAIUserActionInProgress(false), 2000);
+    }
+  };
 
   if (error) {
     return (
-      <div className="container mx-auto p-6">
+      <div className="container mx-auto p-3 sm:p-6">
+        {/* Breadcrumb */}
+        <Breadcrumb
+          items={[
+            breadcrumbItems.dashboard,
+            breadcrumbItems.artists,
+            { label: 'Error' },
+          ]}
+          className="mb-4"
+        />
+
         <Card className="p-6 bg-destructive/10 border-destructive">
-          <h2 className="text-xl font-bold text-destructive mb-2">Error loading albums</h2>
-          <p className="text-sm">{error.message}</p>
-          <Link to="/library/artists" className="text-primary hover:underline mt-4 inline-block">
-            ← Back to Artists
-          </Link>
+          <h2 className="text-xl font-bold text-destructive mb-2">
+            Error loading artist
+          </h2>
+          <p className="text-sm mb-4">{error.message}</p>
+          <Button variant="outline" asChild>
+            <Link to="/library/artists">
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Artists
+            </Link>
+          </Button>
         </Card>
       </div>
     );
   }
 
-  const sortedAlbums = [...albums].sort((a, b) => a.name.localeCompare(b.name));
+  const sortedAlbums = [...albums].sort((a, b) => (a.name || '').localeCompare(b.name || ''));
+  const sortedSongs = [...songs].sort((a, b) => (a.name || a.title || '').localeCompare(b.name || b.title || ''));
+
+  const renderAlbumCard = (album: typeof albums[0]) => (
+    <Card
+      key={album.id}
+      className="cursor-pointer transition-shadow hover:shadow-md border-border/50 overflow-hidden"
+    >
+      <CardContent className="p-0">
+        <div
+          className="block p-3 sm:p-4 hover:bg-accent hover:text-accent-foreground transition-colors min-h-[44px]"
+          onClick={() =>
+            navigate({
+              to: '/library/artists/$id/albums/$albumId',
+              params: { id, albumId: album.id },
+            })
+          }
+          role="button"
+          tabIndex={0}
+          aria-label={`View album: ${album.name}${album.year ? ` (${album.year})` : ''}`}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              navigate({
+                to: '/library/artists/$id/albums/$albumId',
+                params: { id, albumId: album.id },
+              });
+            }
+          }}
+        >
+          <div className="aspect-square w-full rounded-lg mb-2 sm:mb-3 overflow-hidden bg-muted flex items-center justify-center">
+            {album.artwork ? (
+              <img
+                src={album.artwork}
+                alt={`Album cover for ${album.name}`}
+                className="w-full h-full object-cover"
+                loading="lazy"
+              />
+            ) : (
+              <Disc className="h-12 w-12 text-muted-foreground" />
+            )}
+          </div>
+          <div className="space-y-1">
+            <div className="font-semibold line-clamp-2 text-xs sm:text-sm text-foreground">
+              {album.name}
+            </div>
+            {album.year ? (
+              <div className="text-xs text-muted-foreground">
+                {album.year}
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+
+  const renderSongRow = (song: typeof songs[0]) => (
+    <div
+      key={song.id}
+      className="flex items-center p-3 sm:p-4 border rounded hover:bg-accent transition-colors min-h-[44px]"
+    >
+      <div
+        className="flex-1 min-w-0 cursor-pointer hover:text-accent-foreground"
+        onClick={() => handleSongClick(song.id)}
+        role="button"
+        tabIndex={0}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            handleSongClick(song.id);
+          }
+        }}
+      >
+        <div className="font-medium truncate text-sm sm:text-base">{song.name || song.title || 'Unknown'}</div>
+        <div className="text-xs sm:text-sm text-muted-foreground">
+          {song.album && <span>{song.album} • </span>}
+          {Math.floor(song.duration / 60)}:{Math.floor(song.duration % 60).toString().padStart(2, '0')}
+        </div>
+      </div>
+      <div className="ml-2 flex items-center gap-2 flex-shrink-0">
+        <DropdownMenu>
+          <DropdownMenuTrigger asChild>
+            <Button
+              variant="default"
+              size="sm"
+              className="h-9 w-9 p-0 bg-green-600 hover:bg-green-700 text-white shadow-sm"
+              onClick={(e) => e.stopPropagation()}
+            >
+              <ListPlus className="h-4 w-4" />
+              <span className="sr-only">Add to queue</span>
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="end" className="w-40">
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleAddToQueue(song, 'now');
+              }}
+              className="min-h-[44px]"
+            >
+              <Play className="mr-2 h-4 w-4" />
+              Play Now
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleAddToQueue(song, 'next');
+              }}
+              className="min-h-[44px]"
+            >
+              <Play className="mr-2 h-4 w-4" />
+              Play Next
+            </DropdownMenuItem>
+            <DropdownMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                handleAddToQueue(song, 'end');
+              }}
+              className="min-h-[44px]"
+            >
+              <Plus className="mr-2 h-4 w-4" />
+              Add to End
+            </DropdownMenuItem>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <SongFeedbackButtons
+          songId={song.id}
+          artistName={song.artist || 'Unknown Artist'}
+          songTitle={song.name || song.title || 'Unknown'}
+          currentFeedback={feedback[song.id] || null}
+          source="library"
+          size="sm"
+        />
+      </div>
+    </div>
+  );
 
   return (
     <div className="container mx-auto p-3 sm:p-6 space-y-4 sm:space-y-6">
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb items={breadcrumbPath} />
+
+      {/* Header Card */}
       <Card>
         <CardContent className="p-4 sm:p-6">
-          <div className="flex flex-col sm:flex-row justify-between items-start gap-4 mb-4 sm:mb-6">
+          <div className="flex flex-col sm:flex-row justify-between items-start gap-4">
+            {/* Artist Info */}
             <div className="flex items-center gap-3 sm:gap-4">
               <div className="w-12 h-12 sm:w-16 sm:h-16 bg-muted rounded-full flex items-center justify-center flex-shrink-0">
                 <Music className="h-6 w-6 sm:h-8 sm:w-8 text-muted-foreground" />
               </div>
               <div>
-                <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">Artist Albums</h1>
-                <p className="text-sm sm:text-base text-muted-foreground mt-1">
-                  {albums.length} {albums.length === 1 ? 'album' : 'albums'}
-                </p>
+                {loadingArtist ? (
+                  <>
+                    <Skeleton className="h-8 w-48 mb-2" />
+                    <Skeleton className="h-4 w-24" />
+                  </>
+                ) : (
+                  <>
+                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
+                      {artist?.name || 'Unknown Artist'}
+                    </h1>
+                    <p className="text-sm sm:text-base text-muted-foreground mt-1">
+                      {albums.length} {albums.length === 1 ? 'album' : 'albums'}
+                      {' '}&bull;{' '}
+                      {songs.length} {songs.length === 1 ? 'song' : 'songs'}
+                    </p>
+                  </>
+                )}
               </div>
             </div>
-            <Link to="/dashboard" className="text-primary hover:underline text-sm min-h-[44px] flex items-center">
-              ← Dashboard
-            </Link>
+
+            {/* Back Button */}
+            <Button
+              variant="outline"
+              asChild
+              className="min-h-[44px]"
+            >
+              <Link to="/library/artists">
+                <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />
+                <span>Back to Artists</span>
+              </Link>
+            </Button>
           </div>
         </CardContent>
       </Card>
 
-      {loadingAlbums ? (
+      {/* Tabs for Albums/Songs */}
+      {isLoading ? (
         <div className="flex justify-center py-12">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
-      ) : sortedAlbums.length === 0 ? (
-        <Card className="text-center py-12">
-          <CardContent>
-            <Music className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
-            <p className="text-muted-foreground">No albums found for this artist.</p>
-            <p className="text-sm mt-2 text-muted-foreground">Check your library configuration.</p>
-          </CardContent>
-        </Card>
       ) : (
-        <div>
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
-            {sortedAlbums.map((album) => (
-              <Card key={album.id} className="cursor-pointer transition-shadow hover:shadow-md border-border/50 overflow-hidden">
-                <CardContent className="p-0">
-                  <div
-                    className="block p-3 sm:p-4 hover:bg-accent hover:text-accent-foreground transition-colors min-h-[44px]"
-                    onClick={() => navigate({ to: '/library/artists/$id/albums/$albumId', params: { id, albumId: album.id } })}
-                    role="button"
-                    tabIndex={0}
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        navigate({ to: '/library/artists/$id/albums/$albumId', params: { id, albumId: album.id } });
-                      }
-                    }}
-                  >
-                    <div className="aspect-square w-full rounded-lg mb-2 sm:mb-3 overflow-hidden bg-muted flex items-center justify-center">
-                      {album.artwork ? (
-                        <img
-                          src={album.artwork}
-                          alt={album.name}
-                          className="w-full h-full object-cover"
-                          loading="lazy"
-                        />
-                      ) : (
-                        <Music className="h-12 w-12 text-muted-foreground" />
-                      )}
-                    </div>
-                    <div className="space-y-1">
-                      <div className="font-semibold line-clamp-2 text-xs sm:text-sm text-foreground">{album.name}</div>
-                      {album.year ? <div className="text-xs text-muted-foreground">{album.year}</div> : null}
-                    </div>
-                  </div>
+        <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as 'all' | 'albums' | 'songs')}>
+          <TabsList className="grid w-full grid-cols-3 mb-4 h-12">
+            <TabsTrigger value="all">
+              All
+            </TabsTrigger>
+            <TabsTrigger value="albums">
+              <Disc className="h-4 w-4 mr-2" />
+              Albums ({albums.length})
+            </TabsTrigger>
+            <TabsTrigger value="songs">
+              <ListMusic className="h-4 w-4 mr-2" />
+              Songs ({songs.length})
+            </TabsTrigger>
+          </TabsList>
+
+          {/* All Content */}
+          <TabsContent value="all" className="space-y-6">
+            {/* Albums Section */}
+            {sortedAlbums.length > 0 && (
+              <div>
+                <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <Disc className="h-5 w-5" />
+                  Albums
+                </h2>
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
+                  {sortedAlbums.map(renderAlbumCard)}
+                </div>
+              </div>
+            )}
+
+            {/* Songs Section */}
+            {sortedSongs.length > 0 && (
+              <div>
+                <h2 className="text-lg font-semibold mb-3 flex items-center gap-2">
+                  <ListMusic className="h-5 w-5" />
+                  Songs
+                </h2>
+                <div className="space-y-2">
+                  {sortedSongs.slice(0, 20).map(renderSongRow)}
+                  {sortedSongs.length > 20 && (
+                    <Button
+                      variant="ghost"
+                      className="w-full"
+                      onClick={() => setActiveTab('songs')}
+                    >
+                      View all {songs.length} songs
+                    </Button>
+                  )}
+                </div>
+              </div>
+            )}
+
+            {sortedAlbums.length === 0 && sortedSongs.length === 0 && (
+              <Card className="text-center py-12">
+                <CardContent>
+                  <Music className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                  <p className="text-muted-foreground">
+                    No albums or songs found for this artist.
+                  </p>
                 </CardContent>
               </Card>
-            ))}
-          </div>
-        </div>
+            )}
+          </TabsContent>
+
+          {/* Albums Tab */}
+          <TabsContent value="albums">
+            {sortedAlbums.length === 0 ? (
+              <Card className="text-center py-12">
+                <CardContent>
+                  <Disc className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                  <p className="text-muted-foreground">No albums found.</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
+                {sortedAlbums.map(renderAlbumCard)}
+              </div>
+            )}
+          </TabsContent>
+
+          {/* Songs Tab */}
+          <TabsContent value="songs">
+            {sortedSongs.length === 0 ? (
+              <Card className="text-center py-12">
+                <CardContent>
+                  <ListMusic className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+                  <p className="text-muted-foreground">No songs found.</p>
+                </CardContent>
+              </Card>
+            ) : (
+              <div className="space-y-2">
+                {sortedSongs.map(renderSongRow)}
+              </div>
+            )}
+          </TabsContent>
+        </Tabs>
       )}
 
+      {/* Bottom Navigation */}
       <div className="text-center pt-4 border-t">
-        <Link to="/dashboard" className="text-primary hover:underline">← Back to Dashboard</Link>
+        <Button variant="ghost" asChild className="min-h-[44px]">
+          <Link to="/library/artists">
+            <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />
+            Back to Artists
+          </Link>
+        </Button>
       </div>
     </div>
   );

--- a/src/routes/library/artists/$id/albums/$albumId.tsx
+++ b/src/routes/library/artists/$id/albums/$albumId.tsx
@@ -1,11 +1,14 @@
-import { createFileRoute, useParams, redirect } from '@tanstack/react-router';
+import { createFileRoute, useParams, redirect, Link } from '@tanstack/react-router';
 import { useQuery } from '@tanstack/react-query';
-import { getSongs } from '@/lib/services/navidrome';
+import { getSongs, getAlbumDetail, getArtistDetail } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
-import { Loader2, Play, Plus, ListPlus } from 'lucide-react';
+import { Loader2, Play, Plus, ListPlus, ArrowLeft, Disc } from 'lucide-react';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
 import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
 import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+import { Breadcrumb, breadcrumbItems } from '@/components/ui/breadcrumb';
+import { Skeleton } from '@/components/ui/skeleton';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -24,12 +27,42 @@ export const Route = createFileRoute('/library/artists/$id/albums/$albumId')({
 });
 
 function AlbumSongs() {
-  const { albumId } = useParams({ from: '/library/artists/$id/albums/$albumId' }) as { albumId: string };
+  const { id: artistId, albumId } = useParams({ from: '/library/artists/$id/albums/$albumId' }) as { id: string; albumId: string };
   const { playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress } = useAudioStore();
 
-  const { data: songs = [], isLoading, error } = useQuery({
+  // Fetch album details
+  const {
+    data: album,
+    isLoading: loadingAlbum,
+    error: albumError,
+  } = useQuery({
+    queryKey: ['albumDetail', albumId],
+    queryFn: () => getAlbumDetail(albumId),
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  // Fetch artist details for breadcrumb
+  const {
+    data: artist,
+    isLoading: loadingArtist,
+  } = useQuery({
+    queryKey: ['artist', artistId],
+    queryFn: () => getArtistDetail(artistId),
+    retry: 1,
+    refetchOnWindowFocus: false,
+  });
+
+  // Fetch songs for this album
+  const {
+    data: songs = [],
+    isLoading: loadingSongs,
+    error: songsError,
+  } = useQuery({
     queryKey: ['songs', albumId],
-    queryFn: () => getSongs(albumId, 0, 50), // Fetch first 50 songs for the album
+    queryFn: () => getSongs(albumId, 0, 100),
+    retry: 1,
+    refetchOnWindowFocus: false,
   });
 
   // Fetch feedback for all songs
@@ -37,15 +70,32 @@ function AlbumSongs() {
   const { data: feedbackData } = useSongFeedback(songIds);
   const feedback = feedbackData?.feedback || {};
 
+  const error = albumError || songsError;
+  const isLoading = loadingAlbum || loadingArtist || loadingSongs;
+
+  // Build breadcrumb items
+  const breadcrumbPath = [
+    breadcrumbItems.dashboard,
+    breadcrumbItems.artists,
+    {
+      label: artist?.name || 'Artist',
+      href: `/library/artists/${artistId}`,
+    },
+    {
+      label: album?.name || 'Loading...',
+    },
+  ];
+
   const handleSongClick = (songId: string) => {
     playSong(songId, songs);
   };
 
   const handleAddToQueue = (song: typeof songs[0], position: 'now' | 'next' | 'end') => {
+    const songName = song.name || song.title || 'Unknown';
     const audioSong = {
       id: song.id,
-      name: song.name,
-      title: song.name,
+      name: songName,
+      title: songName,
       artist: song.artist,
       album: song.album,
       albumId: song.albumId,
@@ -57,34 +107,137 @@ function AlbumSongs() {
     if (position === 'now') {
       playSong(song.id, songs);
       setIsPlaying(true);
-      toast.success(`Now playing "${song.name}"`);
+      toast.success(`Now playing "${songName}"`);
     } else if (position === 'next') {
       setAIUserActionInProgress(true);
       addToQueueNext([audioSong]);
-      toast.success(`Added "${song.name}" to play next`);
+      toast.success(`Added "${songName}" to play next`);
       setTimeout(() => setAIUserActionInProgress(false), 2000);
     } else {
       setAIUserActionInProgress(true);
       addToQueueEnd([audioSong]);
-      toast.success(`Added "${song.name}" to end of queue`);
+      toast.success(`Added "${songName}" to end of queue`);
       setTimeout(() => setAIUserActionInProgress(false), 2000);
     }
   };
 
+  // Calculate total duration
+  const totalDuration = songs.reduce((acc, song) => acc + song.duration, 0);
+  const totalMinutes = Math.floor(totalDuration / 60);
+  const totalHours = Math.floor(totalMinutes / 60);
+  const remainingMinutes = totalMinutes % 60;
+
   if (error) {
-    return <div className="container mx-auto p-4">Error loading songs: {error.message}</div>;
+    return (
+      <div className="container mx-auto p-3 sm:p-6">
+        {/* Breadcrumb */}
+        <Breadcrumb
+          items={[
+            breadcrumbItems.dashboard,
+            breadcrumbItems.artists,
+            { label: 'Error' },
+          ]}
+          className="mb-4"
+        />
+
+        <Card className="p-6 bg-destructive/10 border-destructive">
+          <h2 className="text-xl font-bold text-destructive mb-2">
+            Error loading album
+          </h2>
+          <p className="text-sm mb-4">{error.message}</p>
+          <Button variant="outline" asChild>
+            <Link to={`/library/artists/${artistId}`}>
+              <ArrowLeft className="h-4 w-4 mr-2" />
+              Back to Artist
+            </Link>
+          </Button>
+        </Card>
+      </div>
+    );
   }
 
   // Sort songs by track number
   const sortedSongs = [...songs].sort((a, b) => a.track - b.track);
 
   return (
-    <div className="container mx-auto p-3 sm:p-6">
-      <h1 className="text-2xl sm:text-3xl font-bold mb-4 sm:mb-6">Songs</h1>
+    <div className="container mx-auto p-3 sm:p-6 space-y-4 sm:space-y-6">
+      {/* Breadcrumb Navigation */}
+      <Breadcrumb items={breadcrumbPath} />
+
+      {/* Header Card */}
+      <Card>
+        <CardContent className="p-4 sm:p-6">
+          <div className="flex flex-col sm:flex-row justify-between items-start gap-4">
+            {/* Album Info */}
+            <div className="flex items-center gap-3 sm:gap-4">
+              <div className="w-16 h-16 sm:w-20 sm:h-20 bg-muted rounded-lg flex items-center justify-center flex-shrink-0 overflow-hidden">
+                {album?.artwork ? (
+                  <img
+                    src={album.artwork}
+                    alt={`Album cover for ${album.name}`}
+                    className="w-full h-full object-cover"
+                  />
+                ) : (
+                  <Disc className="h-8 w-8 sm:h-10 sm:w-10 text-muted-foreground" />
+                )}
+              </div>
+              <div>
+                {loadingAlbum ? (
+                  <>
+                    <Skeleton className="h-8 w-48 mb-2" />
+                    <Skeleton className="h-4 w-32 mb-1" />
+                    <Skeleton className="h-4 w-24" />
+                  </>
+                ) : (
+                  <>
+                    <h1 className="text-2xl sm:text-3xl font-bold tracking-tight">
+                      {album?.name || 'Unknown Album'}
+                    </h1>
+                    <p className="text-sm sm:text-base text-muted-foreground mt-1">
+                      {artist?.name || album?.artist || 'Unknown Artist'}
+                      {album?.year ? ` • ${album.year}` : ''}
+                    </p>
+                    <p className="text-xs sm:text-sm text-muted-foreground">
+                      {songs.length} {songs.length === 1 ? 'song' : 'songs'}
+                      {totalDuration > 0 && (
+                        <>
+                          {' '}&bull;{' '}
+                          {totalHours > 0 ? `${totalHours} hr ${remainingMinutes} min` : `${totalMinutes} min`}
+                        </>
+                      )}
+                    </p>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {/* Back Button */}
+            <Button
+              variant="outline"
+              asChild
+              className="min-h-[44px]"
+            >
+              <Link to={`/library/artists/${artistId}`}>
+                <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />
+                <span>Back to Artist</span>
+              </Link>
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      {/* Songs List */}
       {isLoading ? (
         <div className="flex justify-center py-12">
           <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
         </div>
+      ) : sortedSongs.length === 0 ? (
+        <Card className="text-center py-12">
+          <CardContent>
+            <Disc className="h-12 w-12 text-muted-foreground mx-auto mb-4" />
+            <p className="text-muted-foreground">No songs found in this album.</p>
+          </CardContent>
+        </Card>
       ) : (
         <div className="space-y-2">
           {sortedSongs.map((song) => (
@@ -107,9 +260,9 @@ function AlbumSongs() {
                   }
                 }}
               >
-                <div className="font-medium truncate text-sm sm:text-base">{song.name}</div>
+                <div className="font-medium truncate text-sm sm:text-base">{song.name || song.title || 'Unknown'}</div>
                 <div className="text-xs sm:text-sm text-muted-foreground">
-                  Duration: {Math.floor(song.duration / 60)}:{(song.duration % 60).toString().padStart(2, '0')}
+                  {Math.floor(song.duration / 60)}:{Math.floor(song.duration % 60).toString().padStart(2, '0')}
                 </div>
               </div>
               <div className="ml-2 flex items-center gap-2 flex-shrink-0">
@@ -161,7 +314,7 @@ function AlbumSongs() {
                 <SongFeedbackButtons
                   songId={song.id}
                   artistName={song.artist || 'Unknown Artist'}
-                  songTitle={song.name}
+                  songTitle={song.name || song.title || 'Unknown'}
                   currentFeedback={feedback[song.id] || null}
                   source="library"
                   size="sm"
@@ -171,6 +324,16 @@ function AlbumSongs() {
           ))}
         </div>
       )}
+
+      {/* Bottom Navigation */}
+      <div className="text-center pt-4 border-t">
+        <Button variant="ghost" asChild className="min-h-[44px]">
+          <Link to={`/library/artists/${artistId}`}>
+            <ArrowLeft className="h-4 w-4 mr-2" aria-hidden="true" />
+            Back to Artist
+          </Link>
+        </Button>
+      </div>
     </div>
   );
 }


### PR DESCRIPTION
Story 5.5: Artist Page Navigation & Context Improvements

**Navigation:**
- Add reusable Breadcrumb component with pre-built items for common paths
- Implement breadcrumb navigation on artist and album detail pages
- Add back buttons for easy navigation

**Artist Detail Page:**
- Show albums AND songs together with tabbed interface (All/Albums/Songs)
- Display artist header with album/song counts
- Add song playback and queue management functionality
- Include feedback buttons for rating songs

**Album Detail Page:**
- Enhanced layout with album artwork, artist name, year, and duration
- Breadcrumb showing full navigation path (Dashboard > Artists > Artist > Album)
- Song list sorted by track number with playback controls

**Navidrome Integration:**
- Add API proxy routes for browser-side requests (CORS fix)
- Add getAlbumDetail and getSongsByArtist service functions
- Proxy routes for /api/artist, /api/album, /api/song endpoints

**Bug Fixes:**
- Fix duration display showing floating point decimals (3:19.43... -> 3:19)
- Fix null safety for songs with title instead of name property
- Fix tab indicator alignment in artist page tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)