### PR TITLE
Crossfade v2: Dual-deck system with iOS fixes and AI DJ improvements

### DIFF
--- a/docs/architecture/ai-dj-mode-hybrid-plan.md
+++ b/docs/architecture/ai-dj-mode-hybrid-plan.md
@@ -1,0 +1,340 @@
+# AI DJ Mode - Hybrid Recommendation Architecture
+
+> **Status:** Planning
+> **Created:** 2026-01-26
+> **Author:** AI-assisted design session
+
+## Overview
+
+AI DJ Mode allows users to press play with an empty queue and have the AI DJ automatically generate a personalized 5-10 song starter queue based on their listening profile. The system uses a **hybrid approach**: pre-computed candidate pools for fast response, with dynamic filtering/ranking at play time.
+
+## Goals
+
+1. **Zero-latency startup** - No waiting for API calls when user presses play
+2. **Personalized** - Based on user's listening history, liked songs, and preferences
+3. **Smart transitions** - BPM and energy matching for smooth DJ-like flow
+4. **Continuous** - Drip-feed recommendations every 3 songs keeps the mix going
+
+---
+
+## High-Level Architecture
+
+```
+┌─────────────────────────────────────────────────────────────────────┐
+│                    DAILY PRE-COMPUTATION (Background Job)           │
+│                                                                     │
+│  1. Sync Navidrome starred songs → likedSongsSync                  │
+│  2. Calculate artist affinities from listening history             │
+│  3. Calculate temporal preferences (genre by time of day)          │
+│  4. Update compound scores from recent plays                       │
+│  5. Generate "AI DJ Candidate Pool" → ~100 top songs               │
+│     - Top compound scored songs                                     │
+│     - Top artist affinity songs                                     │
+│     - Liked/starred songs                                           │
+│     - Store with: songId, artist, title, genre, BPM, energy, key   │
+└─────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│              AT PLAY TIME (User presses play, queue empty)          │
+│                                                                     │
+│  1. Load candidate pool from DB (zero API calls)                   │
+│  2. Apply dynamic filters:                                         │
+│     - Time of day preference (morning=chill, night=upbeat)         │
+│     - Exclude recently played (last 24h)                           │
+│     - Exclude skipped songs                                         │
+│  3. Pick seed song (highest scored candidate)                      │
+│  4. Build queue with BPM/Energy trajectory:                        │
+│     - Analyze seed energy level                                     │
+│     - If low energy: gradual build-up                              │
+│     - If high energy: maintain intensity                           │
+│     - BPM transitions: ±10 BPM between songs                       │
+│  5. Return 5-10 songs, start playback                              │
+└─────────────────────────────────────────────────────────────────────┘
+                                    │
+                                    ▼
+┌─────────────────────────────────────────────────────────────────────┐
+│                    ONGOING (Drip-Feed Every 3 Songs)                │
+│                                                                     │
+│  Uses same candidate pool + dynamic BPM/energy matching            │
+│  Inserts recommendation right after current song                   │
+│  Visual: Colored duration bar indicates AI DJ active               │
+└─────────────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Existing Infrastructure (Already Built)
+
+### Database Tables
+
+| Table | What It Stores | Updated When |
+|-------|---------------|--------------|
+| `artistAffinities` | User's affinity per artist (plays, likes, skips) | Periodically |
+| `temporalPreferences` | Genre preferences by time of day/season | Periodically |
+| `compoundScores` | Songs suggested by multiple played songs | After plays |
+| `trackSimilarities` | Cached Last.fm similar tracks | 30-day cache |
+| `listeningHistory` | Every song play with skip detection | Real-time |
+| `recommendationFeedback` | Thumbs up/down feedback | Real-time |
+| `likedSongsSync` | Synced starred songs from Navidrome | On sync |
+
+### Existing Scoring Mechanisms
+
+- **Compound scoring** - Songs suggested by multiple plays rank higher
+- **Skip scoring** - Penalize frequently skipped songs
+- **DJ match scoring** - BPM, energy, key compatibility
+- **Blended scoring** - Combines all signals with weights
+
+---
+
+## New Components Required
+
+### 1. Database: AI DJ Candidate Pool Table
+
+```sql
+CREATE TABLE ai_dj_candidate_pool (
+  id TEXT PRIMARY KEY,
+  user_id TEXT NOT NULL REFERENCES users(id),
+
+  -- Song identifiers
+  song_id TEXT NOT NULL,
+  artist TEXT NOT NULL,
+  title TEXT NOT NULL,
+  album TEXT,
+  genre TEXT,
+
+  -- DJ metadata (for BPM/energy matching)
+  bpm REAL,
+  energy REAL,        -- 0.0-1.0
+  musical_key TEXT,   -- e.g., "Am", "C", "F#m"
+
+  -- Pre-computed scores
+  profile_score REAL NOT NULL,      -- Combined score from all signals
+  compound_score REAL DEFAULT 0,    -- From compound scoring
+  affinity_score REAL DEFAULT 0,    -- From artist affinity
+  is_liked INTEGER DEFAULT 0,       -- 1 if starred/liked
+  play_count INTEGER DEFAULT 0,     -- Total plays
+
+  -- Source tracking (for debugging/analytics)
+  source TEXT,        -- 'compound', 'affinity', 'liked', 'mixed'
+
+  -- Timestamps
+  calculated_at TIMESTAMP NOT NULL,
+  expires_at TIMESTAMP NOT NULL,    -- Recalculate after this
+
+  UNIQUE(user_id, song_id)
+);
+
+-- Indexes
+CREATE INDEX ai_dj_pool_user_score_idx ON ai_dj_candidate_pool(user_id, profile_score DESC);
+CREATE INDEX ai_dj_pool_user_energy_idx ON ai_dj_candidate_pool(user_id, energy);
+CREATE INDEX ai_dj_pool_user_bpm_idx ON ai_dj_candidate_pool(user_id, bpm);
+CREATE INDEX ai_dj_pool_expires_idx ON ai_dj_candidate_pool(expires_at);
+```
+
+### 2. Service: Candidate Pool Generator
+
+**File:** `src/lib/services/ai-dj-pool-generator.ts`
+
+```typescript
+interface CandidatePoolConfig {
+  maxCandidates: number;      // Default: 100
+  compoundWeight: number;     // Default: 0.35
+  affinityWeight: number;     // Default: 0.30
+  likedWeight: number;        // Default: 0.25
+  playCountWeight: number;    // Default: 0.10
+  expiryHours: number;        // Default: 24
+}
+
+async function generateCandidatePool(userId: string, config?: CandidatePoolConfig): Promise<void> {
+  // 1. Fetch top compound scored songs (limit 50)
+  // 2. Fetch top artist affinity songs (limit 50)
+  // 3. Fetch all liked/starred songs
+  // 4. Merge and dedupe by songId
+  // 5. Enrich with DJ metadata (BPM, energy, key) from Navidrome
+  // 6. Calculate combined profile_score
+  // 7. Store top 100 in ai_dj_candidate_pool
+}
+```
+
+### 3. Service: Initial Queue Builder
+
+**File:** `src/lib/services/ai-dj-queue-builder.ts`
+
+```typescript
+interface QueueBuilderOptions {
+  queueSize: number;          // Default: 7 (5-10 range)
+  energyMode: 'build' | 'maintain' | 'descend' | 'auto';
+  maxBpmDelta: number;        // Default: 10
+  timeOfDayBoost: boolean;    // Default: true
+}
+
+async function buildInitialQueue(userId: string, options?: QueueBuilderOptions): Promise<Song[]> {
+  // 1. Load candidate pool from DB
+  // 2. Apply exclusions (recently played, skipped)
+  // 3. Apply time-of-day filtering
+  // 4. Pick seed song (highest scored after filters)
+  // 5. Build queue using BPM/energy trajectory
+  // 6. Return ordered list of songs
+}
+```
+
+### 4. BPM/Energy Trajectory Algorithm
+
+```typescript
+type EnergyMode = 'build' | 'maintain' | 'peak';
+
+function determineEnergyMode(seedEnergy: number): EnergyMode {
+  if (seedEnergy < 0.4) return 'build';      // Low energy → build up
+  if (seedEnergy < 0.7) return 'maintain';   // Medium → maintain
+  return 'peak';                              // High → stay high or gentle descent
+}
+
+function selectNextSong(
+  candidates: CandidateSong[],
+  previousSong: { bpm: number; energy: number },
+  mode: EnergyMode,
+  position: number,
+  totalSongs: number
+): CandidateSong {
+  // Filter by BPM range (±10 of previous)
+  const bpmFiltered = candidates.filter(c =>
+    Math.abs(c.bpm - previousSong.bpm) <= 10
+  );
+
+  // Score by energy trajectory
+  const scored = bpmFiltered.map(c => {
+    let energyScore = 0;
+
+    switch (mode) {
+      case 'build':
+        // Prefer slightly higher energy (but not too much)
+        const targetEnergy = previousSong.energy + (0.1 * (position / totalSongs));
+        energyScore = 1 - Math.abs(c.energy - targetEnergy);
+        break;
+      case 'maintain':
+        // Prefer similar energy (±0.1)
+        energyScore = 1 - Math.abs(c.energy - previousSong.energy);
+        break;
+      case 'peak':
+        // Stay high or gentle descent
+        energyScore = c.energy >= previousSong.energy - 0.1 ? 1 : 0.5;
+        break;
+    }
+
+    return { ...c, trajectoryScore: energyScore };
+  });
+
+  // Pick highest trajectory score
+  return scored.sort((a, b) => b.trajectoryScore - a.trajectoryScore)[0];
+}
+```
+
+### 5. API Endpoint
+
+**File:** `src/routes/api/ai-dj/generate-queue.ts`
+
+```typescript
+// POST /api/ai-dj/generate-queue
+// Request: { queueSize?: number, energyMode?: string }
+// Response: { songs: Song[], source: 'pool', metadata: { ... } }
+```
+
+### 6. UI Changes
+
+#### Now Playing Button Enhancement
+
+When queue is empty and AI DJ is enabled:
+- Button triggers `buildInitialQueue()` instead of "nothing to play"
+- Shows brief loading state: "AI DJ is curating..."
+- Starts playback immediately when queue is ready
+
+#### Visual Indicator: Colored Duration Bar
+
+When AI DJ mode is active:
+- Progress/duration bar has a subtle gradient or accent color
+- Could be purple gradient (matches AI DJ branding)
+- Indicates to user that AI DJ is in control
+
+**Implementation options:**
+1. CSS class toggle on PlayerBar when `aiDJEnabled && hasAIDJGeneratedQueue`
+2. Gradient: `bg-gradient-to-r from-purple-500/20 to-pink-500/20`
+
+---
+
+## Implementation Phases
+
+### Phase 1: Database & Pool Generator
+- [ ] Create `ai_dj_candidate_pool` table schema
+- [ ] Run migration
+- [ ] Implement `generateCandidatePool()` service
+- [ ] Add to existing daily/periodic job (or create new one)
+
+### Phase 2: Queue Builder
+- [ ] Implement `buildInitialQueue()` service
+- [ ] Implement BPM/energy trajectory algorithm
+- [ ] Add time-of-day filtering logic
+- [ ] Create API endpoint `/api/ai-dj/generate-queue`
+
+### Phase 3: Audio Store Integration
+- [ ] Modify play button logic to detect empty queue + AI DJ enabled
+- [ ] Call `buildInitialQueue()` when conditions met
+- [ ] Update drip-feed to use candidate pool with BPM matching
+
+### Phase 4: UI Polish
+- [ ] Add colored duration bar when AI DJ active
+- [ ] Add loading state for queue generation
+- [ ] Add indicator showing "AI DJ Mode" somewhere subtle
+
+---
+
+## Configuration Options
+
+### User Preferences (AI DJ Settings)
+
+| Setting | Default | Range | Description |
+|---------|---------|-------|-------------|
+| `aiDJInitialQueueSize` | 7 | 5-10 | Songs to generate on empty queue |
+| `aiDJEnergyMode` | 'auto' | auto/build/maintain | How to handle energy trajectory |
+| `aiDJBpmTolerance` | 10 | 5-20 | Max BPM difference between songs |
+| `aiDJTimeOfDayBoost` | true | bool | Adjust for time of day |
+
+### Scoring Weights (Internal)
+
+| Signal | Weight | Rationale |
+|--------|--------|-----------|
+| Compound Score | 35% | Multiple plays suggest this song |
+| Artist Affinity | 30% | User loves this artist |
+| Liked/Starred | 25% | Explicit positive signal |
+| Play Count | 10% | Frequency matters but less than quality |
+
+---
+
+## Open Questions
+
+1. **Pool refresh frequency** - Daily at midnight? Or after every N plays?
+2. **Cold start** - What if user has no listening history? Fall back to liked songs only? Random high-rated songs?
+3. **Pool size** - 100 candidates enough? Or should we go larger (200)?
+4. **Energy detection** - Do we have reliable energy data from Navidrome, or need to analyze/estimate?
+
+---
+
+## Related Documents
+
+- [Recommendation Engine Refactor](./recommendation-engine-refactor.md)
+- [Profile-Based Recommendations Plan](../../.claude/plans/glowing-churning-naur.md)
+
+---
+
+## Appendix: Existing Files Reference
+
+| File | Purpose |
+|------|---------|
+| `src/lib/services/compound-scoring.ts` | Compound score calculation |
+| `src/lib/services/artist-affinity.ts` | Artist affinity calculation |
+| `src/lib/services/profile-recommendations.ts` | Current profile-based recs |
+| `src/lib/services/dj-match-scorer.ts` | BPM/energy/key scoring |
+| `src/lib/services/blended-recommendation-scorer.ts` | Multi-signal scoring |
+| `src/lib/db/schema/profile.schema.ts` | Profile tables (affinity, temporal) |
+| `src/lib/db/schema/listening-history.schema.ts` | History + compound scores |
+| `src/lib/stores/audio.ts` | Audio player + AI DJ state |

--- a/docs/architecture/ios-audio-resilience-plan.md
+++ b/docs/architecture/ios-audio-resilience-plan.md
@@ -1,0 +1,352 @@
+# iOS Audio Resilience - Comprehensive Plan
+
+> **Status:** Planning
+> **Created:** 2026-01-27
+> **Context:** Dual-deck crossfade system with iOS Safari background playback
+
+## Research Summary
+
+### Industry State of Affairs
+
+iOS Safari HTML5 audio is notoriously unreliable. Even popular libraries like [howler.js](https://github.com/goldfire/howler.js/issues/1753) struggle with:
+- Audio not playing after returning from background
+- Random playback stops ([Issue #862](https://github.com/goldfire/howler.js/issues/862))
+- iOS 15+ blocking Web Audio API in background ([Issue #1525](https://github.com/goldfire/howler.js/issues/1525))
+- Live streams buffering forever on iOS 17.4 ([Issue #1711](https://github.com/goldfire/howler.js/issues/1711))
+
+### Key Patterns from Research
+
+| Pattern | Source | Implementation |
+|---------|--------|----------------|
+| **AudioContext state check** | howler.js #1753 | Check for `"suspended"` or `"interrupted"` before play |
+| **User interaction warm-up** | [GitHub Gist](https://gist.github.com/kus/3f01d60569eeadefe3a1) | Prime audio on first user gesture |
+| **Stalled event → load()** | [Apple Community](https://discussions.apple.com/thread/6838273) | Force reload on stall, but beware false positives |
+| **Buffer monitoring** | [Mediabuffer](https://github.com/krisnoble/Mediabuffer) | Track buffered vs currentTime ratio |
+
+### What We Already Have
+
+| Feature | Status | Notes |
+|---------|--------|-------|
+| Dual-deck crossfade | ✅ | With abort fallback |
+| Mobile deck priming | ✅ | Silent audio on first play |
+| Visibility recovery | ✅ | Stall detection + resume |
+| Media Session debounce | ✅ | Bluetooth glitch protection |
+| isPlaying sync defense | ✅ | Won't pause playing audio |
+| Buffer stall detection | ✅ | On visibility change only |
+
+---
+
+## Gap Analysis
+
+### Critical Gaps
+
+#### 1. No Real-Time Stall Detection
+**Problem:** Buffer stall detection only runs on visibility change. If user is actively using the app and audio stalls mid-playback, there's no recovery.
+
+**Evidence:** Logs showed `time=77.4` frozen while `buffered=77.3` - playback stalled but no recovery attempted until user switched away and back.
+
+**Solution:** Implement a stall watchdog that monitors `currentTime` progress.
+
+#### 2. No `stalled` Event Handling
+**Problem:** HTML5 audio fires `stalled` when buffering fails (~3 seconds no data). We don't handle it.
+
+**Caveat:** Safari fires `stalled` spuriously during normal playback. Need to filter false positives.
+
+**Solution:** Handle `stalled` event with debouncing and validation.
+
+#### 3. No AudioContext State Recovery
+**Problem:** iOS can suspend the AudioContext when backgrounded. We don't check/resume it.
+
+**Evidence:** howler.js recommends checking `Howler.ctx.state === "suspended"` before play.
+
+**Solution:** Check AudioContext state on visibility change and before play attempts.
+
+### Medium Priority Gaps
+
+#### 4. Both Decks Have Progress Edge Case
+**Problem:** If both decks have `currentTime > 0` after failed crossfade cleanup, activeDeckRef correction might pick wrong one.
+
+**Solution:** Use most recent activity timestamp or highest currentTime as tiebreaker.
+
+#### 5. Network Recovery
+**Problem:** When network goes offline→online, no automatic recovery for stalled playback.
+
+**Solution:** Listen for `online` event and attempt recovery if audio was playing.
+
+### Low Priority Gaps
+
+#### 6. Duration = Infinity Handling
+**Problem:** Streaming audio shows `Infinity` duration. Crossfade timing based on `duration - currentTime` won't work.
+
+**Solution:** Skip crossfade for infinite duration streams, or use time-based heuristics.
+
+---
+
+## Implementation Plan
+
+### Phase 1: Stall Watchdog (High Priority)
+
+Add a real-time stall detector that monitors playback progress.
+
+```typescript
+// Stall watchdog state
+const lastProgressTimeRef = useRef<number>(0);
+const lastProgressValueRef = useRef<number>(0);
+const stallCheckIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+// In a useEffect:
+const STALL_THRESHOLD_MS = 5000; // 5 seconds no progress = stall
+const CHECK_INTERVAL_MS = 2000;  // Check every 2 seconds
+
+stallCheckIntervalRef.current = setInterval(() => {
+  const audio = getActiveDeck();
+  if (!audio || audio.paused || !useAudioStore.getState().isPlaying) return;
+
+  const now = Date.now();
+  const currentProgress = audio.currentTime;
+
+  // Check if time has advanced
+  if (currentProgress > lastProgressValueRef.current + 0.5) {
+    // Progress made - reset watchdog
+    lastProgressTimeRef.current = now;
+    lastProgressValueRef.current = currentProgress;
+  } else if (now - lastProgressTimeRef.current > STALL_THRESHOLD_MS) {
+    // Stalled! Attempt recovery
+    console.log('🚨 [STALL WATCHDOG] Playback stalled - attempting recovery');
+    attemptStallRecovery(audio);
+    lastProgressTimeRef.current = now; // Reset to prevent rapid retries
+  }
+}, CHECK_INTERVAL_MS);
+```
+
+**Recovery Strategy:**
+1. First attempt: `audio.play()` - kicks browser to continue buffering
+2. Second attempt: Seek back 2-5 seconds and play
+3. Third attempt: `audio.load()` then seek to position and play
+4. Final fallback: Skip to next song
+
+### Phase 2: Stalled Event Handler (Medium Priority)
+
+Handle the HTML5 `stalled` event with false-positive filtering.
+
+```typescript
+const stalledCountRef = useRef<number>(0);
+const lastStalledTimeRef = useRef<number>(0);
+
+const handleStalled = (e: Event) => {
+  const deck = e.target as HTMLAudioElement;
+  if (deck !== getActiveDeck()) return; // Ignore inactive deck
+
+  const now = Date.now();
+
+  // Filter false positives: Safari fires stalled during normal load
+  // Only act if we were playing and time hasn't advanced
+  if (deck.paused) return;
+  if (deck.currentTime < 1) return; // Still loading initial data
+
+  // Debounce: don't fire repeatedly
+  if (now - lastStalledTimeRef.current < 10000) return;
+  lastStalledTimeRef.current = now;
+
+  console.log('🔴 [STALLED EVENT] Browser reports stall');
+
+  // Check if we're actually stalled (buffered <= currentTime)
+  const bufferedEnd = deck.buffered.length > 0
+    ? deck.buffered.end(deck.buffered.length - 1)
+    : 0;
+
+  if (deck.currentTime >= bufferedEnd - 1) {
+    // Genuine stall - attempt recovery
+    attemptStallRecovery(deck);
+  }
+};
+```
+
+### Phase 3: AudioContext State Check (Medium Priority)
+
+Check and resume AudioContext on visibility change and play attempts.
+
+```typescript
+const checkAndResumeAudioContext = async () => {
+  // Get the AudioContext (create if needed for analysis)
+  const audioContext = new (window.AudioContext || (window as any).webkitAudioContext)();
+
+  if (audioContext.state === 'suspended' || audioContext.state === 'interrupted') {
+    console.log(`🔊 [AUDIO CONTEXT] State is ${audioContext.state} - resuming`);
+    try {
+      await audioContext.resume();
+      console.log('🔊 [AUDIO CONTEXT] Resumed successfully');
+      return true;
+    } catch (err) {
+      console.error('🔊 [AUDIO CONTEXT] Resume failed:', err);
+      return false;
+    }
+  }
+  return true;
+};
+
+// Call before play attempts:
+const safePlay = async (audio: HTMLAudioElement) => {
+  await checkAndResumeAudioContext();
+  return audio.play();
+};
+```
+
+### Phase 4: Network Recovery (Low Priority)
+
+Listen for network restoration and recover stalled playback.
+
+```typescript
+useEffect(() => {
+  const handleOnline = () => {
+    console.log('🌐 [NETWORK] Back online');
+
+    const audio = getActiveDeck();
+    const storeIsPlaying = useAudioStore.getState().isPlaying;
+
+    if (audio && storeIsPlaying && audio.paused) {
+      console.log('🌐 [NETWORK] Attempting to resume playback after reconnect');
+      audio.play().catch(err => {
+        console.log('🌐 [NETWORK] Resume failed:', err.message);
+      });
+    }
+  };
+
+  window.addEventListener('online', handleOnline);
+  return () => window.removeEventListener('online', handleOnline);
+}, [getActiveDeck]);
+```
+
+### Phase 5: Edge Case Hardening (Low Priority)
+
+#### Both Decks Have Progress
+```typescript
+// In activeDeckRef correction logic:
+if (deckAHasProgress && deckBHasProgress) {
+  // Both have progress - use the one with higher currentTime (more recent)
+  const correctDeck = deckA.currentTime > deckB.currentTime ? 'A' : 'B';
+  if (activeDeckRef.current !== correctDeck) {
+    console.log(`🎮 [STORE] Both decks have progress - using ${correctDeck} (higher currentTime)`);
+    activeDeckRef.current = correctDeck;
+  }
+}
+```
+
+#### Infinite Duration Handling
+```typescript
+// In crossfade trigger logic:
+if (!isFinite(deck.duration)) {
+  console.log('[XFADE] Skipping crossfade - infinite duration (live stream)');
+  return; // Don't attempt crossfade for live streams
+}
+```
+
+---
+
+## Recovery Function
+
+Centralized stall recovery with escalating strategies:
+
+```typescript
+const recoveryAttemptRef = useRef<number>(0);
+const MAX_RECOVERY_ATTEMPTS = 3;
+
+const attemptStallRecovery = async (audio: HTMLAudioElement) => {
+  const attempt = ++recoveryAttemptRef.current;
+  const savedTime = audio.currentTime;
+
+  console.log(`🔧 [RECOVERY] Attempt ${attempt}/${MAX_RECOVERY_ATTEMPTS} at ${savedTime.toFixed(1)}s`);
+
+  if (attempt > MAX_RECOVERY_ATTEMPTS) {
+    console.log('🔧 [RECOVERY] Max attempts reached - skipping to next song');
+    recoveryAttemptRef.current = 0;
+    nextSong();
+    return;
+  }
+
+  // Check AudioContext first
+  await checkAndResumeAudioContext();
+
+  try {
+    if (attempt === 1) {
+      // Attempt 1: Simple play() to kick buffering
+      await audio.play();
+      console.log('🔧 [RECOVERY] Attempt 1 succeeded (play())');
+    } else if (attempt === 2) {
+      // Attempt 2: Seek back and play
+      const seekTarget = Math.max(0, savedTime - 3);
+      audio.currentTime = seekTarget;
+      await audio.play();
+      console.log(`🔧 [RECOVERY] Attempt 2 succeeded (seek to ${seekTarget.toFixed(1)}s)`);
+    } else {
+      // Attempt 3: Full reload
+      const src = audio.src;
+      audio.src = '';
+      audio.src = src;
+      audio.currentTime = Math.max(0, savedTime - 5);
+      await audio.play();
+      console.log('🔧 [RECOVERY] Attempt 3 succeeded (reload)');
+    }
+
+    // Success - reset counter after brief delay
+    setTimeout(() => {
+      recoveryAttemptRef.current = 0;
+    }, 5000);
+
+  } catch (err) {
+    console.log(`🔧 [RECOVERY] Attempt ${attempt} failed:`, (err as Error).message);
+    // Will retry on next watchdog check
+  }
+};
+```
+
+---
+
+## Testing Checklist
+
+### Stall Scenarios to Test
+- [ ] Buffer underrun mid-playback (slow network simulation)
+- [ ] Return from background after long idle
+- [ ] Bluetooth disconnect/reconnect during playback
+- [ ] Network offline→online during playback
+- [ ] Lock screen for extended period
+- [ ] Switch to different app and back
+- [ ] Crossfade during low buffer condition
+
+### Recovery Verification
+- [ ] Watchdog detects stall within 5 seconds
+- [ ] Recovery attempts escalate correctly
+- [ ] Max attempts triggers skip to next song
+- [ ] No false positives during normal playback
+- [ ] No recovery loops (rapid retry prevention)
+
+---
+
+## Implementation Priority
+
+| Phase | Priority | Effort | Impact |
+|-------|----------|--------|--------|
+| Phase 1: Stall Watchdog | High | Medium | High |
+| Phase 2: Stalled Event | Medium | Low | Medium |
+| Phase 3: AudioContext | Medium | Low | Medium |
+| Phase 4: Network Recovery | Low | Low | Low |
+| Phase 5: Edge Cases | Low | Low | Low |
+
+**Recommended Order:** Phase 1 → Phase 3 → Phase 2 → Phase 4 → Phase 5
+
+---
+
+## Related Documents
+
+- [AI DJ Mode Hybrid Plan](./ai-dj-mode-hybrid-plan.md)
+- [Profile-Based Recommendations](./.claude/plans/glowing-churning-naur.md)
+
+## Sources
+
+- [howler.js Issue #1753 - Background Audio Recovery](https://github.com/goldfire/howler.js/issues/1753)
+- [howler.js Issue #862 - Random Audio Stops](https://github.com/goldfire/howler.js/issues/862)
+- [howler.js Issue #1525 - iOS 15 Background Blocking](https://github.com/goldfire/howler.js/issues/1525)
+- [MDN - HTMLMediaElement stalled event](https://developer.mozilla.org/en-US/docs/Web/API/HTMLMediaElement/stalled_event)
+- [Apple Community - Safari Audio Stalls](https://discussions.apple.com/thread/6838273)
+- [Mediabuffer - Buffer Management](https://github.com/krisnoble/Mediabuffer)
+- [iOS AudioContext Fix Gist](https://gist.github.com/kus/3f01d60569eeadefe3a1)

--- a/docs/screenshots/.gitkeep
+++ b/docs/screenshots/.gitkeep
@@ -1,0 +1,1 @@
+# Keep this directory in git for README screenshots

--- a/drizzle/0016_profile-tables.sql
+++ b/drizzle/0016_profile-tables.sql
@@ -1,0 +1,51 @@
+CREATE TABLE "artist_affinities" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"artist" text NOT NULL,
+	"affinity_score" real DEFAULT 0 NOT NULL,
+	"play_count" integer DEFAULT 0 NOT NULL,
+	"liked_count" integer DEFAULT 0 NOT NULL,
+	"skip_count" integer DEFAULT 0 NOT NULL,
+	"total_play_time" integer DEFAULT 0 NOT NULL,
+	"calculated_at" timestamp NOT NULL,
+	CONSTRAINT "artist_affinities_unique" UNIQUE("user_id","artist")
+);
+--> statement-breakpoint
+CREATE TABLE "liked_songs_sync" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"song_id" text NOT NULL,
+	"artist" text NOT NULL,
+	"title" text NOT NULL,
+	"synced_at" timestamp NOT NULL,
+	"is_active" integer DEFAULT 1 NOT NULL,
+	CONSTRAINT "liked_songs_sync_unique" UNIQUE("user_id","song_id")
+);
+--> statement-breakpoint
+CREATE TABLE "temporal_preferences" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"time_slot" text NOT NULL,
+	"season" text,
+	"genre" text NOT NULL,
+	"preference_score" real DEFAULT 0 NOT NULL,
+	"play_count" integer DEFAULT 0 NOT NULL,
+	"calculated_at" timestamp NOT NULL,
+	CONSTRAINT "temporal_preferences_unique" UNIQUE("user_id","time_slot","season","genre")
+);
+--> statement-breakpoint
+ALTER TABLE "discovery_job_state" ADD COLUMN "max_suggestions_per_run" integer DEFAULT 15 NOT NULL;--> statement-breakpoint
+ALTER TABLE "discovery_job_state" ADD COLUMN "seed_count" integer DEFAULT 10 NOT NULL;--> statement-breakpoint
+ALTER TABLE "artist_affinities" ADD CONSTRAINT "artist_affinities_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "liked_songs_sync" ADD CONSTRAINT "liked_songs_sync_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "temporal_preferences" ADD CONSTRAINT "temporal_preferences_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "artist_affinities_user_id_idx" ON "artist_affinities" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "artist_affinities_user_score_idx" ON "artist_affinities" USING btree ("user_id","affinity_score");--> statement-breakpoint
+CREATE INDEX "artist_affinities_artist_idx" ON "artist_affinities" USING btree ("artist");--> statement-breakpoint
+CREATE INDEX "liked_songs_sync_user_id_idx" ON "liked_songs_sync" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "liked_songs_sync_song_id_idx" ON "liked_songs_sync" USING btree ("song_id");--> statement-breakpoint
+CREATE INDEX "liked_songs_sync_user_active_idx" ON "liked_songs_sync" USING btree ("user_id","is_active");--> statement-breakpoint
+CREATE INDEX "temporal_preferences_user_id_idx" ON "temporal_preferences" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "temporal_preferences_user_time_idx" ON "temporal_preferences" USING btree ("user_id","time_slot");--> statement-breakpoint
+CREATE INDEX "temporal_preferences_user_season_idx" ON "temporal_preferences" USING btree ("user_id","season");--> statement-breakpoint
+CREATE INDEX "temporal_preferences_genre_idx" ON "temporal_preferences" USING btree ("genre");

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,6606 @@
+{
+  "id": "100846fa-a11a-4c62-9c55-4696ada2a650",
+  "prevId": "076cdbe5-7aaf-413f-97b6-ca938c3596dc",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations_cache": {
+      "name": "recommendations_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_count": {
+          "name": "feedback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recommendations_cache_user_id_user_id_fk": {
+          "name": "recommendations_cache_user_id_user_id_fk",
+          "tableFrom": "recommendations_cache",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_settings": {
+          "name": "recommendation_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"aiEnabled\":true,\"frequency\":\"always\",\"styleBasedPlaylists\":true,\"useFeedbackForPersonalization\":true,\"enableSeasonalRecommendations\":true,\"syncFeedbackToNavidrome\":true,\"aiDJEnabled\":false,\"aiDJQueueThreshold\":2,\"aiDJBatchSize\":3,\"aiDJUseCurrentContext\":true,\"aiDJGenreExploration\":50,\"autoplayEnabled\":false,\"autoplayBlendMode\":\"crossfade\",\"autoplayTransitionDuration\":4,\"autoplaySmartTransitions\":true}'::jsonb"
+        },
+        "playback_settings": {
+          "name": "playback_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"volume\":0.5,\"autoplayNext\":true,\"crossfadeDuration\":0,\"defaultQuality\":\"high\"}'::jsonb"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"browserNotifications\":false,\"downloadCompletion\":true,\"recommendationUpdates\":true}'::jsonb"
+        },
+        "dashboard_layout": {
+          "name": "dashboard_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"showRecommendations\":true,\"showRecentlyPlayed\":true,\"widgetOrder\":[\"recommendations\",\"recentlyPlayed\"]}'::jsonb"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_feedback": {
+      "name": "recommendation_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_cache_id": {
+          "name": "recommendation_cache_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommendation'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hour_of_day": {
+          "name": "hour_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_feedback_user_id_idx": {
+          "name": "recommendation_feedback_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_timestamp_idx": {
+          "name": "recommendation_feedback_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_cache_id_idx": {
+          "name": "recommendation_feedback_cache_id_idx",
+          "columns": [
+            {
+              "expression": "recommendation_cache_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_type_time_idx": {
+          "name": "recommendation_feedback_user_type_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedback_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_month_idx": {
+          "name": "recommendation_feedback_month_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_season_idx": {
+          "name": "recommendation_feedback_season_idx",
+          "columns": [
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_season_idx": {
+          "name": "recommendation_feedback_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_month_idx": {
+          "name": "recommendation_feedback_user_month_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_song_id_idx": {
+          "name": "recommendation_feedback_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_song_id_idx": {
+          "name": "recommendation_feedback_user_song_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_feedback_user_id_user_id_fk": {
+          "name": "recommendation_feedback_user_id_user_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk": {
+          "name": "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "recommendations_cache",
+          "columnsFrom": [
+            "recommendation_cache_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_songs": {
+      "name": "playlist_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_songs_playlist_id_idx": {
+          "name": "playlist_songs_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_song_id_idx": {
+          "name": "playlist_songs_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_position_idx": {
+          "name": "playlist_songs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_songs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_songs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_songs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_song": {
+          "name": "unique_playlist_song",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlists": {
+      "name": "user_playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navidrome_id": {
+          "name": "navidrome_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_playlist_criteria": {
+          "name": "smart_playlist_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_playlists_user_id_idx": {
+          "name": "user_playlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_created_at_idx": {
+          "name": "user_playlists_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_navidrome_id_idx": {
+          "name": "user_playlists_navidrome_id_idx",
+          "columns": [
+            {
+              "expression": "navidrome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlists_user_id_user_id_fk": {
+          "name": "user_playlists_user_id_user_id_fk",
+          "tableFrom": "user_playlists",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_playlist_name": {
+          "name": "unique_user_playlist_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaboration_activity": {
+      "name": "collaboration_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_playlist_id_idx": {
+          "name": "activity_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_id_idx": {
+          "name": "activity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_created_at_idx": {
+          "name": "activity_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collaboration_activity_playlist_id_user_playlists_id_fk": {
+          "name": "collaboration_activity_playlist_id_user_playlists_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaboration_activity_user_id_user_id_fk": {
+          "name": "collaboration_activity_user_id_user_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaboration_settings": {
+      "name": "playlist_collaboration_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "playlist_privacy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_approve_threshold": {
+          "name": "auto_approve_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "max_suggestions_per_user": {
+          "name": "max_suggestions_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "max_total_suggestions": {
+          "name": "max_total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notify_on_suggestion": {
+          "name": "notify_on_suggestion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_on_vote": {
+          "name": "notify_on_vote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_approval": {
+          "name": "notify_on_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_code": {
+          "name": "share_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collab_settings_playlist_id_idx": {
+          "name": "collab_settings_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_settings_share_code_idx": {
+          "name": "collab_settings_share_code_idx",
+          "columns": [
+            {
+              "expression": "share_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaboration_settings_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaboration_settings_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaboration_settings",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlist_collaboration_settings_playlist_id_unique": {
+          "name": "playlist_collaboration_settings_playlist_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id"
+          ]
+        },
+        "playlist_collaboration_settings_share_code_unique": {
+          "name": "playlist_collaboration_settings_share_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaborators": {
+      "name": "playlist_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "collaborator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "collaborators_playlist_id_idx": {
+          "name": "collaborators_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collaborators_user_id_idx": {
+          "name": "collaborators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaborators_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaborators_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_user_id_user_id_fk": {
+          "name": "playlist_collaborators_user_id_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_invited_by_user_id_fk": {
+          "name": "playlist_collaborators_invited_by_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_collaborator": {
+          "name": "unique_playlist_collaborator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_suggestions": {
+      "name": "playlist_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_title": {
+          "name": "song_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist": {
+          "name": "song_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_album": {
+          "name": "song_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_checked_at": {
+          "name": "availability_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suggestions_playlist_id_idx": {
+          "name": "suggestions_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_suggested_by_idx": {
+          "name": "suggestions_suggested_by_idx",
+          "columns": [
+            {
+              "expression": "suggested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_status_idx": {
+          "name": "suggestions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_score_idx": {
+          "name": "suggestions_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_suggestions_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_suggestions_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_suggested_by_user_id_fk": {
+          "name": "playlist_suggestions_suggested_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "suggested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_processed_by_user_id_fk": {
+          "name": "playlist_suggestions_processed_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_song_playlist": {
+          "name": "unique_suggestion_song_playlist",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestion_votes": {
+      "name": "suggestion_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_suggestion_id_idx": {
+          "name": "votes_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestion_votes_suggestion_id_playlist_suggestions_id_fk": {
+          "name": "suggestion_votes_suggestion_id_playlist_suggestions_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "playlist_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestion_votes_user_id_user_id_fk": {
+          "name": "suggestion_votes_user_id_user_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_vote": {
+          "name": "unique_suggestion_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suggestion_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_profiles": {
+      "name": "library_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_distribution": {
+          "name": "genre_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_keywords": {
+          "name": "top_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_needed": {
+          "name": "refresh_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "library_profiles_user_id_idx": {
+          "name": "library_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_last_analyzed_idx": {
+          "name": "library_profiles_last_analyzed_idx",
+          "columns": [
+            {
+              "expression": "last_analyzed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_refresh_needed_idx": {
+          "name": "library_profiles_refresh_needed_idx",
+          "columns": [
+            {
+              "expression": "refresh_needed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_profiles_user_id_user_id_fk": {
+          "name": "library_profiles_user_id_user_id_fk",
+          "tableFrom": "library_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_profiles_user_id_unique": {
+          "name": "library_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compound_scores": {
+      "name": "compound_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_count": {
+          "name": "source_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recency_weighted_score": {
+          "name": "recency_weighted_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "compound_scores_user_id_idx": {
+          "name": "compound_scores_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_user_score_idx": {
+          "name": "compound_scores_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_song_id_idx": {
+          "name": "compound_scores_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compound_scores_user_id_user_id_fk": {
+          "name": "compound_scores_user_id_user_id_fk",
+          "tableFrom": "compound_scores",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compound_scores_unique": {
+          "name": "compound_scores_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_history": {
+      "name": "listening_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_detected": {
+          "name": "skip_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "listening_history_user_id_idx": {
+          "name": "listening_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_played_at_idx": {
+          "name": "listening_history_played_at_idx",
+          "columns": [
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_user_played_at_idx": {
+          "name": "listening_history_user_played_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_song_id_idx": {
+          "name": "listening_history_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_artist_idx": {
+          "name": "listening_history_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_skip_idx": {
+          "name": "listening_history_skip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skip_detected",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_history_user_id_user_id_fk": {
+          "name": "listening_history_user_id_user_id_fk",
+          "tableFrom": "listening_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.track_similarities": {
+      "name": "track_similarities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_artist": {
+          "name": "source_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_title": {
+          "name": "source_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist": {
+          "name": "target_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_song_id": {
+          "name": "target_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "track_similarities_source_idx": {
+          "name": "track_similarities_source_idx",
+          "columns": [
+            {
+              "expression": "source_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_idx": {
+          "name": "track_similarities_target_idx",
+          "columns": [
+            {
+              "expression": "target_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_song_id_idx": {
+          "name": "track_similarities_target_song_id_idx",
+          "columns": [
+            {
+              "expression": "target_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_expires_at_idx": {
+          "name": "track_similarities_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "track_similarities_unique": {
+          "name": "track_similarities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_artist",
+            "source_title",
+            "target_artist",
+            "target_title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_artists": {
+      "name": "indexed_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_artist_id": {
+          "name": "navidrome_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_count": {
+          "name": "album_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_artists_user_id_idx": {
+          "name": "indexed_artists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_user_artist_idx": {
+          "name": "indexed_artists_user_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_name_idx": {
+          "name": "indexed_artists_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_songs": {
+      "name": "indexed_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_song_id": {
+          "name": "navidrome_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_key": {
+          "name": "song_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_songs_user_id_idx": {
+          "name": "indexed_songs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_user_song_idx": {
+          "name": "indexed_songs_user_song_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_song_key_idx": {
+          "name": "indexed_songs_song_key_idx",
+          "columns": [
+            {
+              "expression": "song_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_artist_idx": {
+          "name": "indexed_songs_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_synced_at_idx": {
+          "name": "indexed_songs_synced_at_idx",
+          "columns": [
+            {
+              "expression": "synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sync_state": {
+      "name": "library_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_sync_at": {
+          "name": "last_full_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_incremental_sync_at": {
+          "name": "last_incremental_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_items": {
+          "name": "processed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_frequency_minutes": {
+          "name": "sync_frequency_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "max_concurrent_requests": {
+          "name": "max_concurrent_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_sync_duration_ms": {
+          "name": "last_sync_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_songs_indexed": {
+          "name": "total_songs_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_artists_indexed": {
+          "name": "total_artists_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_albums_indexed": {
+          "name": "total_albums_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sync_state_user_id_idx": {
+          "name": "library_sync_state_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_error_log": {
+      "name": "sync_error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_session_id": {
+          "name": "sync_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_error_log_user_id_idx": {
+          "name": "sync_error_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_session_idx": {
+          "name": "sync_error_log_session_idx",
+          "columns": [
+            {
+              "expression": "sync_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_created_at_idx": {
+          "name": "sync_error_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mood_snapshots": {
+      "name": "mood_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_distribution": {
+          "name": "mood_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_listens": {
+          "name": "total_listens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_feedback": {
+          "name": "total_feedback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_up_count": {
+          "name": "thumbs_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_down_count": {
+          "name": "thumbs_down_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "acceptance_rate": {
+          "name": "acceptance_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diversity_score": {
+          "name": "diversity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mood_snapshots_user_id_idx": {
+          "name": "mood_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_start_idx": {
+          "name": "mood_snapshots_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_idx": {
+          "name": "mood_snapshots_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_type_idx": {
+          "name": "mood_snapshots_period_type_idx",
+          "columns": [
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_type_idx": {
+          "name": "mood_snapshots_user_period_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mood_snapshots_user_id_user_id_fk": {
+          "name": "mood_snapshots_user_id_user_id_fk",
+          "tableFrom": "mood_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_history": {
+      "name": "recommendation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_songs": {
+          "name": "recommended_songs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_context": {
+          "name": "mood_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_factors": {
+          "name": "reasoning_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taste_profile_snapshot": {
+          "name": "taste_profile_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_history_user_id_idx": {
+          "name": "recommendation_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_generated_at_idx": {
+          "name": "recommendation_history_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_user_generated_at_idx": {
+          "name": "recommendation_history_user_generated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_source_idx": {
+          "name": "recommendation_history_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_history_user_id_user_id_fk": {
+          "name": "recommendation_history_user_id_user_id_fk",
+          "tableFrom": "recommendation_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_snapshots": {
+      "name": "taste_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_data": {
+          "name": "profile_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_formats": {
+          "name": "export_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_generated": {
+          "name": "is_auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "taste_snapshots_user_id_idx": {
+          "name": "taste_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "taste_snapshots_captured_at_idx": {
+          "name": "taste_snapshots_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "taste_snapshots_user_id_user_id_fk": {
+          "name": "taste_snapshots_user_id_user_id_fk",
+          "tableFrom": "taste_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_analytics": {
+      "name": "discovery_feed_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_level": {
+          "name": "aggregation_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items_shown": {
+          "name": "total_items_shown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_clicks": {
+          "name": "total_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_plays": {
+          "name": "total_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_duration": {
+          "name": "total_play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_saves": {
+          "name": "total_saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_skips": {
+          "name": "total_skips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dismissals": {
+          "name": "total_dismissals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_likes": {
+          "name": "total_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dislikes": {
+          "name": "total_dislikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_not_interested": {
+          "name": "total_not_interested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_through_rate": {
+          "name": "click_through_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "play_rate": {
+          "name": "play_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "save_rate": {
+          "name": "save_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "dismissal_rate": {
+          "name": "dismissal_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "time_slot_breakdown": {
+          "name": "time_slot_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notifications_sent": {
+          "name": "notifications_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notifications_opened": {
+          "name": "notifications_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notification_open_rate": {
+          "name": "notification_open_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_analytics_period_idx": {
+          "name": "discovery_feed_analytics_period_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_analytics_user_id_idx": {
+          "name": "discovery_feed_analytics_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_analytics_user_id_user_id_fk": {
+          "name": "discovery_feed_analytics_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_analytics",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_feed_analytics_unique": {
+          "name": "discovery_feed_analytics_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "period_start",
+            "aggregation_level",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_items": {
+      "name": "discovery_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendation_source": {
+          "name": "recommendation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "target_time_slot": {
+          "name": "target_time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'any'"
+        },
+        "target_context": {
+          "name": "target_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "shown": {
+          "name": "shown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played": {
+          "name": "played",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_at": {
+          "name": "feedback_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_items_user_id_idx": {
+          "name": "discovery_feed_items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_time_slot_idx": {
+          "name": "discovery_feed_items_user_time_slot_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_shown_at_idx": {
+          "name": "discovery_feed_items_shown_at_idx",
+          "columns": [
+            {
+              "expression": "shown_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_expires_at_idx": {
+          "name": "discovery_feed_items_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_content_idx": {
+          "name": "discovery_feed_items_user_content_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_items_user_id_user_id_fk": {
+          "name": "discovery_feed_items_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_notification_preferences": {
+      "name": "discovery_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "preferred_times": {
+          "name": "preferred_times",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"09:00\",\"17:00\"]'::jsonb"
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'22:00'"
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "active_days": {
+          "name": "active_days",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[0,1,2,3,4,5,6]'::jsonb"
+        },
+        "include_new_releases": {
+          "name": "include_new_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_personalized": {
+          "name": "include_personalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_time_based_suggestions": {
+          "name": "include_time_based_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_trending": {
+          "name": "include_trending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_notifications_per_day": {
+          "name": "max_notifications_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "computed_optimal_time": {
+          "name": "computed_optimal_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ab_test_group": {
+          "name": "ab_test_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'control'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_notification_prefs_user_id_idx": {
+          "name": "discovery_notification_prefs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_notification_preferences_user_id_user_id_fk": {
+          "name": "discovery_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "discovery_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_notification_preferences_user_id_unique": {
+          "name": "discovery_notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_patterns": {
+      "name": "listening_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "top_moods": {
+          "name": "top_moods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avg_energy": {
+          "name": "avg_energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "avg_bpm": {
+          "name": "avg_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_context": {
+          "name": "primary_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "listening_patterns_user_id_idx": {
+          "name": "listening_patterns_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_time_slot_idx": {
+          "name": "listening_patterns_time_slot_idx",
+          "columns": [
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_user_time_day_idx": {
+          "name": "listening_patterns_user_time_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_patterns_user_id_user_id_fk": {
+          "name": "listening_patterns_user_id_user_id_fk",
+          "tableFrom": "listening_patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "listening_patterns_unique": {
+          "name": "listening_patterns_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "day_of_week"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_notifications": {
+      "name": "scheduled_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ab_test_variant": {
+          "name": "ab_test_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scheduled_notifications_status_scheduled_idx": {
+          "name": "scheduled_notifications_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_user_id_idx": {
+          "name": "scheduled_notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_type_status_idx": {
+          "name": "scheduled_notifications_type_status_idx",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_notifications_user_id_user_id_fk": {
+          "name": "scheduled_notifications_user_id_user_id_fk",
+          "tableFrom": "scheduled_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_credentials": {
+      "name": "platform_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expiry": {
+          "name": "token_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "platform_credentials_user_platform_idx": {
+          "name": "platform_credentials_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_credentials_user_id_user_id_fk": {
+          "name": "platform_credentials_user_id_user_id_fk",
+          "tableFrom": "platform_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_download_jobs": {
+      "name": "playlist_download_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_job_id": {
+          "name": "import_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "completed_items": {
+          "name": "completed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "download_queue": {
+          "name": "download_queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_organization": {
+          "name": "pending_organization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_download_jobs_user_id_idx": {
+          "name": "playlist_download_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_service_idx": {
+          "name": "playlist_download_jobs_service_idx",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_status_idx": {
+          "name": "playlist_download_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_created_at_idx": {
+          "name": "playlist_download_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_download_jobs_user_id_user_id_fk": {
+          "name": "playlist_download_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk": {
+          "name": "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "playlist_import_jobs",
+          "columnsFrom": [
+            "import_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_export_jobs": {
+      "name": "playlist_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exported_data": {
+          "name": "exported_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_export_jobs_user_id_idx": {
+          "name": "playlist_export_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_status_idx": {
+          "name": "playlist_export_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_created_at_idx": {
+          "name": "playlist_export_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_export_jobs_user_id_user_id_fk": {
+          "name": "playlist_export_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_export_jobs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_export_jobs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_import_jobs": {
+      "name": "playlist_import_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_platform": {
+          "name": "target_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_description": {
+          "name": "playlist_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_playlist_id": {
+          "name": "created_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "matched_songs": {
+          "name": "matched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unmatched_songs": {
+          "name": "unmatched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pending_review_songs": {
+          "name": "pending_review_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "match_results": {
+          "name": "match_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_import_jobs_user_id_idx": {
+          "name": "playlist_import_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_status_idx": {
+          "name": "playlist_import_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_created_at_idx": {
+          "name": "playlist_import_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_import_jobs_user_id_user_id_fk": {
+          "name": "playlist_import_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_import_jobs_created_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_import_jobs_created_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "created_playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_identity_summaries": {
+      "name": "music_identity_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_insights": {
+          "name": "ai_insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_profile": {
+          "name": "mood_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_affinities": {
+          "name": "artist_affinities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trend_analysis": {
+          "name": "trend_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_theme": {
+          "name": "card_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_identity_user_id_idx": {
+          "name": "music_identity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_user_period_idx": {
+          "name": "music_identity_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_share_token_idx": {
+          "name": "music_identity_share_token_idx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_identity_summaries_user_id_user_id_fk": {
+          "name": "music_identity_summaries_user_id_user_id_fk",
+          "tableFrom": "music_identity_summaries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lyrics_cache": {
+      "name": "lyrics_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics": {
+          "name": "lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_lyrics": {
+          "name": "synced_lyrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrumental": {
+          "name": "instrumental",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_job_state": {
+      "name": "discovery_job_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "max_suggestions_per_run": {
+          "name": "max_suggestions_per_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "seed_count": {
+          "name": "seed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_running": {
+          "name": "is_running",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_suggestions_generated": {
+          "name": "total_suggestions_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_approved": {
+          "name": "total_approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_rejected": {
+          "name": "total_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_job_state_next_run_at_idx": {
+          "name": "discovery_job_state_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_job_state_enabled_idx": {
+          "name": "discovery_job_state_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_job_state_user_id_user_id_fk": {
+          "name": "discovery_job_state_user_id_user_id_fk",
+          "tableFrom": "discovery_job_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_rejection_history": {
+      "name": "discovery_rejection_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_rejection_expires_at_idx": {
+          "name": "discovery_rejection_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_rejection_user_artist_track_idx": {
+          "name": "discovery_rejection_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_rejection_history_user_id_user_id_fk": {
+          "name": "discovery_rejection_history_user_id_user_id_fk",
+          "tableFrom": "discovery_rejection_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_rejection_unique": {
+          "name": "discovery_rejection_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist_name",
+            "track_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_suggestions": {
+      "name": "discovery_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_artist": {
+          "name": "seed_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_track": {
+          "name": "seed_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lastfm_url": {
+          "name": "lastfm_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discovery_suggestions_user_status_idx": {
+          "name": "discovery_suggestions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_user_artist_track_idx": {
+          "name": "discovery_suggestions_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_match_score_idx": {
+          "name": "discovery_suggestions_match_score_idx",
+          "columns": [
+            {
+              "expression": "match_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_seed_artist_idx": {
+          "name": "discovery_suggestions_seed_artist_idx",
+          "columns": [
+            {
+              "expression": "seed_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_suggestions_user_id_user_id_fk": {
+          "name": "discovery_suggestions_user_id_user_id_fk",
+          "tableFrom": "discovery_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_affinities": {
+      "name": "artist_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity_score": {
+          "name": "affinity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "liked_count": {
+          "name": "liked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_count": {
+          "name": "skip_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_time": {
+          "name": "total_play_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_affinities_user_id_idx": {
+          "name": "artist_affinities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_user_score_idx": {
+          "name": "artist_affinities_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_artist_idx": {
+          "name": "artist_affinities_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_affinities_user_id_user_id_fk": {
+          "name": "artist_affinities_user_id_user_id_fk",
+          "tableFrom": "artist_affinities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_affinities_unique": {
+          "name": "artist_affinities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liked_songs_sync": {
+      "name": "liked_songs_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "liked_songs_sync_user_id_idx": {
+          "name": "liked_songs_sync_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_song_id_idx": {
+          "name": "liked_songs_sync_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_user_active_idx": {
+          "name": "liked_songs_sync_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "liked_songs_sync_user_id_user_id_fk": {
+          "name": "liked_songs_sync_user_id_user_id_fk",
+          "tableFrom": "liked_songs_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "liked_songs_sync_unique": {
+          "name": "liked_songs_sync_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.temporal_preferences": {
+      "name": "temporal_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_score": {
+          "name": "preference_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "temporal_preferences_user_id_idx": {
+          "name": "temporal_preferences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_time_idx": {
+          "name": "temporal_preferences_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_season_idx": {
+          "name": "temporal_preferences_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_genre_idx": {
+          "name": "temporal_preferences_genre_idx",
+          "columns": [
+            {
+              "expression": "genre",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "temporal_preferences_user_id_user_id_fk": {
+          "name": "temporal_preferences_user_id_user_id_fk",
+          "tableFrom": "temporal_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "temporal_preferences_unique": {
+          "name": "temporal_preferences_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "season",
+            "genre"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collaborator_role": {
+      "name": "collaborator_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.playlist_privacy": {
+      "name": "playlist_privacy",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "invite_only"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1768600790026,
       "tag": "0015_organic_midnight",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "7",
+      "when": 1769026870606,
+      "tag": "0016_profile-tables",
+      "breakpoints": true
     }
   ]
 }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,9 @@
     "test:ci:e2e": "playwright test tests/e2e/ --headed=false --coverage --reporter=html,line,json --project=e2e",
     "deploy": "npm run build:cloudflare && wrangler pages deploy .output/public",
     "deploy:production": "npm run build:cloudflare && wrangler pages deploy .output/public --branch=main",
-    "deploy:preview": "npm run build:cloudflare && wrangler pages deploy .output/public --branch=preview"
+    "deploy:preview": "npm run build:cloudflare && wrangler pages deploy .output/public --branch=preview",
+    "readme:screenshots": "npx tsx scripts/capture-readme-screenshots.ts",
+    "readme:update": "npx tsx scripts/update-readme-with-screenshots.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/scripts/capture-readme-screenshots.ts
+++ b/scripts/capture-readme-screenshots.ts
@@ -1,0 +1,365 @@
+/**
+ * Playwright Script: Capture README Screenshots
+ *
+ * Generates high-quality screenshots of the AIDJ app for the README.
+ * Run with: npx playwright test scripts/capture-readme-screenshots.ts --project=chromium-headed
+ *
+ * Or directly: npx tsx scripts/capture-readme-screenshots.ts
+ */
+
+import { chromium, type Page, type Browser } from 'playwright';
+import * as fs from 'fs';
+import * as path from 'path';
+
+const BASE_URL = process.env.BASE_URL || 'http://localhost:3003';
+const SCREENSHOT_DIR = path.join(process.cwd(), 'docs', 'screenshots');
+
+// Test credentials - update these for your environment
+const TEST_EMAIL = process.env.TEST_EMAIL || 'demo@example.com';
+const TEST_PASSWORD = process.env.TEST_PASSWORD || 'demo123';
+
+interface ScreenshotConfig {
+  name: string;
+  route: string;
+  description: string;
+  viewport?: { width: number; height: number };
+  waitFor?: string;
+  actions?: (page: Page) => Promise<void>;
+  delay?: number;
+}
+
+const DESKTOP_VIEWPORT = { width: 1280, height: 800 };
+const MOBILE_VIEWPORT = { width: 390, height: 844 };
+
+const screenshots: ScreenshotConfig[] = [
+  // Auth screens
+  {
+    name: 'login',
+    route: '/login',
+    description: 'Login page',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: 'input[type="email"]',
+  },
+
+  // Dashboard
+  {
+    name: 'dashboard',
+    route: '/dashboard',
+    description: 'Main dashboard overview',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="dashboard"], h1, .dashboard-content',
+    delay: 1000,
+  },
+  {
+    name: 'dashboard-analytics',
+    route: '/dashboard/analytics',
+    description: 'Listening analytics',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '.recharts-wrapper, [data-testid="analytics"], h1',
+    delay: 1500,
+  },
+  {
+    name: 'dashboard-discover',
+    route: '/dashboard/discover',
+    description: 'Music discovery page',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="discover"], h1',
+    delay: 1000,
+  },
+
+  // Library
+  {
+    name: 'library-artists',
+    route: '/library/artists',
+    description: 'Artists grid view',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="artists-grid"], .artist-card, img',
+    delay: 1500,
+  },
+  {
+    name: 'library-search',
+    route: '/library/search',
+    description: 'Library search',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: 'input[type="search"], input[placeholder*="Search"]',
+    actions: async (page) => {
+      const searchInput = page.locator('input[type="search"], input[placeholder*="Search"]').first();
+      await searchInput.fill('rock');
+      await page.waitForTimeout(1000);
+    },
+  },
+
+  // Playlists
+  {
+    name: 'playlists',
+    route: '/playlists',
+    description: 'Playlists overview',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="playlists"], h1',
+    delay: 1000,
+  },
+
+  // DJ Features
+  {
+    name: 'dj-set-builder',
+    route: '/dj/set-builder',
+    description: 'DJ Set Builder',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="set-builder"], h1',
+    delay: 1000,
+  },
+  {
+    name: 'dj-settings',
+    route: '/dj/settings',
+    description: 'DJ Settings (AI DJ configuration)',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="dj-settings"], h1, form',
+    delay: 500,
+  },
+
+  // Music Identity (Spotify Wrapped-like)
+  {
+    name: 'music-identity',
+    route: '/music-identity',
+    description: 'Music Identity - Your listening personality',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="music-identity"], h1',
+    delay: 1500,
+  },
+
+  // Settings
+  {
+    name: 'settings',
+    route: '/settings',
+    description: 'Settings overview',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: '[data-testid="settings"], h1, nav',
+    delay: 500,
+  },
+  {
+    name: 'settings-playback',
+    route: '/settings/playback',
+    description: 'Playback settings',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: 'form, [data-testid="playback-settings"]',
+    delay: 500,
+  },
+
+  // Downloads
+  {
+    name: 'downloads-youtube',
+    route: '/downloads/youtube',
+    description: 'YouTube downloader',
+    viewport: DESKTOP_VIEWPORT,
+    waitFor: 'input, form, h1',
+    delay: 500,
+  },
+
+  // Mobile views
+  {
+    name: 'mobile-dashboard',
+    route: '/dashboard',
+    description: 'Mobile dashboard view',
+    viewport: MOBILE_VIEWPORT,
+    waitFor: '[data-testid="dashboard"], h1',
+    delay: 1000,
+  },
+  {
+    name: 'mobile-library',
+    route: '/library/artists',
+    description: 'Mobile library view',
+    viewport: MOBILE_VIEWPORT,
+    waitFor: '[data-testid="artists-grid"], .artist-card, img',
+    delay: 1000,
+  },
+  {
+    name: 'mobile-player',
+    route: '/library/artists',
+    description: 'Mobile player view',
+    viewport: MOBILE_VIEWPORT,
+    waitFor: '.artist-card, img',
+    delay: 500,
+    actions: async (page) => {
+      // Click first artist to show player
+      const firstArtist = page.locator('.artist-card, [data-testid="artist-item"]').first();
+      if (await firstArtist.isVisible()) {
+        await firstArtist.click();
+        await page.waitForTimeout(1000);
+      }
+    },
+  },
+];
+
+async function ensureDirectoryExists(dir: string) {
+  if (!fs.existsSync(dir)) {
+    fs.mkdirSync(dir, { recursive: true });
+    console.log(`📁 Created directory: ${dir}`);
+  }
+}
+
+async function login(page: Page): Promise<boolean> {
+  try {
+    await page.goto(`${BASE_URL}/login`);
+    await page.waitForLoadState('networkidle');
+
+    // Check if already logged in (redirected to dashboard)
+    if (page.url().includes('/dashboard')) {
+      console.log('✅ Already logged in');
+      return true;
+    }
+
+    // Fill login form
+    const emailInput = page.locator('input[type="email"]');
+    const passwordInput = page.locator('input[type="password"]');
+
+    if (await emailInput.isVisible()) {
+      await emailInput.fill(TEST_EMAIL);
+      await passwordInput.fill(TEST_PASSWORD);
+      await page.locator('button[type="submit"], button:has-text("Login"), button:has-text("Sign In")').click();
+
+      // Wait for redirect
+      await page.waitForURL(/dashboard|library/, { timeout: 10000 }).catch(() => {});
+
+      if (page.url().includes('/dashboard') || page.url().includes('/library')) {
+        console.log('✅ Login successful');
+        return true;
+      }
+    }
+
+    console.log('⚠️ Login may have failed, continuing anyway...');
+    return false;
+  } catch (error) {
+    console.log(`⚠️ Login error: ${error}`);
+    return false;
+  }
+}
+
+async function captureScreenshot(page: Page, config: ScreenshotConfig): Promise<string | null> {
+  const { name, route, description, viewport, waitFor, actions, delay } = config;
+
+  try {
+    // Set viewport
+    if (viewport) {
+      await page.setViewportSize(viewport);
+    }
+
+    // Navigate
+    console.log(`📸 Capturing: ${name} (${route})`);
+    await page.goto(`${BASE_URL}${route}`);
+    await page.waitForLoadState('networkidle');
+
+    // Wait for specific element
+    if (waitFor) {
+      try {
+        await page.waitForSelector(waitFor, { timeout: 5000 });
+      } catch {
+        console.log(`   ⚠️ Selector "${waitFor}" not found, continuing...`);
+      }
+    }
+
+    // Execute custom actions
+    if (actions) {
+      await actions(page);
+    }
+
+    // Additional delay for animations/loading
+    if (delay) {
+      await page.waitForTimeout(delay);
+    }
+
+    // Capture screenshot
+    const filename = `${name}.png`;
+    const filepath = path.join(SCREENSHOT_DIR, filename);
+
+    await page.screenshot({
+      path: filepath,
+      fullPage: false,
+      animations: 'disabled',
+    });
+
+    console.log(`   ✅ Saved: ${filename}`);
+    return filename;
+  } catch (error) {
+    console.error(`   ❌ Error capturing ${name}:`, error);
+    return null;
+  }
+}
+
+async function generateMarkdownGallery(captured: { name: string; description: string; file: string }[]) {
+  const galleryPath = path.join(SCREENSHOT_DIR, 'GALLERY.md');
+
+  const content = `# AIDJ Screenshots Gallery
+
+> Auto-generated on ${new Date().toISOString().split('T')[0]}
+
+## Desktop Views
+
+${captured
+  .filter((s) => !s.name.startsWith('mobile-'))
+  .map((s) => `### ${s.description}\n![${s.description}](./${s.file})`)
+  .join('\n\n')}
+
+## Mobile Views
+
+${captured
+  .filter((s) => s.name.startsWith('mobile-'))
+  .map((s) => `### ${s.description}\n![${s.description}](./${s.file})`)
+  .join('\n\n')}
+
+---
+
+*Screenshots captured with Playwright*
+`;
+
+  fs.writeFileSync(galleryPath, content);
+  console.log(`\n📝 Generated gallery: ${galleryPath}`);
+}
+
+async function main() {
+  console.log('🎬 AIDJ README Screenshot Capture\n');
+  console.log(`Base URL: ${BASE_URL}`);
+  console.log(`Output: ${SCREENSHOT_DIR}\n`);
+
+  ensureDirectoryExists(SCREENSHOT_DIR);
+
+  const browser: Browser = await chromium.launch({
+    headless: process.env.HEADLESS !== 'false',
+  });
+
+  const context = await browser.newContext({
+    viewport: DESKTOP_VIEWPORT,
+    deviceScaleFactor: 2, // Retina quality
+  });
+
+  const page = await context.newPage();
+
+  // Login first
+  await login(page);
+
+  // Capture all screenshots
+  const captured: { name: string; description: string; file: string }[] = [];
+
+  for (const config of screenshots) {
+    const file = await captureScreenshot(page, config);
+    if (file) {
+      captured.push({
+        name: config.name,
+        description: config.description,
+        file,
+      });
+    }
+  }
+
+  // Generate gallery markdown
+  await generateMarkdownGallery(captured);
+
+  await browser.close();
+
+  console.log(`\n✨ Captured ${captured.length}/${screenshots.length} screenshots`);
+  console.log('\n📋 Next steps:');
+  console.log('   1. Review screenshots in docs/screenshots/');
+  console.log('   2. Run: npx tsx scripts/update-readme-with-screenshots.ts');
+  console.log('   3. Commit changes\n');
+}
+
+main().catch(console.error);

--- a/scripts/update-readme-with-screenshots.ts
+++ b/scripts/update-readme-with-screenshots.ts
@@ -1,0 +1,374 @@
+/**
+ * Update README with Screenshots
+ *
+ * Generates an enhanced README.md with screenshots, badges, and modern layout.
+ * Run after: npx tsx scripts/capture-readme-screenshots.ts
+ *
+ * Usage: npx tsx scripts/update-readme-with-screenshots.ts
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const README_PATH = path.join(process.cwd(), 'README.md');
+const SCREENSHOT_DIR = path.join(process.cwd(), 'docs', 'screenshots');
+
+interface ScreenshotInfo {
+  name: string;
+  path: string;
+  exists: boolean;
+}
+
+function getAvailableScreenshots(): ScreenshotInfo[] {
+  const expectedScreenshots = [
+    'dashboard',
+    'dashboard-analytics',
+    'dashboard-discover',
+    'library-artists',
+    'library-search',
+    'playlists',
+    'dj-set-builder',
+    'dj-settings',
+    'music-identity',
+    'settings',
+    'settings-playback',
+    'downloads-youtube',
+    'mobile-dashboard',
+    'mobile-library',
+    'mobile-player',
+    'login',
+  ];
+
+  return expectedScreenshots.map((name) => {
+    const filename = `${name}.png`;
+    const filepath = path.join(SCREENSHOT_DIR, filename);
+    return {
+      name,
+      path: `docs/screenshots/${filename}`,
+      exists: fs.existsSync(filepath),
+    };
+  });
+}
+
+function generateReadme(screenshots: ScreenshotInfo[]): string {
+  const hasScreenshots = screenshots.some((s) => s.exists);
+  const heroScreenshot = screenshots.find((s) => s.name === 'dashboard' && s.exists);
+  const libraryScreenshot = screenshots.find((s) => s.name === 'library-artists' && s.exists);
+  const djScreenshot = screenshots.find((s) => s.name === 'dj-set-builder' && s.exists);
+  const identityScreenshot = screenshots.find((s) => s.name === 'music-identity' && s.exists);
+  const mobileScreenshots = screenshots.filter((s) => s.name.startsWith('mobile-') && s.exists);
+
+  return `<!-- PROJECT LOGO -->
+<div align="center">
+  <h1>AIDJ</h1>
+  <p><strong>AI-Assisted Music Library & Smart DJ</strong></p>
+  <p>
+    A modern web application for managing your self-hosted music library with AI-powered recommendations,
+    smart playlists, and seamless crossfade playback.
+  </p>
+
+  <!-- BADGES -->
+  <p>
+    <a href="https://github.com/lolimmlost/aidj/actions"><img src="https://github.com/lolimmlost/aidj/actions/workflows/ci.yml/badge.svg" alt="CI Status"></a>
+    <a href="https://codecov.io/gh/lolimmlost/aidj"><img src="https://codecov.io/gh/lolimmlost/aidj/branch/main/graph/badge.svg" alt="Coverage"></a>
+    <img src="https://img.shields.io/badge/React-19-61DAFB?logo=react" alt="React 19">
+    <img src="https://img.shields.io/badge/TypeScript-5.0-3178C6?logo=typescript" alt="TypeScript">
+    <img src="https://img.shields.io/badge/License-Unlicense-blue" alt="License">
+  </p>
+
+  ${heroScreenshot ? `<img src="${heroScreenshot.path}" alt="AIDJ Dashboard" width="800">` : ''}
+</div>
+
+---
+
+## Features
+
+| Feature | Description |
+|---------|-------------|
+| **Smart Music Library** | Browse artists, albums, and tracks with infinite scroll and search |
+| **AI DJ Mode** | Automatic queue management with intelligent song recommendations |
+| **Crossfade Playback** | Smooth transitions between tracks with dual-deck audio engine |
+| **Music Identity** | Spotify Wrapped-style insights into your listening habits |
+| **Smart Playlists** | Create rule-based playlists that auto-update |
+| **DJ Set Builder** | Build and save DJ sets with BPM/key matching |
+| **YouTube Downloads** | Download and import music from YouTube |
+| **Dark Mode** | Beautiful dark theme with system preference detection |
+| **Mobile Responsive** | Full-featured mobile experience with touch controls |
+| **Self-Hosted** | All data stays on your local network |
+
+${
+  libraryScreenshot
+    ? `
+### Library View
+<img src="${libraryScreenshot.path}" alt="Music Library" width="700">
+`
+    : ''
+}
+
+${
+  djScreenshot
+    ? `
+### DJ Set Builder
+<img src="${djScreenshot.path}" alt="DJ Set Builder" width="700">
+`
+    : ''
+}
+
+${
+  identityScreenshot
+    ? `
+### Music Identity
+<img src="${identityScreenshot.path}" alt="Music Identity" width="700">
+`
+    : ''
+}
+
+${
+  mobileScreenshots.length > 0
+    ? `
+### Mobile Experience
+<p>
+  ${mobileScreenshots.map((s) => `<img src="${s.path}" alt="${s.name}" width="200">`).join(' ')}
+</p>
+`
+    : ''
+}
+
+---
+
+## Tech Stack
+
+<table>
+  <tr>
+    <td align="center"><strong>Frontend</strong></td>
+    <td align="center"><strong>Backend</strong></td>
+    <td align="center"><strong>Infrastructure</strong></td>
+  </tr>
+  <tr>
+    <td>
+      <a href="https://react.dev">React 19</a> + React Compiler<br>
+      <a href="https://tanstack.com/start">TanStack Start</a><br>
+      <a href="https://tailwindcss.com">Tailwind CSS v4</a><br>
+      <a href="https://ui.shadcn.com">shadcn/ui</a>
+    </td>
+    <td>
+      <a href="https://orm.drizzle.team">Drizzle ORM</a><br>
+      PostgreSQL<br>
+      <a href="https://better-auth.com">Better Auth</a><br>
+      <a href="https://tanstack.com/query">TanStack Query</a>
+    </td>
+    <td>
+      <a href="https://www.navidrome.org">Navidrome</a> (music server)<br>
+      <a href="https://www.last.fm/api">Last.fm API</a> (recommendations)<br>
+      Vite + Node.js
+    </td>
+  </tr>
+</table>
+
+---
+
+## Getting Started
+
+### Prerequisites
+
+- Node.js 20+
+- PostgreSQL database
+- [Navidrome](https://www.navidrome.org/) music server
+- (Optional) Last.fm API key for recommendations
+
+### Installation
+
+1. **Clone the repository**
+   \`\`\`bash
+   git clone https://github.com/lolimmlost/aidj.git
+   cd aidj
+   \`\`\`
+
+2. **Install dependencies**
+   \`\`\`bash
+   npm install
+   \`\`\`
+
+3. **Configure environment**
+   \`\`\`bash
+   cp .env.example .env
+   \`\`\`
+
+   Edit \`.env\` with your configuration. See [environment-configuration.md](./docs/environment-configuration.md) for details.
+
+4. **Initialize database**
+   \`\`\`bash
+   npm run db:push
+   \`\`\`
+
+5. **Start development server**
+   \`\`\`bash
+   npm run dev
+   \`\`\`
+
+   Open [http://localhost:3000](http://localhost:3000)
+
+---
+
+## Project Structure
+
+\`\`\`
+src/
+├── components/           # UI components (shadcn/ui)
+│   ├── layout/           # PlayerBar, Sidebar, etc.
+│   └── ui/               # Reusable UI primitives
+├── lib/
+│   ├── auth/             # Better Auth setup
+│   ├── db/               # Drizzle ORM schema
+│   ├── services/         # External integrations
+│   │   ├── navidrome.ts  # Navidrome/Subsonic API
+│   │   ├── lastfm/       # Last.fm recommendations
+│   │   └── ai-dj/        # AI DJ engine
+│   └── stores/           # Zustand state management
+├── routes/
+│   ├── dashboard/        # Main dashboard views
+│   ├── library/          # Music library (artists/albums)
+│   ├── dj/               # DJ features
+│   ├── playlists/        # Playlist management
+│   └── settings/         # App configuration
+└── styles.css            # Global Tailwind styles
+\`\`\`
+
+---
+
+## Configuration
+
+### Required Services
+
+| Service | Purpose | Configuration |
+|---------|---------|---------------|
+| **Navidrome** | Music streaming & library | URL, username, password |
+| **PostgreSQL** | App database | Connection string |
+
+### Optional Services
+
+| Service | Purpose | Configuration |
+|---------|---------|---------------|
+| **Last.fm** | Music recommendations | API key |
+| **MusicBrainz** | Extended metadata | (No auth required) |
+
+Configure services in the Settings page or via environment variables.
+
+---
+
+## Development
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| \`npm run dev\` | Start development server |
+| \`npm run build\` | Build for production |
+| \`npm run test\` | Run unit tests |
+| \`npm run test:e2e\` | Run Playwright E2E tests |
+| \`npm run lint\` | Lint codebase |
+| \`npm run db:push\` | Push schema to database |
+| \`npm run db:studio\` | Open Drizzle Studio |
+
+### Testing
+
+\`\`\`bash
+# Unit tests with Vitest
+npm run test
+npm run test:coverage
+
+# E2E tests with Playwright
+npm run test:e2e
+npm run test:e2e:ui
+\`\`\`
+
+### CI/CD
+
+The project includes GitHub Actions workflows for:
+- Linting & type checking
+- Unit tests with coverage (>80% required)
+- Security scanning (Trivy, Gitleaks)
+- Automated builds
+
+---
+
+## Roadmap
+
+- [x] Music library integration (Navidrome)
+- [x] Audio player with crossfade
+- [x] AI DJ mode with smart recommendations
+- [x] Music Identity (listening insights)
+- [x] Smart playlists
+- [x] DJ Set Builder
+- [x] YouTube downloads
+- [ ] Ollama integration for local AI
+- [ ] Multi-user support
+- [ ] Offline mode (PWA)
+
+---
+
+## Contributing
+
+Contributions are welcome! Please:
+
+1. Fork the repository
+2. Create a feature branch (\`git checkout -b feature/amazing-feature\`)
+3. Commit changes (\`git commit -m 'Add amazing feature'\`)
+4. Push to branch (\`git push origin feature/amazing-feature\`)
+5. Open a Pull Request
+
+---
+
+## License
+
+This project is released into the public domain via the [Unlicense](./LICENSE).
+
+---
+
+<div align="center">
+  <p>
+    <a href="https://github.com/lolimmlost/aidj/issues">Report Bug</a>
+    ·
+    <a href="https://github.com/lolimmlost/aidj/issues">Request Feature</a>
+  </p>
+</div>
+`;
+}
+
+function main() {
+  console.log('📝 Updating README with screenshots...\n');
+
+  const screenshots = getAvailableScreenshots();
+  const available = screenshots.filter((s) => s.exists);
+  const missing = screenshots.filter((s) => !s.exists);
+
+  console.log(`Found ${available.length} screenshots:`);
+  available.forEach((s) => console.log(`  ✅ ${s.name}`));
+
+  if (missing.length > 0) {
+    console.log(`\nMissing ${missing.length} screenshots:`);
+    missing.forEach((s) => console.log(`  ⚠️ ${s.name}`));
+    console.log('\nRun: npx tsx scripts/capture-readme-screenshots.ts');
+  }
+
+  // Generate README
+  const readme = generateReadme(screenshots);
+
+  // Backup existing README
+  if (fs.existsSync(README_PATH)) {
+    const backup = README_PATH + '.backup';
+    fs.copyFileSync(README_PATH, backup);
+    console.log(`\n📋 Backed up existing README to ${backup}`);
+  }
+
+  // Write new README
+  fs.writeFileSync(README_PATH, readme);
+  console.log(`✅ Updated README.md`);
+
+  console.log('\n📋 Next steps:');
+  console.log('   1. Review the updated README.md');
+  console.log('   2. Adjust any screenshot paths if needed');
+  console.log('   3. git add . && git commit -m "Update README with screenshots"');
+}
+
+main();

--- a/src/components/ai-dj-settings.tsx
+++ b/src/components/ai-dj-settings.tsx
@@ -6,7 +6,9 @@ import { Card } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
+import { Button } from '@/components/ui/button';
 import { usePreferencesStore } from '@/lib/stores/preferences';
+import { useAudioStore } from '@/lib/stores/audio';
 import { toast } from 'sonner';
 
 export function AIDJSettings() {
@@ -21,6 +23,18 @@ export function AIDJSettings() {
   const [useContext, setUseContext] = useState(
     preferences.recommendationSettings.aiDJUseCurrentContext
   );
+  const [djMatchingEnabled, setDjMatchingEnabled] = useState(
+    preferences.recommendationSettings.djMatchingEnabled ?? true
+  );
+  const [bpmAnalysisEnabled, setBpmAnalysisEnabled] = useState(
+    preferences.recommendationSettings.bpmAnalysisEnabled ?? false
+  );
+  const [seedQueueEnabled, setSeedQueueEnabled] = useState(
+    preferences.recommendationSettings.aiDJSeedQueueEnabled ?? false
+  );
+  const [seedDensity, setSeedDensity] = useState(
+    preferences.recommendationSettings.aiDJSeedDensity ?? 2
+  );
 
   // Sync with preferences changes
   useEffect(() => {
@@ -29,8 +43,12 @@ export function AIDJSettings() {
       setThreshold(preferences.recommendationSettings.aiDJQueueThreshold);
       setBatchSize(preferences.recommendationSettings.aiDJBatchSize);
       setUseContext(preferences.recommendationSettings.aiDJUseCurrentContext);
+      setDjMatchingEnabled(preferences.recommendationSettings.djMatchingEnabled ?? true);
+      setBpmAnalysisEnabled(preferences.recommendationSettings.bpmAnalysisEnabled ?? false);
+      setSeedQueueEnabled(preferences.recommendationSettings.aiDJSeedQueueEnabled ?? false);
+      setSeedDensity(preferences.recommendationSettings.aiDJSeedDensity ?? 2);
     }, 0);
-    
+
     return () => clearTimeout(timeoutId);
   }, [preferences.recommendationSettings]);
 
@@ -70,6 +88,57 @@ export function AIDJSettings() {
       toast.error('Failed to update context setting');
       // Revert on error
       setUseContext(preferences.recommendationSettings.aiDJUseCurrentContext);
+    }
+  };
+
+  // Handle DJ matching toggle
+  const handleDjMatchingChange = async (value: boolean) => {
+    setDjMatchingEnabled(value);
+    try {
+      await setRecommendationSettings({ djMatchingEnabled: value });
+      toast.success(value ? 'DJ matching enabled' : 'DJ matching disabled');
+    } catch (error) {
+      console.error('Failed to update DJ matching setting:', error);
+      toast.error('Failed to update DJ matching setting');
+      setDjMatchingEnabled(preferences.recommendationSettings.djMatchingEnabled ?? true);
+    }
+  };
+
+  // Handle BPM analysis toggle
+  const handleBpmAnalysisChange = async (value: boolean) => {
+    setBpmAnalysisEnabled(value);
+    try {
+      await setRecommendationSettings({ bpmAnalysisEnabled: value });
+      toast.success(value ? 'BPM analysis enabled - Songs will be analyzed during playback' : 'BPM analysis disabled');
+    } catch (error) {
+      console.error('Failed to update BPM analysis setting:', error);
+      toast.error('Failed to update BPM analysis setting');
+      setBpmAnalysisEnabled(preferences.recommendationSettings.bpmAnalysisEnabled ?? false);
+    }
+  };
+
+  // Handle seed queue toggle
+  const handleSeedQueueChange = async (value: boolean) => {
+    setSeedQueueEnabled(value);
+    try {
+      await setRecommendationSettings({ aiDJSeedQueueEnabled: value });
+      toast.success(value ? 'Queue seeding enabled - Recommendations will be injected throughout your queue' : 'Queue seeding disabled');
+    } catch (error) {
+      console.error('Failed to update seed queue setting:', error);
+      toast.error('Failed to update seed queue setting');
+      setSeedQueueEnabled(preferences.recommendationSettings.aiDJSeedQueueEnabled ?? false);
+    }
+  };
+
+  // Handle seed density change
+  const handleSeedDensityChange = async (value: number) => {
+    setSeedDensity(value);
+    try {
+      await setRecommendationSettings({ aiDJSeedDensity: value });
+    } catch (error) {
+      console.error('Failed to update seed density:', error);
+      toast.error('Failed to update seed density');
+      setSeedDensity(preferences.recommendationSettings.aiDJSeedDensity ?? 2);
     }
   };
 
@@ -163,6 +232,135 @@ export function AIDJSettings() {
             disabled={isAIDJDisabled}
             aria-label="Use current context for recommendations"
           />
+        </div>
+
+        {/* DJ Matching Section */}
+        <div className="pt-4 border-t border-purple-200 dark:border-purple-700">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-lg">🎧</span>
+            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              DJ Mixing Features
+            </h4>
+          </div>
+
+          {/* DJ Matching Toggle */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="dj-matching" className="text-sm font-medium">
+                BPM/Energy/Key Matching
+              </Label>
+              <p className="text-xs text-gray-600 dark:text-gray-400">
+                Score recommendations by tempo, energy level, and musical key for smoother transitions
+              </p>
+            </div>
+            <Switch
+              id="dj-matching"
+              checked={djMatchingEnabled}
+              onCheckedChange={handleDjMatchingChange}
+              disabled={isAIDJDisabled}
+              aria-label="Enable DJ matching"
+            />
+          </div>
+
+          {/* BPM Analysis Toggle */}
+          <div className="flex items-center justify-between">
+            <div className="space-y-0.5">
+              <Label htmlFor="bpm-analysis" className="text-sm font-medium">
+                Auto BPM Analysis
+              </Label>
+              <p className="text-xs text-gray-600 dark:text-gray-400">
+                Automatically detect BPM during playback using audio analysis
+              </p>
+              {bpmAnalysisEnabled && (
+                <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
+                  ⚡ May use extra CPU during playback
+                </p>
+              )}
+            </div>
+            <Switch
+              id="bpm-analysis"
+              checked={bpmAnalysisEnabled}
+              onCheckedChange={handleBpmAnalysisChange}
+              disabled={isAIDJDisabled || !djMatchingEnabled}
+              aria-label="Enable automatic BPM analysis"
+            />
+          </div>
+        </div>
+
+        {/* Queue Seeding Section */}
+        <div className="pt-4 border-t border-purple-200 dark:border-purple-700">
+          <div className="flex items-center gap-2 mb-3">
+            <span className="text-lg">🌱</span>
+            <h4 className="text-sm font-semibold text-gray-700 dark:text-gray-300">
+              Queue Seeding
+            </h4>
+          </div>
+
+          {/* Seed Queue Toggle */}
+          <div className="flex items-center justify-between mb-4">
+            <div className="space-y-0.5">
+              <Label htmlFor="seed-queue" className="text-sm font-medium">
+                Seed Recommendations Throughout Queue
+              </Label>
+              <p className="text-xs text-gray-600 dark:text-gray-400">
+                Inject AI recommendations throughout your existing queue immediately, not just at the end
+              </p>
+            </div>
+            <Switch
+              id="seed-queue"
+              checked={seedQueueEnabled}
+              onCheckedChange={handleSeedQueueChange}
+              disabled={isAIDJDisabled}
+              aria-label="Enable queue seeding"
+            />
+          </div>
+
+          {/* Seed Density Slider */}
+          {seedQueueEnabled && (
+            <div>
+              <div className="flex items-center justify-between mb-2">
+                <Label htmlFor="seed-density" className="text-sm font-medium">
+                  Seed Density
+                </Label>
+                <span className="text-sm font-semibold text-purple-600 dark:text-purple-400">
+                  {seedDensity} per 10 songs
+                </span>
+              </div>
+              <Slider
+                id="seed-density"
+                min={1}
+                max={5}
+                step={1}
+                value={[seedDensity]}
+                onValueChange={(value) => handleSeedDensityChange(value[0])}
+                className="cursor-pointer"
+                disabled={isAIDJDisabled}
+                aria-label="Seed density"
+              />
+              <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                Insert {seedDensity} AI recommendation{seedDensity > 1 ? 's' : ''} for every 10 songs in your queue
+              </p>
+            </div>
+          )}
+
+          {/* Seed Now Button */}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              const audioStore = useAudioStore.getState();
+              if (audioStore.queue.length === 0) {
+                toast.error('Add some songs to your queue first');
+                return;
+              }
+              audioStore.seedQueueWithRecommendations();
+              toast.success('Seeding recommendations into your queue...');
+            }}
+            disabled={isAIDJDisabled}
+            className="w-full mt-3"
+          >
+            Seed Queue Now
+          </Button>
         </div>
 
         {/* Preview Summary */}

--- a/src/components/ai-dj-settings.tsx
+++ b/src/components/ai-dj-settings.tsx
@@ -1,5 +1,6 @@
 // AI DJ Settings Panel
 // Story 3.9: AI DJ Toggle Mode
+// Updated for profile-based drip-feed recommendations
 
 import { useState, useEffect } from 'react';
 import { Card } from '@/components/ui/card';
@@ -7,6 +8,7 @@ import { Label } from '@/components/ui/label';
 import { Slider } from '@/components/ui/slider';
 import { Switch } from '@/components/ui/switch';
 import { Button } from '@/components/ui/button';
+import { ChevronDown, ChevronUp } from 'lucide-react';
 import { usePreferencesStore } from '@/lib/stores/preferences';
 import { useAudioStore } from '@/lib/stores/audio';
 import { toast } from 'sonner';
@@ -14,6 +16,12 @@ import { toast } from 'sonner';
 export function AIDJSettings() {
   const { preferences, setRecommendationSettings } = usePreferencesStore();
 
+  // Primary setting: Drip-feed interval
+  const [dripInterval, setDripInterval] = useState(
+    preferences.recommendationSettings.aiDJDripInterval ?? 3
+  );
+
+  // Legacy settings (moved to advanced)
   const [threshold, setThreshold] = useState(
     preferences.recommendationSettings.aiDJQueueThreshold
   );
@@ -23,12 +31,16 @@ export function AIDJSettings() {
   const [useContext, setUseContext] = useState(
     preferences.recommendationSettings.aiDJUseCurrentContext
   );
+
+  // DJ Matching settings
   const [djMatchingEnabled, setDjMatchingEnabled] = useState(
     preferences.recommendationSettings.djMatchingEnabled ?? true
   );
   const [bpmAnalysisEnabled, setBpmAnalysisEnabled] = useState(
     preferences.recommendationSettings.bpmAnalysisEnabled ?? false
   );
+
+  // Queue Seeding settings
   const [seedQueueEnabled, setSeedQueueEnabled] = useState(
     preferences.recommendationSettings.aiDJSeedQueueEnabled ?? false
   );
@@ -36,10 +48,13 @@ export function AIDJSettings() {
     preferences.recommendationSettings.aiDJSeedDensity ?? 2
   );
 
+  // UI state
+  const [showAdvanced, setShowAdvanced] = useState(false);
+
   // Sync with preferences changes
   useEffect(() => {
-    // Use setTimeout to avoid cascading renders
     const timeoutId = setTimeout(() => {
+      setDripInterval(preferences.recommendationSettings.aiDJDripInterval ?? 3);
       setThreshold(preferences.recommendationSettings.aiDJQueueThreshold);
       setBatchSize(preferences.recommendationSettings.aiDJBatchSize);
       setUseContext(preferences.recommendationSettings.aiDJUseCurrentContext);
@@ -52,6 +67,18 @@ export function AIDJSettings() {
     return () => clearTimeout(timeoutId);
   }, [preferences.recommendationSettings]);
 
+  // Handle drip interval change
+  const handleDripIntervalChange = async (value: number) => {
+    setDripInterval(value);
+    try {
+      await setRecommendationSettings({ aiDJDripInterval: value });
+    } catch (error) {
+      console.error('Failed to update drip interval:', error);
+      toast.error('Failed to update recommendation frequency');
+      setDripInterval(preferences.recommendationSettings.aiDJDripInterval ?? 3);
+    }
+  };
+
   // Handle threshold change with immediate save
   const handleThresholdChange = async (value: number) => {
     setThreshold(value);
@@ -60,7 +87,6 @@ export function AIDJSettings() {
     } catch (error) {
       console.error('Failed to update threshold:', error);
       toast.error('Failed to update queue threshold');
-      // Revert on error
       setThreshold(preferences.recommendationSettings.aiDJQueueThreshold);
     }
   };
@@ -73,7 +99,6 @@ export function AIDJSettings() {
     } catch (error) {
       console.error('Failed to update batch size:', error);
       toast.error('Failed to update batch size');
-      // Revert on error
       setBatchSize(preferences.recommendationSettings.aiDJBatchSize);
     }
   };
@@ -86,7 +111,6 @@ export function AIDJSettings() {
     } catch (error) {
       console.error('Failed to update context setting:', error);
       toast.error('Failed to update context setting');
-      // Revert on error
       setUseContext(preferences.recommendationSettings.aiDJUseCurrentContext);
     }
   };
@@ -163,55 +187,29 @@ export function AIDJSettings() {
       )}
 
       <div className="space-y-6">
-        {/* Queue Threshold Slider */}
+        {/* Primary Setting: Recommendation Frequency (Drip-feed) */}
         <div>
           <div className="flex items-center justify-between mb-2">
-            <Label htmlFor="ai-dj-threshold" className="text-sm font-medium">
-              Queue Threshold
+            <Label htmlFor="ai-dj-drip" className="text-sm font-medium">
+              Recommendation Frequency
             </Label>
             <span className="text-sm font-semibold text-purple-600 dark:text-purple-400">
-              {threshold} {threshold === 1 ? 'song' : 'songs'}
+              Every {dripInterval} songs
             </span>
           </div>
           <Slider
-            id="ai-dj-threshold"
-            min={1}
+            id="ai-dj-drip"
+            min={2}
             max={5}
             step={1}
-            value={[threshold]}
-            onValueChange={(value) => handleThresholdChange(value[0])}
+            value={[dripInterval]}
+            onValueChange={(value) => handleDripIntervalChange(value[0])}
             className="cursor-pointer"
             disabled={isAIDJDisabled}
-            aria-label="Queue threshold"
+            aria-label="Recommendation frequency"
           />
           <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
-            Add more songs when queue has {threshold} {threshold === 1 ? 'song' : 'songs'} left
-          </p>
-        </div>
-
-        {/* Batch Size Slider */}
-        <div>
-          <div className="flex items-center justify-between mb-2">
-            <Label htmlFor="ai-dj-batch" className="text-sm font-medium">
-              Batch Size
-            </Label>
-            <span className="text-sm font-semibold text-purple-600 dark:text-purple-400">
-              {batchSize} {batchSize === 1 ? 'song' : 'songs'}
-            </span>
-          </div>
-          <Slider
-            id="ai-dj-batch"
-            min={1}
-            max={10}
-            step={1}
-            value={[batchSize]}
-            onValueChange={(value) => handleBatchSizeChange(value[0])}
-            className="cursor-pointer"
-            disabled={isAIDJDisabled}
-            aria-label="Batch size"
-          />
-          <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
-            Add {batchSize} {batchSize === 1 ? 'song' : 'songs'} at a time
+            Add 1 AI recommendation every {dripInterval} songs you play
           </p>
         </div>
 
@@ -222,7 +220,7 @@ export function AIDJSettings() {
               Use Current Context
             </Label>
             <p className="text-xs text-gray-600 dark:text-gray-400">
-              Base recommendations on currently playing song and recent queue
+              Base recommendations on currently playing song
             </p>
           </div>
           <Switch
@@ -250,7 +248,7 @@ export function AIDJSettings() {
                 BPM/Energy/Key Matching
               </Label>
               <p className="text-xs text-gray-600 dark:text-gray-400">
-                Score recommendations by tempo, energy level, and musical key for smoother transitions
+                Score recommendations by tempo and musical key for smoother transitions
               </p>
             </div>
             <Switch
@@ -269,11 +267,11 @@ export function AIDJSettings() {
                 Auto BPM Analysis
               </Label>
               <p className="text-xs text-gray-600 dark:text-gray-400">
-                Automatically detect BPM during playback using audio analysis
+                Detect BPM during playback using audio analysis
               </p>
               {bpmAnalysisEnabled && (
                 <p className="text-xs text-amber-600 dark:text-amber-400 mt-1">
-                  ⚡ May use extra CPU during playback
+                  May use extra CPU during playback
                 </p>
               )}
             </div>
@@ -303,7 +301,7 @@ export function AIDJSettings() {
                 Seed Recommendations Throughout Queue
               </Label>
               <p className="text-xs text-gray-600 dark:text-gray-400">
-                Inject AI recommendations throughout your existing queue immediately, not just at the end
+                Inject AI picks throughout your queue, not just at the end
               </p>
             </div>
             <Switch
@@ -338,7 +336,7 @@ export function AIDJSettings() {
                 aria-label="Seed density"
               />
               <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
-                Insert {seedDensity} AI recommendation{seedDensity > 1 ? 's' : ''} for every 10 songs in your queue
+                Insert {seedDensity} AI recommendation{seedDensity > 1 ? 's' : ''} for every 10 songs
               </p>
             </div>
           )}
@@ -349,7 +347,7 @@ export function AIDJSettings() {
             size="sm"
             onClick={() => {
               const audioStore = useAudioStore.getState();
-              if (audioStore.queue.length === 0) {
+              if (audioStore.playlist.length === 0) {
                 toast.error('Add some songs to your queue first');
                 return;
               }
@@ -363,21 +361,94 @@ export function AIDJSettings() {
           </Button>
         </div>
 
+        {/* Advanced Settings (Collapsible) */}
+        <div className="pt-4 border-t border-purple-200 dark:border-purple-700">
+          <button
+            type="button"
+            onClick={() => setShowAdvanced(!showAdvanced)}
+            className="flex items-center justify-between w-full text-sm font-medium text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200"
+          >
+            <span>Advanced Settings</span>
+            {showAdvanced ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+          </button>
+
+          {showAdvanced && (
+            <div className="mt-4 space-y-4 pl-2 border-l-2 border-purple-200 dark:border-purple-700">
+              <p className="text-xs text-gray-500 dark:text-gray-400 italic">
+                These settings control fallback behavior when queue runs low
+              </p>
+
+              {/* Queue Threshold Slider */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <Label htmlFor="ai-dj-threshold" className="text-sm font-medium">
+                    Queue Threshold (Fallback)
+                  </Label>
+                  <span className="text-sm font-semibold text-purple-600 dark:text-purple-400">
+                    {threshold} {threshold === 1 ? 'song' : 'songs'}
+                  </span>
+                </div>
+                <Slider
+                  id="ai-dj-threshold"
+                  min={1}
+                  max={5}
+                  step={1}
+                  value={[threshold]}
+                  onValueChange={(value) => handleThresholdChange(value[0])}
+                  className="cursor-pointer"
+                  disabled={isAIDJDisabled}
+                  aria-label="Queue threshold"
+                />
+                <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                  Add batch when queue has {threshold} {threshold === 1 ? 'song' : 'songs'} left
+                </p>
+              </div>
+
+              {/* Batch Size Slider */}
+              <div>
+                <div className="flex items-center justify-between mb-2">
+                  <Label htmlFor="ai-dj-batch" className="text-sm font-medium">
+                    Batch Size (Fallback)
+                  </Label>
+                  <span className="text-sm font-semibold text-purple-600 dark:text-purple-400">
+                    {batchSize} {batchSize === 1 ? 'song' : 'songs'}
+                  </span>
+                </div>
+                <Slider
+                  id="ai-dj-batch"
+                  min={1}
+                  max={10}
+                  step={1}
+                  value={[batchSize]}
+                  onValueChange={(value) => handleBatchSizeChange(value[0])}
+                  className="cursor-pointer"
+                  disabled={isAIDJDisabled}
+                  aria-label="Batch size"
+                />
+                <p className="text-xs text-gray-600 dark:text-gray-400 mt-2">
+                  Add {batchSize} {batchSize === 1 ? 'song' : 'songs'} at a time when queue is low
+                </p>
+              </div>
+            </div>
+          )}
+        </div>
+
         {/* Preview Summary */}
         <div className="mt-6 p-4 rounded-lg bg-white/50 dark:bg-black/20 border border-purple-200 dark:border-purple-800">
           <p className="text-sm font-medium text-gray-700 dark:text-gray-300 mb-2">
-            Preview:
+            How it works:
           </p>
           <p className="text-sm text-gray-600 dark:text-gray-400">
-            AI DJ will add <span className="font-semibold text-purple-600 dark:text-purple-400">{batchSize} {batchSize === 1 ? 'song' : 'songs'}</span>{' '}
-            when <span className="font-semibold text-purple-600 dark:text-purple-400">{threshold} {threshold === 1 ? 'song remains' : 'songs remain'}</span> in your queue
-            {useContext ? ', based on what you\'re currently listening to' : ''}.
+            AI DJ adds <span className="font-semibold text-purple-600 dark:text-purple-400">1 song</span> every{' '}
+            <span className="font-semibold text-purple-600 dark:text-purple-400">{dripInterval} songs</span> you play
+            {useContext ? ', based on what you\'re listening to' : ''}.
+            {threshold <= 2 && ` If queue runs low, adds ${batchSize} songs at once.`}
           </p>
         </div>
 
         {/* Note about saving */}
         <p className="text-xs text-gray-500 dark:text-gray-400 italic">
-          Note: Changes are saved automatically when you adjust the settings above.
+          Changes are saved automatically.
         </p>
       </div>
     </Card>
@@ -387,6 +458,10 @@ export function AIDJSettings() {
 // Hook version for inline use in settings pages
 export function useAIDJSettingsSync() {
   const { preferences, setRecommendationSettings } = usePreferencesStore();
+
+  const updateDripInterval = async (interval: number) => {
+    await setRecommendationSettings({ aiDJDripInterval: interval });
+  };
 
   const updateThreshold = async (threshold: number) => {
     await setRecommendationSettings({ aiDJQueueThreshold: threshold });
@@ -401,9 +476,11 @@ export function useAIDJSettingsSync() {
   };
 
   return {
+    dripInterval: preferences.recommendationSettings.aiDJDripInterval ?? 3,
     threshold: preferences.recommendationSettings.aiDJQueueThreshold,
     batchSize: preferences.recommendationSettings.aiDJBatchSize,
     useContext: preferences.recommendationSettings.aiDJUseCurrentContext,
+    updateDripInterval,
     updateThreshold,
     updateBatchSize,
     updateUseContext,

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -206,11 +206,14 @@ export function AppLayout({ children }: AppLayoutProps) {
       </div>
 
       {/* Bottom Player Bar - Fixed to viewport bottom on all screen sizes */}
-      {hasActiveSong && (
-        <div className="fixed bottom-0 left-0 right-0 z-50 border-t bg-background/95 backdrop-blur-xl pb-[env(safe-area-inset-bottom)]">
-          <PlayerBar />
-        </div>
-      )}
+      {/* CRITICAL: Always render PlayerBar to preserve audio elements across state changes.
+         Unmounting destroys <audio> elements and kills playback. Hide visually instead. */}
+      <div className={cn(
+        "fixed bottom-0 left-0 right-0 z-50 border-t bg-background/95 backdrop-blur-xl pb-[env(safe-area-inset-bottom)]",
+        !hasActiveSong && "hidden"
+      )}>
+        <PlayerBar />
+      </div>
 
       {/* Queue Panel - Slide-out drawer */}
       <QueuePanel />

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -996,17 +996,6 @@ export function PlayerBar() {
         setIsPlaying(true);
         return;
       }
-      // CRITICAL: If audio has progressed (was playing) but iOS briefly paused it,
-      // don't permanently pause it - try to resume instead
-      // This handles iOS visibility change behavior where audio gets briefly paused
-      if (audio.currentTime > 0 && hasRealSong(audio) && audio.readyState >= 2) {
-        console.log('🎮 [STORE] Store says pause but audio has progress - resuming instead');
-        audio.play().catch((err) => {
-          console.log('🎮 [STORE] Resume failed, accepting paused state:', err.message);
-        });
-        setIsPlaying(true);
-        return;
-      }
       audio.pause();
     } else if (audio.readyState >= 2) {
       // Only try to play if audio is ready (has enough data)

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -1,7 +1,7 @@
 import { useAudioStore } from '@/lib/stores/audio';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X, Music, Trash2, GripVertical, Plus, RotateCcw, ThumbsUp, ThumbsDown, Shuffle, SkipForward } from 'lucide-react';
+import { X, Music, Trash2, GripVertical, Plus, RotateCcw, ThumbsUp, ThumbsDown, Shuffle, SkipForward, Sparkles } from 'lucide-react';
 import { useState, useEffect, useCallback, useMemo, memo, useRef } from 'react';
 import { CreatePlaylistDialog } from '@/components/playlists/CreatePlaylistDialog';
 import { useQueryClient } from '@tanstack/react-query';
@@ -328,6 +328,7 @@ export function QueuePanel() {
     autoplayQueuedSongIds,
     autoplayLastQueueTime,
     skipAutoplayedSong,
+    nudgeMoreLikeThis,
   } = useAudioStore();
   const [isOpen, setIsOpen] = useState(false);
   const [timeSinceLastQueue, setTimeSinceLastQueue] = useState(0);
@@ -789,6 +790,22 @@ export function QueuePanel() {
                     </Button>
                   )}
                 </div>
+
+                {/* More Like This Button */}
+                {currentSong && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      nudgeMoreLikeThis();
+                      toast.success(`Finding more songs like "${currentSong.title || currentSong.name}"...`);
+                    }}
+                    className="w-full h-8 md:h-9 text-xs md:text-sm bg-gradient-to-r from-purple-500/5 to-pink-500/5 hover:from-purple-500/10 hover:to-pink-500/10 border-purple-500/20 hover:border-purple-500/30 text-purple-600/80 dark:text-purple-400/80 hover:text-purple-600 dark:hover:text-purple-400 transition-all duration-200 group"
+                  >
+                    <Sparkles className="mr-1 md:mr-2 h-3.5 w-3.5 md:h-4 md:w-4 group-hover:scale-110 transition-transform" />
+                    More Like This
+                  </Button>
+                )}
 
                 {undoTimeRemaining !== null && undoTimeRemaining > 0 ? (
                   <Button

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -37,9 +37,11 @@ interface SortableQueueItemProps {
   currentFeedback?: 'thumbs_up' | 'thumbs_down' | null;
   onFeedback?: (songId: string, songTitle: string, artist: string, type: 'thumbs_up' | 'thumbs_down') => void;
   onSkipAutoplay?: (songId: string) => void;
+  /** Unique sortable ID for drag-and-drop (handles duplicate songs) */
+  sortableId?: string;
 }
 
-const SortableQueueItem = memo(function SortableQueueItem({ song, index, actualIndex, onRemove, onPlay, isAIQueued, isAutoplayQueued, currentFeedback, onFeedback, onSkipAutoplay }: SortableQueueItemProps) {
+const SortableQueueItem = memo(function SortableQueueItem({ song, index, actualIndex, onRemove, onPlay, isAIQueued, isAutoplayQueued, currentFeedback, onFeedback, onSkipAutoplay, sortableId }: SortableQueueItemProps) {
   const {
     attributes,
     listeners,
@@ -47,7 +49,7 @@ const SortableQueueItem = memo(function SortableQueueItem({ song, index, actualI
     transform,
     transition,
     isDragging,
-  } = useSortable({ id: song.id });
+  } = useSortable({ id: sortableId || song.id });
 
   const isLiked = currentFeedback === 'thumbs_up';
   const isDisliked = currentFeedback === 'thumbs_down';
@@ -728,7 +730,7 @@ export function QueuePanel() {
                 onDragEnd={handleDragEnd}
               >
                 <SortableContext
-                  items={upcomingQueue.map(s => s.id)}
+                  items={upcomingQueue.map((s, i) => `${s.id}-${i}`)}
                   strategy={verticalListSortingStrategy}
                 >
                   <div className="h-[25vh] md:h-[40vh] overflow-y-auto overflow-x-hidden pr-1 md:pr-2 space-y-2">
@@ -738,9 +740,12 @@ export function QueuePanel() {
                       const isAIQueued = aiQueuedSongIds.has(song.id);
                       const isAutoplayQueued = autoplayQueuedSongIds.has(song.id);
                       const isAutoQueued = isAIQueued || isAutoplayQueued;
+                      // Use index in key to handle duplicate songs in queue
+                      const sortableId = `${song.id}-${index}`;
                       return (
                         <SortableQueueItem
-                          key={song.id}
+                          key={sortableId}
+                          sortableId={sortableId}
                           song={song}
                           index={index}
                           actualIndex={actualIndex}

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -12,3 +12,4 @@ export * from "./playlist-export.schema";
 export * from "./music-identity.schema";
 export * from "./lyrics-cache.schema";
 export * from "./background-discovery.schema";
+export * from "./profile.schema";

--- a/src/lib/db/schema/preferences.schema.ts
+++ b/src/lib/db/schema/preferences.schema.ts
@@ -27,6 +27,13 @@ export const userPreferences = pgTable("user_preferences", {
     autoplayBlendMode: 'crossfade' | 'silence' | 'reverb_tail'; // Transition effect between songs
     autoplayTransitionDuration: number; // Duration in seconds (1-10)
     autoplaySmartTransitions: boolean; // Use AI to determine optimal transition type
+    // DJ Matching Settings (BPM/Energy/Key)
+    djMatchingEnabled?: boolean; // Enable BPM/energy/key scoring for AI DJ recommendations
+    bpmAnalysisEnabled?: boolean; // Auto-analyze BPM during playback
+    djMatchingMinScore?: number; // Minimum DJ score threshold (0-1)
+    // Queue Seeding Settings
+    aiDJSeedQueueEnabled?: boolean; // Seed recommendations throughout queue when AI DJ enabled
+    aiDJSeedDensity?: number; // How many recommendations per 10 songs (1-5)
   }>().default({
     aiEnabled: true,
     frequency: 'always',

--- a/src/lib/db/schema/profile.schema.ts
+++ b/src/lib/db/schema/profile.schema.ts
@@ -1,0 +1,181 @@
+/**
+ * Profile Schema
+ *
+ * Pre-computed user profile data for profile-based AI DJ recommendations.
+ * These tables store pre-calculated scores that enable zero-API-call
+ * recommendation generation.
+ *
+ * Key tables:
+ * - artistAffinities: User's affinity scores for each artist
+ * - temporalPreferences: Genre preferences by time of day/season
+ *
+ * @see docs/architecture/profile-based-recommendations.md
+ */
+
+import { pgTable, text, timestamp, integer, real, index, unique } from "drizzle-orm/pg-core";
+import { user } from "./auth.schema";
+
+/**
+ * Artist Affinities Table
+ *
+ * Stores pre-computed affinity scores for each artist a user has listened to.
+ * Affinity is calculated from:
+ * - Play count (how many times user played songs by this artist)
+ * - Liked count (how many songs by this artist are starred/liked)
+ * - Skip count (how often songs by this artist are skipped)
+ *
+ * Formula: affinity = (play_weight * plays + liked_weight * likes) / (1 + skip_penalty * skips)
+ */
+export const artistAffinities = pgTable("artist_affinities", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  // Artist identifier (normalized lowercase)
+  artist: text("artist").notNull(),
+
+  // Normalized affinity score (0-1)
+  // Higher = stronger preference for this artist
+  affinityScore: real("affinity_score").notNull().default(0),
+
+  // Raw counts used to calculate affinity
+  playCount: integer("play_count").notNull().default(0),
+  likedCount: integer("liked_count").notNull().default(0),
+  skipCount: integer("skip_count").notNull().default(0),
+
+  // Total play time in seconds (for weighted scoring)
+  totalPlayTime: integer("total_play_time").notNull().default(0),
+
+  // When this affinity was last calculated
+  calculatedAt: timestamp("calculated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+}, (table) => ({
+  // Unique constraint: one affinity per user-artist pair
+  uniqueUserArtist: unique("artist_affinities_unique").on(table.userId, table.artist),
+
+  // Index for user lookups
+  userIdIdx: index("artist_affinities_user_id_idx").on(table.userId),
+
+  // Index for ranked affinities (by score)
+  userScoreIdx: index("artist_affinities_user_score_idx").on(table.userId, table.affinityScore),
+
+  // Index for artist lookups
+  artistIdx: index("artist_affinities_artist_idx").on(table.artist),
+}));
+
+/**
+ * Temporal Preferences Table
+ *
+ * Stores genre preferences by time of day and season.
+ * Enables recommendations that match the user's mood patterns.
+ *
+ * Time slots:
+ * - morning: 6:00 - 11:59
+ * - afternoon: 12:00 - 17:59
+ * - evening: 18:00 - 21:59
+ * - night: 22:00 - 5:59
+ *
+ * Seasons:
+ * - spring: March-May
+ * - summer: June-August
+ * - fall: September-November
+ * - winter: December-February
+ */
+export const temporalPreferences = pgTable("temporal_preferences", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  // Time context
+  timeSlot: text("time_slot", { enum: ['morning', 'afternoon', 'evening', 'night'] }).notNull(),
+  season: text("season", { enum: ['spring', 'summer', 'fall', 'winter'] }),
+
+  // Genre for this preference
+  genre: text("genre").notNull(),
+
+  // Normalized preference score (0-1)
+  // Higher = stronger preference for this genre at this time
+  preferenceScore: real("preference_score").notNull().default(0),
+
+  // Play count at this time/season combination
+  playCount: integer("play_count").notNull().default(0),
+
+  // When this preference was last calculated
+  calculatedAt: timestamp("calculated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+}, (table) => ({
+  // Unique constraint: one preference per user-time-season-genre combination
+  uniqueTemporal: unique("temporal_preferences_unique").on(
+    table.userId,
+    table.timeSlot,
+    table.season,
+    table.genre
+  ),
+
+  // Index for user lookups
+  userIdIdx: index("temporal_preferences_user_id_idx").on(table.userId),
+
+  // Index for time-based queries
+  userTimeIdx: index("temporal_preferences_user_time_idx").on(table.userId, table.timeSlot),
+
+  // Index for season-based queries
+  userSeasonIdx: index("temporal_preferences_user_season_idx").on(table.userId, table.season),
+
+  // Index for genre lookups
+  genreIdx: index("temporal_preferences_genre_idx").on(table.genre),
+}));
+
+/**
+ * Liked Songs Sync Tracker
+ *
+ * Tracks which starred songs have been synced to the feedback table.
+ * Prevents duplicate syncing and tracks un-stars.
+ */
+export const likedSongsSync = pgTable("liked_songs_sync", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  // Song identifiers
+  songId: text("song_id").notNull(),
+  artist: text("artist").notNull(),
+  title: text("title").notNull(),
+
+  // Sync status
+  syncedAt: timestamp("synced_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+
+  // Is the song still starred? (false = was un-starred)
+  isActive: integer("is_active").notNull().default(1), // 1 = active, 0 = un-starred
+}, (table) => ({
+  // Unique constraint: one sync record per user-song pair
+  uniqueUserSong: unique("liked_songs_sync_unique").on(table.userId, table.songId),
+
+  // Index for user lookups
+  userIdIdx: index("liked_songs_sync_user_id_idx").on(table.userId),
+
+  // Index for song lookups
+  songIdIdx: index("liked_songs_sync_song_id_idx").on(table.songId),
+
+  // Index for active songs
+  userActiveIdx: index("liked_songs_sync_user_active_idx").on(table.userId, table.isActive),
+}));
+
+// Type exports
+export type ArtistAffinity = typeof artistAffinities.$inferSelect;
+export type ArtistAffinityInsert = typeof artistAffinities.$inferInsert;
+
+export type TemporalPreference = typeof temporalPreferences.$inferSelect;
+export type TemporalPreferenceInsert = typeof temporalPreferences.$inferInsert;
+
+export type LikedSongsSync = typeof likedSongsSync.$inferSelect;
+export type LikedSongsSyncInsert = typeof likedSongsSync.$inferInsert;

--- a/src/lib/hooks/useEruda.ts
+++ b/src/lib/hooks/useEruda.ts
@@ -1,0 +1,242 @@
+/**
+ * useEruda Hook
+ *
+ * Loads Eruda mobile console and streams logs to server.
+ * Activate by adding ?debug=true to URL or setting localStorage.debug = 'true'
+ *
+ * Logs are sent to /api/debug/logs and printed in server terminal.
+ *
+ * @see https://github.com/liriliri/eruda
+ */
+
+import { useEffect, useState } from 'react';
+
+declare global {
+  interface Window {
+    eruda?: {
+      init: (options?: { container?: HTMLElement; tool?: string[] }) => void;
+      destroy: () => void;
+      show: () => void;
+      hide: () => void;
+    };
+    __originalConsole?: {
+      log: typeof console.log;
+      warn: typeof console.warn;
+      error: typeof console.error;
+      info: typeof console.info;
+    };
+  }
+}
+
+// Queue for batching log sends
+let logQueue: Array<{
+  level: string;
+  args: string[];
+  timestamp: string;
+}> = [];
+let flushTimeout: ReturnType<typeof setTimeout> | null = null;
+
+/**
+ * Send logs to server
+ */
+function flushLogs() {
+  if (logQueue.length === 0) return;
+
+  const logsToSend = [...logQueue];
+  logQueue = [];
+
+  // Send each log individually (simple approach)
+  for (const log of logsToSend) {
+    fetch('/api/debug/logs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...log,
+        userAgent: navigator.userAgent,
+        url: window.location.href,
+      }),
+    }).catch(() => {
+      // Ignore send failures
+    });
+  }
+}
+
+/**
+ * Queue a log to be sent
+ */
+function queueLog(level: string, args: unknown[]) {
+  // Serialize arguments safely with truncation
+  const serializedArgs = args.map(arg => {
+    try {
+      if (arg instanceof Error) {
+        return `Error: ${arg.message}\n${arg.stack || ''}`;
+      }
+      if (typeof arg === 'object' && arg !== null) {
+        const json = JSON.stringify(arg);
+        // Truncate large objects
+        if (json.length > 200) {
+          // For arrays, show count
+          if (Array.isArray(arg)) {
+            return `[Array(${arg.length})]`;
+          }
+          // For objects, show keys only
+          const keys = Object.keys(arg as object);
+          return `{${keys.slice(0, 5).join(', ')}${keys.length > 5 ? '...' : ''}}`;
+        }
+        return json;
+      }
+      return String(arg);
+    } catch {
+      return '[Unserializable]';
+    }
+  });
+
+  // Skip noisy logs
+  const firstArg = serializedArgs[0] || '';
+  if (
+    firstArg.includes('getAlbumList') ||
+    firstArg.includes('[React Query]') ||
+    firstArg.includes('musicBrainzId') ||
+    firstArg.includes('"genres":[')
+  ) {
+    return; // Skip these verbose logs
+  }
+
+  logQueue.push({
+    level,
+    args: serializedArgs,
+    timestamp: new Date().toISOString(),
+  });
+
+  // Debounce flush - send after 100ms of no new logs, or immediately for errors
+  if (flushTimeout) clearTimeout(flushTimeout);
+
+  if (level === 'error') {
+    flushLogs(); // Send errors immediately
+  } else {
+    flushTimeout = setTimeout(flushLogs, 100);
+  }
+}
+
+/**
+ * Override console methods to stream to server
+ */
+function setupRemoteLogging() {
+  // Don't setup twice
+  if (window.__originalConsole) return;
+
+  // Store original methods
+  window.__originalConsole = {
+    log: console.log.bind(console),
+    warn: console.warn.bind(console),
+    error: console.error.bind(console),
+    info: console.info.bind(console),
+  };
+
+  // Override console methods
+  console.log = (...args: unknown[]) => {
+    queueLog('log', args);
+    window.__originalConsole!.log(...args);
+  };
+
+  console.warn = (...args: unknown[]) => {
+    queueLog('warn', args);
+    window.__originalConsole!.warn(...args);
+  };
+
+  console.error = (...args: unknown[]) => {
+    queueLog('error', args);
+    window.__originalConsole!.error(...args);
+  };
+
+  console.info = (...args: unknown[]) => {
+    queueLog('info', args);
+    window.__originalConsole!.info(...args);
+  };
+
+  // Also catch unhandled errors
+  window.addEventListener('error', (event) => {
+    queueLog('error', [`Uncaught: ${event.message} at ${event.filename}:${event.lineno}`]);
+  });
+
+  window.addEventListener('unhandledrejection', (event) => {
+    queueLog('error', [`Unhandled Promise: ${event.reason}`]);
+  });
+}
+
+/**
+ * Hook to conditionally load Eruda debug console
+ * Enable via URL param: ?debug=true
+ * Or via localStorage: localStorage.setItem('debug', 'true')
+ */
+export function useEruda(): { isLoaded: boolean; isEnabled: boolean } {
+  const [isLoaded, setIsLoaded] = useState(false);
+  const [isEnabled, setIsEnabled] = useState(false);
+
+  useEffect(() => {
+    // Check if debug mode should be enabled
+    const urlParams = new URLSearchParams(window.location.search);
+    const debugParam = urlParams.get('debug');
+    const debugStorage = localStorage.getItem('debug');
+
+    const shouldEnable = debugParam === 'true' || debugStorage === 'true';
+
+    // If debug=true in URL, persist to localStorage for future loads
+    if (debugParam === 'true') {
+      localStorage.setItem('debug', 'true');
+    }
+
+    // If debug=false explicitly, disable
+    if (debugParam === 'false') {
+      localStorage.removeItem('debug');
+      if (window.eruda) {
+        window.eruda.destroy();
+      }
+      setIsEnabled(false);
+      setIsLoaded(false);
+      return;
+    }
+
+    if (!shouldEnable) {
+      return;
+    }
+
+    setIsEnabled(true);
+
+    // Setup remote logging FIRST
+    setupRemoteLogging();
+
+    // Don't load Eruda twice
+    if (window.eruda) {
+      setIsLoaded(true);
+      return;
+    }
+
+    // Load Eruda from CDN
+    const script = document.createElement('script');
+    script.src = 'https://cdn.jsdelivr.net/npm/eruda';
+    script.async = true;
+
+    script.onload = () => {
+      if (window.eruda) {
+        window.eruda.init();
+        setIsLoaded(true);
+        console.log('🔧 [Debug] Remote logging enabled - logs streaming to server');
+      }
+    };
+
+    script.onerror = () => {
+      // Eruda failed but remote logging still works
+      console.error('🔧 [Eruda] Failed to load UI, but remote logging is active');
+      setIsLoaded(true);
+    };
+
+    document.head.appendChild(script);
+
+    return () => {
+      // Don't destroy on unmount
+    };
+  }, []);
+
+  return { isLoaded, isEnabled };
+}

--- a/src/lib/query/config.ts
+++ b/src/lib/query/config.ts
@@ -38,7 +38,7 @@ export const defaultQueryOptions = {
   gcTime: GC_TIMES.STANDARD,
   refetchOnWindowFocus: false,
   refetchOnMount: false,
-  refetchOnReconnect: 'always' as const,
+  refetchOnReconnect: false,
   retry: 2,
   retryDelay: (attemptIndex: number) => Math.min(1000 * 2 ** attemptIndex, 30000),
 };

--- a/src/lib/services/__tests__/audio-analysis.test.ts
+++ b/src/lib/services/__tests__/audio-analysis.test.ts
@@ -13,7 +13,7 @@ import {
   detectEnergy,
   detectDanceability
 } from '../audio-analysis';
-import type { Song } from '@/components/ui/audio-player';
+import type { Song } from '@/lib/types/song';
 import type { AudioAnalysis, MusicalKey } from '../audio-analysis';
 
 // Mock song data

--- a/src/lib/services/__tests__/compound-scoring.test.ts
+++ b/src/lib/services/__tests__/compound-scoring.test.ts
@@ -35,7 +35,7 @@ import {
   LOOKBACK_DAYS,
 } from '../compound-scoring';
 import { db } from '@/lib/db';
-import type { Song } from '@/components/ui/audio-player';
+import type { Song } from '@/lib/types/song';
 
 describe('Compound Scoring Service', () => {
   beforeEach(() => {

--- a/src/lib/services/__tests__/dj-queue-manager.test.ts
+++ b/src/lib/services/__tests__/dj-queue-manager.test.ts
@@ -3,7 +3,7 @@
 
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { createDJQueueManager } from '../dj-queue-manager';
-import type { Song } from '@/components/ui/audio-player';
+import type { Song } from '@/lib/types/song';
 
 // Mock song data
 const mockSongs: Song[] = [

--- a/src/lib/services/ai-dj/core.ts
+++ b/src/lib/services/ai-dj/core.ts
@@ -1,8 +1,10 @@
 // AI DJ Service Core
 // Phase 3: Updated to use unified recommendations service (Last.fm-based)
+// Phase 5: Added BPM/energy/key matching for smoother DJ transitions
 
 import type { Song } from '@/lib/types/song';
-import { getRecommendations } from '../recommendations';
+import { getRecommendations, type DJMatchingOptions } from '../recommendations';
+import { enrichSongWithDJMetadata } from '../dj-match-scorer';
 import { ServiceError } from '../../utils';
 
 // AI DJ configuration
@@ -12,6 +14,24 @@ export interface AIDJQueueMetadata {
   aiQueued: boolean;
   queuedAt: number;
   queuedBy: 'ai-dj';
+  /** DJ score for this recommendation (0-1) */
+  djScore?: number;
+}
+
+/** DJ matching settings for AI DJ */
+export interface AIDJMatchingSettings {
+  /** Enable BPM/energy/key matching */
+  enabled: boolean;
+  /** BPM tolerance (0.03 = 3% for tight matching, as per user requirement) */
+  bpmTolerance?: number;
+  /** Minimum DJ score threshold (0-1, default 0.5) */
+  minDJScore?: number;
+  /** Custom weights for BPM/energy/key scoring */
+  weights?: {
+    bpm?: number;
+    energy?: number;
+    key?: number;
+  };
 }
 
 /** Context for AI DJ recommendations */
@@ -20,6 +40,8 @@ export interface AIContext {
   recentQueue: Song[];
   fullPlaylist?: Song[];
   currentSongIndex?: number;
+  /** DJ matching settings for BPM/energy/key-aware recommendations */
+  djMatching?: AIDJMatchingSettings;
 }
 
 /**
@@ -37,6 +59,7 @@ export function checkQueueThreshold(
 /**
  * Generate contextual AI DJ recommendations based on current playback
  * Phase 3: Now uses Last.fm-based unified recommendations service for better accuracy and speed
+ * Phase 5: Added BPM/energy/key matching for smoother DJ-style transitions
  *
  * @param context - Current song and recent queue context
  * @param batchSize - Number of songs to recommend (1-10)
@@ -55,7 +78,7 @@ export async function generateContextualRecommendations(
   excludeArtists: string[] = []
 ): Promise<Song[]> {
   try {
-    const { currentSong } = context;
+    const { currentSong, djMatching } = context;
 
     if (!currentSong) {
       throw new ServiceError('AI_DJ_NO_CURRENT_SONG', 'No current song to base recommendations on');
@@ -63,21 +86,57 @@ export async function generateContextualRecommendations(
 
     console.log(`🎵 AI DJ: Getting similar songs for "${currentSong.artist} - ${currentSong.title}"`);
 
+    // Phase 5: Enrich current song with BPM/key/energy metadata if DJ matching is enabled
+    let enrichedCurrentSong = currentSong;
+    let djMatchingOptions: DJMatchingOptions | undefined;
+
+    if (djMatching?.enabled) {
+      try {
+        // Get BPM/key/energy for current song from cache or estimation
+        enrichedCurrentSong = await enrichSongWithDJMetadata(currentSong);
+        console.log(`🎧 AI DJ: Current song metadata - BPM: ${enrichedCurrentSong.bpm ?? 'unknown'}, Key: ${enrichedCurrentSong.key ?? 'unknown'}, Energy: ${enrichedCurrentSong.energy?.toFixed(2) ?? 'unknown'}`);
+
+        // Build DJ matching options for recommendations
+        djMatchingOptions = {
+          enabled: true,
+          currentBpm: enrichedCurrentSong.bpm,
+          currentKey: enrichedCurrentSong.key,
+          currentEnergy: enrichedCurrentSong.energy,
+          minDJScore: djMatching.minDJScore ?? 0.5,
+          weights: djMatching.weights,
+        };
+      } catch (error) {
+        console.warn('⚠️ AI DJ: Failed to enrich current song metadata, continuing without DJ matching:', error);
+        djMatchingOptions = undefined;
+      }
+    }
+
     // Use the unified recommendations service with 'similar' mode
     // This now uses Last.fm for song similarity (much faster and more accurate)
+    // Phase 5: Pass DJ matching options for BPM/energy/key-aware filtering
     const result = await getRecommendations({
       mode: 'similar',
       currentSong: {
-        artist: currentSong.artist,
-        title: currentSong.title || currentSong.name
+        artist: currentSong.artist || 'Unknown',
+        title: currentSong.title || currentSong.name || 'Unknown',
+        genre: currentSong.genre,
+        bpm: enrichedCurrentSong.bpm,
+        key: enrichedCurrentSong.key,
+        energy: enrichedCurrentSong.energy,
       },
       limit: batchSize,
       excludeSongIds,
       excludeArtists,
+      djMatching: djMatchingOptions,
     });
 
     if (result.songs.length === 0) {
       throw new ServiceError('AI_DJ_NO_RECOMMENDATIONS', 'No similar songs found in your library');
+    }
+
+    // Log DJ matching results if enabled
+    if (result.metadata?.djMatchingApplied) {
+      console.log(`🎧 AI DJ: DJ matching applied - ${result.metadata.djScoredCount} songs scored, avg score ${((result.metadata.avgDJScore ?? 0) * 100).toFixed(1)}%`);
     }
 
     console.log(`✅ AI DJ: Got ${result.songs.length} recommendations from ${result.source}`);

--- a/src/lib/services/artist-affinity.ts
+++ b/src/lib/services/artist-affinity.ts
@@ -1,0 +1,533 @@
+/**
+ * Artist Affinity Service
+ *
+ * Calculates and stores user affinity scores for artists based on:
+ * - Play count (how many times user played songs by this artist)
+ * - Liked count (how many songs by this artist are starred/liked)
+ * - Skip count (how often songs by this artist are skipped)
+ *
+ * Affinity scores are used in the profile-based recommendation system
+ * to give a 15% weight to artist preference.
+ *
+ * @see docs/architecture/profile-based-recommendations.md
+ */
+
+import { db } from '../db';
+import {
+  artistAffinities,
+  listeningHistory,
+  likedSongsSync,
+  temporalPreferences,
+  type ArtistAffinityInsert,
+  type TemporalPreferenceInsert,
+} from '../db/schema';
+import { eq, and, gte, sql, desc } from 'drizzle-orm';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Weight factors for affinity calculation
+const PLAY_WEIGHT = 0.5;      // Weight for play count
+const LIKED_WEIGHT = 0.35;    // Weight for liked count (strong signal)
+const SKIP_PENALTY = 0.15;    // Penalty for skip count
+
+// Lookback period for affinity calculation
+const AFFINITY_LOOKBACK_DAYS = 90;
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ArtistAffinityData {
+  artist: string;
+  affinityScore: number;
+  playCount: number;
+  likedCount: number;
+  skipCount: number;
+}
+
+export interface TemporalPreferenceData {
+  timeSlot: 'morning' | 'afternoon' | 'evening' | 'night';
+  season: 'spring' | 'summer' | 'fall' | 'winter' | null;
+  genre: string;
+  preferenceScore: number;
+  playCount: number;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get time slot from hour of day
+ */
+function getTimeSlot(hour: number): 'morning' | 'afternoon' | 'evening' | 'night' {
+  if (hour >= 6 && hour < 12) return 'morning';
+  if (hour >= 12 && hour < 18) return 'afternoon';
+  if (hour >= 18 && hour < 22) return 'evening';
+  return 'night';
+}
+
+/**
+ * Get season from month
+ */
+function getSeason(month: number): 'spring' | 'summer' | 'fall' | 'winter' {
+  if (month >= 3 && month <= 5) return 'spring';
+  if (month >= 6 && month <= 8) return 'summer';
+  if (month >= 9 && month <= 11) return 'fall';
+  return 'winter';
+}
+
+/**
+ * Get current time context
+ */
+export function getCurrentTimeContext() {
+  const now = new Date();
+  const hour = now.getHours();
+  const month = now.getMonth() + 1;
+
+  return {
+    timeSlot: getTimeSlot(hour),
+    season: getSeason(month),
+  };
+}
+
+// ============================================================================
+// Artist Affinity Functions
+// ============================================================================
+
+/**
+ * Calculate artist affinity scores for a user
+ *
+ * This function:
+ * 1. Aggregates play counts by artist from listening history
+ * 2. Counts liked songs by artist
+ * 3. Counts skips by artist
+ * 4. Calculates normalized affinity score
+ * 5. Stores results in artistAffinities table
+ *
+ * @param userId - The user's ID
+ * @param daysBack - Number of days to look back (default: 90)
+ * @returns Number of artist affinities calculated
+ */
+export async function calculateArtistAffinities(
+  userId: string,
+  daysBack: number = AFFINITY_LOOKBACK_DAYS
+): Promise<number> {
+  console.log(`🎨 [ArtistAffinity] Calculating affinities for user ${userId} (${daysBack} days)`);
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - daysBack);
+
+  // Step 1: Get play counts and skip counts by artist
+  const artistStats = await db
+    .select({
+      artist: listeningHistory.artist,
+      playCount: sql<number>`count(*)`.as('play_count'),
+      skipCount: sql<number>`sum(case when ${listeningHistory.skipDetected} = 1 then 1 else 0 end)`.as('skip_count'),
+      totalPlayTime: sql<number>`coalesce(sum(${listeningHistory.playDuration}), 0)`.as('total_play_time'),
+    })
+    .from(listeningHistory)
+    .where(
+      and(
+        eq(listeningHistory.userId, userId),
+        gte(listeningHistory.playedAt, cutoffDate)
+      )
+    )
+    .groupBy(listeningHistory.artist);
+
+  if (artistStats.length === 0) {
+    console.log(`🎨 [ArtistAffinity] No listening history found for user ${userId}`);
+    return 0;
+  }
+
+  console.log(`🎨 [ArtistAffinity] Found ${artistStats.length} artists in listening history`);
+
+  // Step 2: Get liked song counts by artist
+  const likedStats = await db
+    .select({
+      artist: likedSongsSync.artist,
+      likedCount: sql<number>`count(*)`.as('liked_count'),
+    })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    )
+    .groupBy(likedSongsSync.artist);
+
+  // Build a map of artist -> liked count
+  const likedCountMap = new Map<string, number>();
+  for (const stat of likedStats) {
+    likedCountMap.set(stat.artist.toLowerCase(), stat.likedCount);
+  }
+
+  // Step 3: Find max values for normalization
+  const maxPlayCount = Math.max(...artistStats.map(s => s.playCount), 1);
+  const maxLikedCount = Math.max(...likedStats.map(s => s.likedCount), 1);
+  const maxSkipCount = Math.max(...artistStats.map(s => Number(s.skipCount) || 0), 1);
+
+  // Step 4: Calculate and store affinity scores
+  let stored = 0;
+
+  for (const stat of artistStats) {
+    const normalizedArtist = stat.artist.toLowerCase();
+    const likedCount = likedCountMap.get(normalizedArtist) || 0;
+
+    // Normalize values to 0-1 range
+    const normalizedPlayCount = stat.playCount / maxPlayCount;
+    const normalizedLikedCount = likedCount / maxLikedCount;
+    const normalizedSkipCount = (Number(stat.skipCount) || 0) / maxSkipCount;
+
+    // Calculate affinity score
+    // Formula: (play_weight * plays + liked_weight * likes) * (1 - skip_penalty * skips)
+    const baseScore = (PLAY_WEIGHT * normalizedPlayCount) + (LIKED_WEIGHT * normalizedLikedCount);
+    const skipPenalty = 1 - (SKIP_PENALTY * normalizedSkipCount);
+    const affinityScore = Math.max(0, Math.min(1, baseScore * skipPenalty));
+
+    const record: ArtistAffinityInsert = {
+      userId,
+      artist: normalizedArtist,
+      affinityScore,
+      playCount: stat.playCount,
+      likedCount,
+      skipCount: Number(stat.skipCount) || 0,
+      totalPlayTime: Number(stat.totalPlayTime) || 0,
+    };
+
+    await db
+      .insert(artistAffinities)
+      .values(record)
+      .onConflictDoUpdate({
+        target: [artistAffinities.userId, artistAffinities.artist],
+        set: {
+          affinityScore: record.affinityScore,
+          playCount: record.playCount,
+          likedCount: record.likedCount,
+          skipCount: record.skipCount,
+          totalPlayTime: record.totalPlayTime,
+          calculatedAt: new Date(),
+        },
+      });
+
+    stored++;
+  }
+
+  console.log(`🎨 [ArtistAffinity] Stored ${stored} artist affinities for user ${userId}`);
+  return stored;
+}
+
+/**
+ * Get artist affinity score for a specific artist
+ *
+ * @param userId - The user's ID
+ * @param artist - Artist name
+ * @returns Affinity score (0-1) or 0 if not found
+ */
+export async function getArtistAffinity(
+  userId: string,
+  artist: string
+): Promise<number> {
+  const normalizedArtist = artist.toLowerCase();
+
+  const result = await db
+    .select({ affinityScore: artistAffinities.affinityScore })
+    .from(artistAffinities)
+    .where(
+      and(
+        eq(artistAffinities.userId, userId),
+        eq(artistAffinities.artist, normalizedArtist)
+      )
+    )
+    .limit(1);
+
+  return result.length > 0 ? result[0].affinityScore : 0;
+}
+
+/**
+ * Get top artists by affinity for a user
+ *
+ * @param userId - The user's ID
+ * @param limit - Maximum number of artists to return
+ * @returns Array of artist affinity data
+ */
+export async function getTopArtistsByAffinity(
+  userId: string,
+  limit: number = 20
+): Promise<ArtistAffinityData[]> {
+  const results = await db
+    .select()
+    .from(artistAffinities)
+    .where(eq(artistAffinities.userId, userId))
+    .orderBy(desc(artistAffinities.affinityScore))
+    .limit(limit);
+
+  return results.map(r => ({
+    artist: r.artist,
+    affinityScore: r.affinityScore,
+    playCount: r.playCount,
+    likedCount: r.likedCount,
+    skipCount: r.skipCount,
+  }));
+}
+
+/**
+ * Get multiple artist affinities at once
+ * More efficient than calling getArtistAffinity for each artist
+ *
+ * @param userId - The user's ID
+ * @param artists - Array of artist names
+ * @returns Map of artist -> affinity score
+ */
+export async function getArtistAffinities(
+  userId: string,
+  artists: string[]
+): Promise<Map<string, number>> {
+  if (artists.length === 0) {
+    return new Map();
+  }
+
+  const normalizedArtists = artists.map(a => a.toLowerCase());
+
+  const results = await db
+    .select({
+      artist: artistAffinities.artist,
+      affinityScore: artistAffinities.affinityScore,
+    })
+    .from(artistAffinities)
+    .where(eq(artistAffinities.userId, userId));
+
+  const affinityMap = new Map<string, number>();
+  for (const result of results) {
+    if (normalizedArtists.includes(result.artist)) {
+      affinityMap.set(result.artist, result.affinityScore);
+    }
+  }
+
+  return affinityMap;
+}
+
+// ============================================================================
+// Temporal Preference Functions
+// ============================================================================
+
+/**
+ * Calculate temporal preferences (genre preferences by time of day/season)
+ *
+ * @param userId - The user's ID
+ * @param daysBack - Number of days to look back
+ * @returns Number of temporal preferences calculated
+ */
+export async function calculateTemporalPreferences(
+  userId: string,
+  daysBack: number = AFFINITY_LOOKBACK_DAYS
+): Promise<number> {
+  console.log(`⏰ [TemporalPrefs] Calculating preferences for user ${userId} (${daysBack} days)`);
+
+  const cutoffDate = new Date();
+  cutoffDate.setDate(cutoffDate.getDate() - daysBack);
+
+  // Get listening history with genre and timestamp
+  const history = await db
+    .select({
+      genre: listeningHistory.genre,
+      playedAt: listeningHistory.playedAt,
+    })
+    .from(listeningHistory)
+    .where(
+      and(
+        eq(listeningHistory.userId, userId),
+        gte(listeningHistory.playedAt, cutoffDate)
+      )
+    );
+
+  if (history.length === 0) {
+    console.log(`⏰ [TemporalPrefs] No listening history found for user ${userId}`);
+    return 0;
+  }
+
+  // Aggregate by time slot + season + genre
+  const prefMap = new Map<string, { count: number; timeSlot: string; season: string; genre: string }>();
+
+  for (const play of history) {
+    if (!play.genre) continue;
+
+    const playDate = new Date(play.playedAt);
+    const hour = playDate.getHours();
+    const month = playDate.getMonth() + 1;
+
+    const timeSlot = getTimeSlot(hour);
+    const season = getSeason(month);
+
+    const key = `${timeSlot}:${season}:${play.genre.toLowerCase()}`;
+    const existing = prefMap.get(key);
+
+    if (existing) {
+      existing.count++;
+    } else {
+      prefMap.set(key, {
+        count: 1,
+        timeSlot,
+        season,
+        genre: play.genre.toLowerCase(),
+      });
+    }
+  }
+
+  if (prefMap.size === 0) {
+    console.log(`⏰ [TemporalPrefs] No genre data in listening history`);
+    return 0;
+  }
+
+  // Find max count for normalization
+  const maxCount = Math.max(...Array.from(prefMap.values()).map(v => v.count));
+
+  // Store temporal preferences
+  let stored = 0;
+
+  for (const [, data] of prefMap) {
+    const preferenceScore = data.count / maxCount;
+
+    const record: TemporalPreferenceInsert = {
+      userId,
+      timeSlot: data.timeSlot as 'morning' | 'afternoon' | 'evening' | 'night',
+      season: data.season as 'spring' | 'summer' | 'fall' | 'winter',
+      genre: data.genre,
+      preferenceScore,
+      playCount: data.count,
+    };
+
+    await db
+      .insert(temporalPreferences)
+      .values(record)
+      .onConflictDoUpdate({
+        target: [
+          temporalPreferences.userId,
+          temporalPreferences.timeSlot,
+          temporalPreferences.season,
+          temporalPreferences.genre,
+        ],
+        set: {
+          preferenceScore: record.preferenceScore,
+          playCount: record.playCount,
+          calculatedAt: new Date(),
+        },
+      });
+
+    stored++;
+  }
+
+  console.log(`⏰ [TemporalPrefs] Stored ${stored} temporal preferences for user ${userId}`);
+  return stored;
+}
+
+/**
+ * Get temporal boost for a genre at current time
+ *
+ * @param userId - The user's ID
+ * @param genre - Genre to check
+ * @returns Preference score (0-1) or 0 if not found
+ */
+export async function getTemporalGenreBoost(
+  userId: string,
+  genre: string
+): Promise<number> {
+  const { timeSlot, season } = getCurrentTimeContext();
+  const normalizedGenre = genre.toLowerCase();
+
+  const result = await db
+    .select({ preferenceScore: temporalPreferences.preferenceScore })
+    .from(temporalPreferences)
+    .where(
+      and(
+        eq(temporalPreferences.userId, userId),
+        eq(temporalPreferences.timeSlot, timeSlot),
+        eq(temporalPreferences.season, season),
+        eq(temporalPreferences.genre, normalizedGenre)
+      )
+    )
+    .limit(1);
+
+  return result.length > 0 ? result[0].preferenceScore : 0;
+}
+
+/**
+ * Get preferred genres for current time context
+ *
+ * @param userId - The user's ID
+ * @param limit - Maximum number of genres to return
+ * @returns Array of temporal preference data
+ */
+export async function getPreferredGenresForNow(
+  userId: string,
+  limit: number = 10
+): Promise<TemporalPreferenceData[]> {
+  const { timeSlot, season } = getCurrentTimeContext();
+
+  const results = await db
+    .select()
+    .from(temporalPreferences)
+    .where(
+      and(
+        eq(temporalPreferences.userId, userId),
+        eq(temporalPreferences.timeSlot, timeSlot),
+        eq(temporalPreferences.season, season)
+      )
+    )
+    .orderBy(desc(temporalPreferences.preferenceScore))
+    .limit(limit);
+
+  return results.map(r => ({
+    timeSlot: r.timeSlot,
+    season: r.season,
+    genre: r.genre,
+    preferenceScore: r.preferenceScore,
+    playCount: r.playCount,
+  }));
+}
+
+// ============================================================================
+// Profile Update Functions
+// ============================================================================
+
+/**
+ * Calculate full user profile (artist affinities + temporal preferences)
+ * Should be called periodically or after significant listening activity
+ *
+ * @param userId - The user's ID
+ * @param daysBack - Number of days to look back
+ */
+export async function calculateUserProfile(
+  userId: string,
+  daysBack: number = AFFINITY_LOOKBACK_DAYS
+): Promise<{ artistCount: number; temporalCount: number }> {
+  console.log(`👤 [Profile] Calculating full profile for user ${userId}`);
+
+  const artistCount = await calculateArtistAffinities(userId, daysBack);
+  const temporalCount = await calculateTemporalPreferences(userId, daysBack);
+
+  console.log(`👤 [Profile] Complete: ${artistCount} artists, ${temporalCount} temporal prefs`);
+
+  return { artistCount, temporalCount };
+}
+
+/**
+ * Clear all profile data for a user
+ * Useful for testing or when user wants to reset
+ *
+ * @param userId - The user's ID
+ */
+export async function clearUserProfile(userId: string): Promise<void> {
+  await db
+    .delete(artistAffinities)
+    .where(eq(artistAffinities.userId, userId));
+
+  await db
+    .delete(temporalPreferences)
+    .where(eq(temporalPreferences.userId, userId));
+
+  console.log(`👤 [Profile] Cleared profile data for user ${userId}`);
+}

--- a/src/lib/services/audio-metadata-cache.ts
+++ b/src/lib/services/audio-metadata-cache.ts
@@ -1,0 +1,563 @@
+/**
+ * Audio Metadata Cache Service
+ *
+ * Provides persistent storage for BPM, key, and energy metadata using IndexedDB.
+ * This avoids repeated API calls and stores estimated/analyzed values.
+ *
+ * Features:
+ * - IndexedDB persistence across browser sessions
+ * - In-memory cache for fast access
+ * - TTL-based expiration (30 days)
+ * - Batch operations for efficiency
+ */
+
+// Cached audio metadata for DJ features
+export interface AudioMetadataCache {
+  id: string;             // Song ID (Navidrome ID)
+  bpm?: number;           // Beats per minute
+  key?: string;           // Musical key (e.g., "Am", "C", "F#m")
+  energy?: number;        // Energy level 0-1
+  source: 'navidrome' | 'estimated' | 'user'; // Where the data came from
+  confidence: number;     // Confidence level 0-1 (1 = from tags, lower = estimated)
+  fetchedAt: number;      // Timestamp when metadata was fetched/estimated
+  updatedAt: number;      // Timestamp when metadata was last updated
+}
+
+// Database configuration
+const DB_NAME = 'aidj-audio-metadata';
+const DB_VERSION = 1;
+const STORE_NAME = 'metadata';
+const CACHE_TTL_MS = 30 * 24 * 60 * 60 * 1000; // 30 days
+
+// In-memory cache for fast access
+const memoryCache = new Map<string, AudioMetadataCache>();
+
+// Database instance
+let dbInstance: IDBDatabase | null = null;
+let dbInitPromise: Promise<IDBDatabase> | null = null;
+
+/**
+ * Initialize the IndexedDB database
+ */
+async function getDB(): Promise<IDBDatabase> {
+  if (dbInstance) return dbInstance;
+
+  if (dbInitPromise) return dbInitPromise;
+
+  // Check if we're in a browser environment
+  if (typeof window === 'undefined' || typeof indexedDB === 'undefined') {
+    throw new Error('IndexedDB not available');
+  }
+
+  dbInitPromise = new Promise((resolve, reject) => {
+    const request = indexedDB.open(DB_NAME, DB_VERSION);
+
+    request.onerror = () => {
+      console.error('[AudioMetadataCache] Failed to open database:', request.error);
+      reject(request.error);
+    };
+
+    request.onsuccess = () => {
+      dbInstance = request.result;
+      console.log('[AudioMetadataCache] Database opened successfully');
+      resolve(dbInstance);
+    };
+
+    request.onupgradeneeded = (event) => {
+      const db = (event.target as IDBOpenDBRequest).result;
+      console.log('[AudioMetadataCache] Upgrading database schema...');
+
+      // Create the metadata store with songId as key
+      if (!db.objectStoreNames.contains(STORE_NAME)) {
+        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+        // Index for finding songs by BPM range (for DJ matching)
+        store.createIndex('bpm', 'bpm', { unique: false });
+        // Index for finding songs by key (for harmonic mixing)
+        store.createIndex('key', 'key', { unique: false });
+        // Index for finding songs by energy (for energy flow)
+        store.createIndex('energy', 'energy', { unique: false });
+        // Index for cache cleanup
+        store.createIndex('fetchedAt', 'fetchedAt', { unique: false });
+        console.log('[AudioMetadataCache] Created metadata store');
+      }
+    };
+  });
+
+  return dbInitPromise;
+}
+
+/**
+ * Check if cached metadata is still valid (not expired)
+ */
+function isValidCache(metadata: AudioMetadataCache): boolean {
+  const now = Date.now();
+  return now - metadata.fetchedAt < CACHE_TTL_MS;
+}
+
+/**
+ * Get metadata for a song from cache
+ * Returns null if not cached or expired
+ *
+ * @param songId - The Navidrome song ID
+ * @returns Cached metadata or null
+ */
+export async function getMetadata(songId: string): Promise<AudioMetadataCache | null> {
+  // Check memory cache first
+  const memoryCached = memoryCache.get(songId);
+  if (memoryCached && isValidCache(memoryCached)) {
+    return memoryCached;
+  }
+
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      const request = store.get(songId);
+
+      request.onsuccess = () => {
+        const metadata = request.result as AudioMetadataCache | undefined;
+
+        if (metadata && isValidCache(metadata)) {
+          // Update memory cache
+          memoryCache.set(songId, metadata);
+          resolve(metadata);
+        } else {
+          // Clean up expired entry if needed
+          if (metadata) {
+            deleteMetadata(songId).catch(() => {});
+          }
+          resolve(null);
+        }
+      };
+
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to get metadata:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to get metadata from cache:', error);
+    return null;
+  }
+}
+
+/**
+ * Get metadata for multiple songs from cache
+ * More efficient than calling getMetadata for each song
+ *
+ * @param songIds - Array of Navidrome song IDs
+ * @returns Map of songId to metadata (only includes cached songs)
+ */
+export async function getMetadataBatch(songIds: string[]): Promise<Map<string, AudioMetadataCache>> {
+  const results = new Map<string, AudioMetadataCache>();
+  const uncachedIds: string[] = [];
+
+  // Check memory cache first
+  for (const songId of songIds) {
+    const memoryCached = memoryCache.get(songId);
+    if (memoryCached && isValidCache(memoryCached)) {
+      results.set(songId, memoryCached);
+    } else {
+      uncachedIds.push(songId);
+    }
+  }
+
+  // Fetch remaining from IndexedDB
+  if (uncachedIds.length > 0) {
+    try {
+      const db = await getDB();
+      const transaction = db.transaction(STORE_NAME, 'readonly');
+      const store = transaction.objectStore(STORE_NAME);
+
+      const promises = uncachedIds.map(songId => {
+        return new Promise<void>((resolve) => {
+          const request = store.get(songId);
+          request.onsuccess = () => {
+            const metadata = request.result as AudioMetadataCache | undefined;
+            if (metadata && isValidCache(metadata)) {
+              results.set(songId, metadata);
+              memoryCache.set(songId, metadata);
+            }
+            resolve();
+          };
+          request.onerror = () => resolve();
+        });
+      });
+
+      await Promise.all(promises);
+    } catch (error) {
+      console.warn('[AudioMetadataCache] Failed to get batch metadata from cache:', error);
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Save metadata for a song to cache
+ *
+ * @param metadata - The metadata to save
+ */
+export async function setMetadata(metadata: AudioMetadataCache): Promise<void> {
+  const dataToSave = {
+    ...metadata,
+    updatedAt: Date.now(),
+  };
+
+  // Update memory cache
+  memoryCache.set(metadata.id, dataToSave);
+
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      const request = store.put(dataToSave);
+      request.onsuccess = () => resolve();
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to save metadata:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to save metadata to cache:', error);
+  }
+}
+
+/**
+ * Save metadata for multiple songs to cache
+ * More efficient than calling setMetadata for each song
+ *
+ * @param metadataList - Array of metadata to save
+ */
+export async function setMetadataBatch(metadataList: AudioMetadataCache[]): Promise<void> {
+  const now = Date.now();
+
+  // Update memory cache
+  for (const metadata of metadataList) {
+    const dataToSave = { ...metadata, updatedAt: now };
+    memoryCache.set(metadata.id, dataToSave);
+  }
+
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    const promises = metadataList.map(metadata => {
+      return new Promise<void>((resolve, reject) => {
+        const request = store.put({ ...metadata, updatedAt: now });
+        request.onsuccess = () => resolve();
+        request.onerror = () => reject(request.error);
+      });
+    });
+
+    await Promise.all(promises);
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to save batch metadata to cache:', error);
+  }
+}
+
+/**
+ * Update specific fields of cached metadata
+ * Useful for partial updates (e.g., only updating energy)
+ *
+ * @param songId - The song ID
+ * @param updates - Partial metadata to merge
+ */
+export async function updateMetadata(
+  songId: string,
+  updates: Partial<Omit<AudioMetadataCache, 'id'>>
+): Promise<void> {
+  const existing = await getMetadata(songId);
+
+  if (existing) {
+    await setMetadata({
+      ...existing,
+      ...updates,
+      id: songId,
+      updatedAt: Date.now(),
+    });
+  } else {
+    // Create new entry with defaults
+    await setMetadata({
+      id: songId,
+      source: 'estimated',
+      confidence: 0.5,
+      fetchedAt: Date.now(),
+      updatedAt: Date.now(),
+      ...updates,
+    });
+  }
+}
+
+/**
+ * Delete metadata for a song from cache
+ *
+ * @param songId - The song ID to delete
+ */
+export async function deleteMetadata(songId: string): Promise<void> {
+  memoryCache.delete(songId);
+
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      const request = store.delete(songId);
+      request.onsuccess = () => resolve();
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to delete metadata:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to delete metadata from cache:', error);
+  }
+}
+
+/**
+ * Find songs by BPM range
+ * Useful for DJ matching - find songs with similar BPM
+ *
+ * @param minBpm - Minimum BPM (inclusive)
+ * @param maxBpm - Maximum BPM (inclusive)
+ * @returns Array of song IDs with BPM in range
+ */
+export async function findSongsByBpmRange(minBpm: number, maxBpm: number): Promise<string[]> {
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const index = store.index('bpm');
+
+    return new Promise((resolve, reject) => {
+      const songIds: string[] = [];
+      const range = IDBKeyRange.bound(minBpm, maxBpm);
+      const request = index.openCursor(range);
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor) {
+          const metadata = cursor.value as AudioMetadataCache;
+          if (isValidCache(metadata)) {
+            songIds.push(metadata.id);
+          }
+          cursor.continue();
+        } else {
+          resolve(songIds);
+        }
+      };
+
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to find songs by BPM:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to find songs by BPM range:', error);
+    return [];
+  }
+}
+
+/**
+ * Find songs by musical key
+ * Useful for harmonic mixing
+ *
+ * @param key - The musical key to search for
+ * @returns Array of song IDs with the specified key
+ */
+export async function findSongsByKey(key: string): Promise<string[]> {
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+    const index = store.index('key');
+
+    return new Promise((resolve, reject) => {
+      const songIds: string[] = [];
+      const request = index.openCursor(IDBKeyRange.only(key));
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor) {
+          const metadata = cursor.value as AudioMetadataCache;
+          if (isValidCache(metadata)) {
+            songIds.push(metadata.id);
+          }
+          cursor.continue();
+        } else {
+          resolve(songIds);
+        }
+      };
+
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to find songs by key:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to find songs by key:', error);
+    return [];
+  }
+}
+
+/**
+ * Get cache statistics
+ * Useful for debugging and monitoring
+ */
+export async function getCacheStats(): Promise<{
+  totalEntries: number;
+  validEntries: number;
+  expiredEntries: number;
+  entriesWithBpm: number;
+  entriesWithKey: number;
+  entriesWithEnergy: number;
+  memoryCacheSize: number;
+}> {
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readonly');
+    const store = transaction.objectStore(STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      let totalEntries = 0;
+      let validEntries = 0;
+      let expiredEntries = 0;
+      let entriesWithBpm = 0;
+      let entriesWithKey = 0;
+      let entriesWithEnergy = 0;
+
+      const request = store.openCursor();
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor) {
+          totalEntries++;
+          const metadata = cursor.value as AudioMetadataCache;
+          if (isValidCache(metadata)) {
+            validEntries++;
+            if (metadata.bpm !== undefined) entriesWithBpm++;
+            if (metadata.key !== undefined) entriesWithKey++;
+            if (metadata.energy !== undefined) entriesWithEnergy++;
+          } else {
+            expiredEntries++;
+          }
+          cursor.continue();
+        } else {
+          resolve({
+            totalEntries,
+            validEntries,
+            expiredEntries,
+            entriesWithBpm,
+            entriesWithKey,
+            entriesWithEnergy,
+            memoryCacheSize: memoryCache.size,
+          });
+        }
+      };
+
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to get cache stats:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to get cache stats:', error);
+    return {
+      totalEntries: 0,
+      validEntries: 0,
+      expiredEntries: 0,
+      entriesWithBpm: 0,
+      entriesWithKey: 0,
+      entriesWithEnergy: 0,
+      memoryCacheSize: memoryCache.size,
+    };
+  }
+}
+
+/**
+ * Clean up expired entries from the cache
+ * Should be called periodically (e.g., on app start)
+ */
+export async function cleanupExpiredEntries(): Promise<number> {
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+    const index = store.index('fetchedAt');
+
+    return new Promise((resolve, reject) => {
+      let deletedCount = 0;
+      const expiryThreshold = Date.now() - CACHE_TTL_MS;
+      const range = IDBKeyRange.upperBound(expiryThreshold);
+      const request = index.openCursor(range);
+
+      request.onsuccess = (event) => {
+        const cursor = (event.target as IDBRequest<IDBCursorWithValue>).result;
+        if (cursor) {
+          cursor.delete();
+          memoryCache.delete(cursor.value.id);
+          deletedCount++;
+          cursor.continue();
+        } else {
+          console.log(`🧹 [AudioMetadataCache] Cleanup: removed ${deletedCount} expired entries`);
+          resolve(deletedCount);
+        }
+      };
+
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to cleanup expired entries:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to cleanup expired cache entries:', error);
+    return 0;
+  }
+}
+
+/**
+ * Clear all cached metadata
+ * Use with caution - will require re-fetching all metadata
+ */
+export async function clearAllMetadata(): Promise<void> {
+  memoryCache.clear();
+
+  try {
+    const db = await getDB();
+    const transaction = db.transaction(STORE_NAME, 'readwrite');
+    const store = transaction.objectStore(STORE_NAME);
+
+    return new Promise((resolve, reject) => {
+      const request = store.clear();
+      request.onsuccess = () => {
+        console.log('🧹 [AudioMetadataCache] Cache cleared');
+        resolve();
+      };
+      request.onerror = () => {
+        console.warn('[AudioMetadataCache] Failed to clear cache:', request.error);
+        reject(request.error);
+      };
+    });
+  } catch (error) {
+    console.warn('[AudioMetadataCache] Failed to clear cache:', error);
+  }
+}
+
+/**
+ * Close the database connection
+ * Should be called when the app is shutting down
+ */
+export function closeDB(): void {
+  if (dbInstance) {
+    dbInstance.close();
+    dbInstance = null;
+    dbInitPromise = null;
+    console.log('[AudioMetadataCache] Database connection closed');
+  }
+}

--- a/src/lib/services/blended-recommendation-scorer.ts
+++ b/src/lib/services/blended-recommendation-scorer.ts
@@ -1,0 +1,906 @@
+/**
+ * Blended Recommendation Scorer Service
+ *
+ * Multi-signal scoring for AI DJ recommendations.
+ * Gathers candidates from ALL sources and scores each using ALL signals.
+ *
+ * This replaces the sequential fallback chain that caused single-artist loops.
+ *
+ * Scoring Weights:
+ * - lastFm: 25% - Last.fm similarity (still valuable)
+ * - compound: 20% - Listening history correlation
+ * - dj: 20% - BPM/Energy/Key for smooth transitions
+ * - feedback: 15% - User explicit preferences (thumbs)
+ * - skip: 10% - Avoid frequently skipped
+ * - temporal: 5% - Time-of-day bonus
+ * - diversity: 5% - Artist variety bonus
+ */
+
+import { db } from '../db';
+import { recommendationFeedback, trackSimilarities, compoundScores, listeningHistory } from '../db/schema';
+import { eq, and, gte, desc, sql, inArray, or } from 'drizzle-orm';
+import type { Song } from '@/lib/types/song';
+// EnrichedTrack no longer needed - using raw Last.fm API with sequential lookups
+import type { LastFmClient } from './lastfm';
+import { getLastFmClient } from './lastfm';
+import { getConfigAsync } from '@/lib/config/config';
+import { search, getRandomSongs } from './navidrome';
+import { getCompoundScoreBoosts } from './compound-scoring';
+import { calculateSkipScores } from './skip-scoring';
+import { calculateDJScore, enrichSongsWithDJMetadata, type SongWithDJMetadata } from './dj-match-scorer';
+import { getTimeSlot, getCurrentTimeContext, type TimeContext } from './time-based-discovery';
+import { getCurrentSeasonalPattern, type SeasonalPattern } from './seasonal-patterns';
+import { normalizeGenre, getGenreSimilarity } from './genre-hierarchy';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+export const SCORE_WEIGHTS = {
+  lastFm: 0.25,        // Last.fm similarity still valuable
+  compound: 0.20,      // Listening history correlation
+  dj: 0.20,            // BPM/Energy/Key for smooth transitions
+  feedback: 0.15,      // User explicit preferences
+  skip: 0.10,          // Avoid frequently skipped
+  temporal: 0.05,      // Time-of-day bonus
+  diversity: 0.05,     // Artist variety bonus
+};
+
+// Delay between searches to avoid rate limiting (ms)
+const SEARCH_THROTTLE_MS = 100;
+
+// Helper to throttle searches
+async function throttledSearch(query: string, start: number, limit: number): Promise<Song[]> {
+  await new Promise(resolve => setTimeout(resolve, SEARCH_THROTTLE_MS));
+  return search(query, start, limit);
+}
+
+// Maximum candidates to gather from each source
+const CANDIDATE_LIMITS = {
+  lastfm: 20,
+  sameArtist: 2,  // Reduced to prevent artist domination
+  similarArtists: 10,
+  genre: 10,
+  compound: 10,
+  liked: 5,
+  temporal: 5,
+};
+
+// Diversity rules
+const MAX_SONGS_PER_ARTIST = 1;  // Max songs from same artist in final results
+const MIN_UNIQUE_ARTISTS = 2;   // Try to have at least this many different artists
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type CandidateSourceType = 'lastfm' | 'same_artist' | 'similar_artist' | 'genre' | 'compound' | 'liked' | 'temporal';
+
+export interface CandidateSource {
+  source: CandidateSourceType;
+  weight: number;
+  /** Match score from source (0-1), e.g., Last.fm match score */
+  matchScore?: number;
+}
+
+export interface ScoredCandidate {
+  song: Song;
+  sources: CandidateSource[];
+  scores: {
+    lastFm: number;
+    compound: number;
+    dj: number;
+    feedback: number;
+    skip: number;
+    temporal: number;
+    diversity: number;
+  };
+  finalScore: number;
+}
+
+export interface GatherOptions {
+  excludeSongIds?: string[];
+  excludeArtists?: string[];
+  queueContext?: {
+    genres?: string[];
+    artists?: string[];
+    artistBatchCounts?: Record<string, number>;
+  };
+  djMatching?: {
+    enabled: boolean;
+    currentBpm?: number;
+    currentKey?: string;
+    currentEnergy?: number;
+  };
+}
+
+export interface ScoringContext {
+  seedSong: Song & { bpm?: number; key?: string; energy?: number };
+  userId?: string;
+  timeContext: TimeContext;
+  seasonalPattern?: SeasonalPattern | null;
+  /** Map of songId -> feedback score (-1 to 1) */
+  feedbackScores: Map<string, number>;
+  /** Map of songId -> skip penalty (0-1) */
+  skipPenalties: Map<string, number>;
+  /** Map of songId -> compound boost (0-1) */
+  compoundBoosts: Map<string, number>;
+  /** Artists already in queue for diversity calculation */
+  queuedArtists: Set<string>;
+}
+
+export interface BlendedRecommendationOptions extends GatherOptions {
+  userId?: string;
+  limit?: number;
+  /** Custom scoring weights */
+  weights?: Partial<typeof SCORE_WEIGHTS>;
+}
+
+// ============================================================================
+// Candidate Gathering
+// ============================================================================
+
+/**
+ * Gather candidates from ALL sources in parallel
+ * Returns a map of songId -> sources that recommended it
+ */
+export async function gatherCandidates(
+  seedSong: { artist: string; title: string; genre?: string },
+  options: GatherOptions
+): Promise<Map<string, { song: Song; sources: CandidateSource[] }>> {
+  const candidates = new Map<string, { song: Song; sources: CandidateSource[] }>();
+  const { excludeSongIds = [], excludeArtists = [], queueContext } = options;
+
+  const excludeSet = new Set(excludeSongIds.map(id => id.toLowerCase()));
+  const excludeArtistsLower = new Set(excludeArtists.map(a => a.toLowerCase()));
+
+  // Helper to add candidate with source tracking
+  const addCandidate = (song: Song, source: CandidateSource) => {
+    if (!song.id || excludeSet.has(song.id.toLowerCase())) return;
+    if (song.artist && excludeArtistsLower.has(song.artist.toLowerCase())) return;
+
+    const existing = candidates.get(song.id);
+    if (existing) {
+      existing.sources.push(source);
+    } else {
+      candidates.set(song.id, { song, sources: [source] });
+    }
+  };
+
+  // Get Last.fm client
+  const config = await getConfigAsync();
+  const lastFm = config.lastfmApiKey ? getLastFmClient(config.lastfmApiKey) : null;
+
+  // Run sources sequentially to avoid rate limiting
+  // Priority order: Last.fm (best quality), Same artist, Similar artists, Genre
+
+  // 1. Last.fm similar tracks (highest quality - already has library matching)
+  if (lastFm) {
+    await gatherLastFmSimilarTracks(lastFm, seedSong, addCandidate).catch(() => {});
+  }
+
+  // 2. Same artist songs (limited, single search)
+  await gatherSameArtistSongs(seedSong, addCandidate, excludeSet).catch(() => {});
+
+  // 3. Similar artists songs (sequential searches)
+  if (lastFm) {
+    await gatherSimilarArtistsSongs(lastFm, seedSong, addCandidate, excludeArtistsLower).catch(() => {});
+  }
+
+  // 4. Genre-based songs (single call to getRandomSongs)
+  const targetGenres = buildTargetGenres(seedSong.genre, queueContext?.genres);
+  if (targetGenres.length > 0) {
+    await gatherGenreBasedSongs(targetGenres, addCandidate, excludeArtistsLower).catch(() => {});
+  }
+
+  console.log(`🎯 [BlendedScorer] Gathered ${candidates.size} unique candidates from multiple sources`);
+
+  return candidates;
+}
+
+/**
+ * Gather similar tracks from Last.fm
+ * Uses raw API call + sequential library lookups to avoid rate limiting
+ */
+async function gatherLastFmSimilarTracks(
+  lastFm: LastFmClient,
+  seedSong: { artist: string; title: string },
+  addCandidate: (song: Song, source: CandidateSource) => void
+): Promise<void> {
+  try {
+    // Get similar tracks without library enrichment to avoid parallel searches
+    const similar = await lastFm.getSimilarTracksRaw(
+      seedSong.artist,
+      seedSong.title,
+      CANDIDATE_LIMITS.lastfm
+    );
+
+    // Search for library matches sequentially (max 5 searches to avoid rate limiting)
+    let count = 0;
+    for (const track of similar.slice(0, 5)) {
+      if (count >= CANDIDATE_LIMITS.lastfm) break;
+
+      try {
+        const query = `${track.artist} ${track.name}`;
+        const results = await throttledSearch(query, 0, 3);
+
+        // Find a good match
+        const match = results.find(song => {
+          const artistLower = (song.artist || '').toLowerCase();
+          const trackArtistLower = track.artist.toLowerCase();
+          const titleLower = (song.title || song.name || '').toLowerCase();
+          const trackNameLower = track.name.toLowerCase();
+
+          const artistMatch = artistLower.includes(trackArtistLower) || trackArtistLower.includes(artistLower);
+          const titleMatch = titleLower.includes(trackNameLower) || trackNameLower.includes(titleLower);
+
+          return artistMatch && titleMatch;
+        });
+
+        if (match) {
+          const songWithUrl: Song = {
+            ...match,
+            url: match.url || `/api/navidrome/stream/${match.id}`,
+          };
+          addCandidate(songWithUrl, {
+            source: 'lastfm',
+            weight: 1.0,
+            matchScore: track.match || 0.5,
+          });
+          count++;
+        }
+      } catch {
+        // Continue with next track
+      }
+    }
+    console.log(`🎵 [BlendedScorer] Last.fm: ${count} library matches from ${similar.length} similar tracks`);
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Last.fm similar tracks failed:', error);
+  }
+}
+
+/**
+ * Gather songs from the same artist (limited to prevent domination)
+ */
+async function gatherSameArtistSongs(
+  seedSong: { artist: string; title: string },
+  addCandidate: (song: Song, source: CandidateSource) => void,
+  excludeSet: Set<string>
+): Promise<void> {
+  try {
+    const artistSongs = await throttledSearch(seedSong.artist, 0, 20);
+    const artistLower = seedSong.artist.toLowerCase();
+    const titleLower = seedSong.title.toLowerCase();
+
+    let count = 0;
+    for (const song of artistSongs) {
+      if (count >= CANDIDATE_LIMITS.sameArtist) break;
+
+      const songArtistLower = (song.artist || '').toLowerCase();
+      const songTitleLower = (song.title || song.name || '').toLowerCase();
+
+      // Must be same artist but different song
+      if (
+        songArtistLower === artistLower &&
+        songTitleLower !== titleLower &&
+        !excludeSet.has(song.id)
+      ) {
+        // search() already returns Song[], just add stream URL if missing
+        const songWithUrl: Song = {
+          ...song,
+          url: song.url || `/api/navidrome/stream/${song.id}`,
+        };
+        addCandidate(songWithUrl, {
+          source: 'same_artist',
+          weight: 0.8,
+          matchScore: 0.6,
+        });
+        count++;
+      }
+    }
+    console.log(`🎤 [BlendedScorer] Same artist: ${count} songs`);
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Same artist search failed:', error);
+  }
+}
+
+/**
+ * Gather songs from similar artists via Last.fm
+ * Note: This function is conservative with searches to avoid rate limiting
+ */
+async function gatherSimilarArtistsSongs(
+  lastFm: LastFmClient,
+  seedSong: { artist: string },
+  addCandidate: (song: Song, source: CandidateSource) => void,
+  excludeArtists: Set<string>
+): Promise<void> {
+  try {
+    // Get similar artists WITHOUT searching Navidrome (just from Last.fm API)
+    // This avoids the parallel search problem
+    const similarArtists = await lastFm.getSimilarArtistsRaw(seedSong.artist, 10);
+
+    // Filter to artists not excluded
+    const candidateArtists = similarArtists
+      .filter(a => !excludeArtists.has(a.name.toLowerCase()))
+      .slice(0, 3); // Only search top 3 to avoid rate limits
+
+    let totalCount = 0;
+    for (const artist of candidateArtists) {
+      if (totalCount >= CANDIDATE_LIMITS.similarArtists) break;
+
+      try {
+        // Search sequentially, not in parallel
+        const artistSongs = await throttledSearch(artist.name, 0, 3);
+        for (const song of artistSongs) {
+          if (totalCount >= CANDIDATE_LIMITS.similarArtists) break;
+
+          const songArtistLower = (song.artist || '').toLowerCase();
+          const artistNameLower = artist.name.toLowerCase();
+          // More strict matching - exact match or song artist starts with artist name
+          if (songArtistLower === artistNameLower || songArtistLower.startsWith(artistNameLower)) {
+            const songWithUrl: Song = {
+              ...song,
+              url: song.url || `/api/navidrome/stream/${song.id}`,
+            };
+            addCandidate(songWithUrl, {
+              source: 'similar_artist',
+              weight: 0.7,
+              matchScore: artist.match || 0.5,
+            });
+            totalCount++;
+          }
+        }
+      } catch {
+        // Continue with next artist
+      }
+    }
+    console.log(`🎭 [BlendedScorer] Similar artists: ${totalCount} songs from ${candidateArtists.length} artists`);
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Similar artists search failed:', error);
+  }
+}
+
+/**
+ * Gather genre-based songs using genre hierarchy
+ */
+async function gatherGenreBasedSongs(
+  targetGenres: string[],
+  addCandidate: (song: Song, source: CandidateSource) => void,
+  excludeArtists: Set<string>
+): Promise<void> {
+  try {
+    // Get random songs and filter by genre similarity
+    const poolSize = Math.max(CANDIDATE_LIMITS.genre * 10, 100);
+    // Add throttle before API call
+    await new Promise(resolve => setTimeout(resolve, SEARCH_THROTTLE_MS));
+    const songs = await getRandomSongs(poolSize);
+
+    // Score each song by genre similarity
+    // getRandomSongs returns Song[], not SubsonicSong
+    const scoredSongs: Array<{ song: Song; score: number }> = [];
+    for (const song of songs) {
+      if (song.artist && excludeArtists.has(song.artist.toLowerCase())) continue;
+
+      const songGenre = normalizeGenre(song.genre || '');
+      if (!songGenre) continue;
+
+      let bestScore = 0;
+      for (const targetGenre of targetGenres) {
+        const similarity = getGenreSimilarity(songGenre, targetGenre);
+        if (similarity > bestScore) bestScore = similarity;
+      }
+
+      if (bestScore >= 0.3) {
+        scoredSongs.push({ song, score: bestScore });
+      }
+    }
+
+    // Sort by score and take top candidates
+    scoredSongs.sort((a, b) => b.score - a.score);
+
+    let count = 0;
+    for (const { song, score } of scoredSongs.slice(0, CANDIDATE_LIMITS.genre)) {
+      // getRandomSongs() already returns Song[], just ensure URL is set
+      const songWithUrl: Song = {
+        ...song,
+        url: song.url || `/api/navidrome/stream/${song.id}`,
+      };
+      addCandidate(songWithUrl, {
+        source: 'genre',
+        weight: 0.6,
+        matchScore: score,
+      });
+      count++;
+    }
+    console.log(`🎸 [BlendedScorer] Genre-based: ${count} songs matching genres: ${targetGenres.slice(0, 3).join(', ')}`);
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Genre-based search failed:', error);
+  }
+}
+
+// ============================================================================
+// Scoring
+// ============================================================================
+
+/**
+ * Build scoring context with all pre-fetched data
+ */
+async function buildScoringContext(
+  seedSong: Song & { bpm?: number; key?: string; energy?: number },
+  songIds: string[],
+  userId?: string,
+  queuedArtists?: string[]
+): Promise<ScoringContext> {
+  const timeContext = getCurrentTimeContext();
+
+  // Initialize maps
+  let feedbackScores = new Map<string, number>();
+  let skipPenalties = new Map<string, number>();
+  let compoundBoosts = new Map<string, number>();
+  let seasonalPattern: SeasonalPattern | null = null;
+
+  if (userId && songIds.length > 0) {
+    // Fetch all scoring data in parallel
+    const [feedbackData, skipData, compoundData, seasonal] = await Promise.allSettled([
+      getFeedbackScores(userId, songIds),
+      getSkipPenalties(userId, songIds),
+      getCompoundScoreBoosts(userId, songIds),
+      getCurrentSeasonalPattern(userId),
+    ]);
+
+    if (feedbackData.status === 'fulfilled') feedbackScores = feedbackData.value;
+    if (skipData.status === 'fulfilled') skipPenalties = skipData.value;
+    if (compoundData.status === 'fulfilled') compoundBoosts = compoundData.value;
+    if (seasonal.status === 'fulfilled') seasonalPattern = seasonal.value;
+  }
+
+  return {
+    seedSong,
+    userId,
+    timeContext,
+    seasonalPattern,
+    feedbackScores,
+    skipPenalties,
+    compoundBoosts,
+    queuedArtists: new Set((queuedArtists || []).map(a => a.toLowerCase())),
+  };
+}
+
+/**
+ * Get feedback scores for songs (thumbs up = 1, thumbs down = -1, no feedback = 0)
+ */
+async function getFeedbackScores(userId: string, songIds: string[]): Promise<Map<string, number>> {
+  const scores = new Map<string, number>();
+
+  try {
+    const feedback = await db
+      .select({
+        songId: recommendationFeedback.songId,
+        feedbackType: recommendationFeedback.feedbackType,
+      })
+      .from(recommendationFeedback)
+      .where(
+        and(
+          eq(recommendationFeedback.userId, userId),
+          inArray(recommendationFeedback.songId, songIds)
+        )
+      );
+
+    // Aggregate feedback per song (most recent wins, or average)
+    const feedbackMap = new Map<string, number[]>();
+    for (const row of feedback) {
+      if (!row.songId) continue;
+      const value = row.feedbackType === 'thumbs_up' ? 1 : -1;
+      const existing = feedbackMap.get(row.songId) || [];
+      existing.push(value);
+      feedbackMap.set(row.songId, existing);
+    }
+
+    // Calculate average feedback per song
+    for (const [songId, values] of feedbackMap) {
+      const avg = values.reduce((a, b) => a + b, 0) / values.length;
+      scores.set(songId, avg);
+    }
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Failed to fetch feedback scores:', error);
+  }
+
+  return scores;
+}
+
+/**
+ * Get skip penalties for songs (0-1, higher = worse)
+ */
+async function getSkipPenalties(userId: string, songIds: string[]): Promise<Map<string, number>> {
+  const penalties = new Map<string, number>();
+
+  try {
+    // Create minimal Song objects for skip scoring
+    const songs: Song[] = songIds.map(id => ({
+      id,
+      name: '',
+      title: '',
+      artist: '',
+      albumId: '',
+      duration: 0,
+      track: 0,
+      url: '',
+    }));
+
+    const skipScores = await calculateSkipScores(songs, { userId });
+
+    for (const [songId, score] of skipScores) {
+      penalties.set(songId, score.skipPenalty);
+    }
+  } catch (error) {
+    console.warn('⚠️ [BlendedScorer] Failed to fetch skip penalties:', error);
+  }
+
+  return penalties;
+}
+
+/**
+ * Score a single candidate using all signals
+ */
+function scoreCandidate(
+  candidate: { song: Song; sources: CandidateSource[] },
+  context: ScoringContext,
+  enrichedSong?: SongWithDJMetadata,
+  weights: typeof SCORE_WEIGHTS = SCORE_WEIGHTS
+): ScoredCandidate {
+  const { song, sources } = candidate;
+  const {
+    seedSong,
+    timeContext,
+    seasonalPattern,
+    feedbackScores,
+    skipPenalties,
+    compoundBoosts,
+    queuedArtists,
+  } = context;
+
+  // 1. Last.fm score - from sources
+  const lastFmSource = sources.find(s => s.source === 'lastfm');
+  const lastFmScore = lastFmSource?.matchScore ?? 0.5;
+
+  // 2. Compound score - from pre-fetched data
+  const compoundScore = compoundBoosts.get(song.id) ?? 0;
+
+  // 3. DJ score - BPM/Energy/Key compatibility
+  let djScore = 0.5; // Default neutral
+  if (enrichedSong && (seedSong.bpm || seedSong.energy || seedSong.key)) {
+    const djResult = calculateDJScore(
+      seedSong as SongWithDJMetadata,
+      enrichedSong
+    );
+    djScore = djResult.totalScore;
+  }
+
+  // 4. Feedback score (-1 to 1 -> 0 to 1)
+  const rawFeedback = feedbackScores.get(song.id) ?? 0;
+  const feedbackScore = (rawFeedback + 1) / 2;
+
+  // 5. Skip penalty (0-1, inverted for score)
+  const skipPenalty = skipPenalties.get(song.id) ?? 0;
+  const skipScore = 1 - skipPenalty;
+
+  // 6. Temporal score - boost songs from current time slot
+  let temporalScore = 0.5; // Default neutral
+  if (seasonalPattern) {
+    // Check if this song's genre matches seasonal preferences
+    const songGenre = normalizeGenre(song.genre || '');
+    if (songGenre && seasonalPattern.preferredGenres?.length > 0) {
+      for (const prefGenre of seasonalPattern.preferredGenres) {
+        const similarity = getGenreSimilarity(songGenre, normalizeGenre(prefGenre));
+        if (similarity > 0.5) {
+          temporalScore = Math.min(1, 0.5 + similarity * 0.5);
+          break;
+        }
+      }
+    }
+    // Also check preferred artists
+    if (song.artist && seasonalPattern.preferredArtists?.includes(song.artist)) {
+      temporalScore = Math.max(temporalScore, 0.8);
+    }
+  }
+
+  // 7. Diversity score - penalize artists already in queue
+  const artistLower = song.artist?.toLowerCase() || '';
+  const diversityScore = queuedArtists.has(artistLower) ? 0.3 : 1.0;
+
+  // Calculate final weighted score
+  const finalScore =
+    (lastFmScore * weights.lastFm) +
+    (compoundScore * weights.compound) +
+    (djScore * weights.dj) +
+    (feedbackScore * weights.feedback) +
+    (skipScore * weights.skip) +
+    (temporalScore * weights.temporal) +
+    (diversityScore * weights.diversity);
+
+  return {
+    song,
+    sources,
+    scores: {
+      lastFm: lastFmScore,
+      compound: compoundScore,
+      dj: djScore,
+      feedback: feedbackScore,
+      skip: skipScore,
+      temporal: temporalScore,
+      diversity: diversityScore,
+    },
+    finalScore,
+  };
+}
+
+// ============================================================================
+// Main Entry Point
+// ============================================================================
+
+/**
+ * Get blended recommendations using multi-signal scoring
+ *
+ * This is the main entry point that:
+ * 1. Gathers candidates from ALL sources (parallel)
+ * 2. Scores each candidate using ALL signals
+ * 3. Applies diversity rules
+ * 4. Returns top recommendations
+ */
+export async function getBlendedRecommendations(
+  seedSong: { artist: string; title: string; genre?: string; bpm?: number; key?: string; energy?: number },
+  options: BlendedRecommendationOptions = {}
+): Promise<{ songs: Song[]; metadata: BlendedMetadata }> {
+  const {
+    userId,
+    limit = 10,
+    excludeSongIds = [],
+    excludeArtists = [],
+    queueContext,
+    djMatching,
+    weights = SCORE_WEIGHTS,
+  } = options;
+
+  console.log(`🎯 [BlendedScorer] Starting blended recommendations for "${seedSong.artist} - ${seedSong.title}"`);
+
+  // 1. Gather candidates from all sources
+  const candidates = await gatherCandidates(seedSong, {
+    excludeSongIds,
+    excludeArtists,
+    queueContext,
+    djMatching,
+  });
+
+  if (candidates.size === 0) {
+    console.log('⚠️ [BlendedScorer] No candidates found from any source');
+    return { songs: [], metadata: { totalCandidates: 0, sourceCounts: {} } };
+  }
+
+  // 2. Build scoring context (pre-fetch all scoring data)
+  const songIds = Array.from(candidates.keys());
+  const songs = Array.from(candidates.values()).map(c => c.song);
+
+  // Create seed song object with all metadata
+  const seedSongFull: Song & { bpm?: number; key?: string; energy?: number } = {
+    id: 'seed',
+    name: seedSong.title,
+    title: seedSong.title,
+    artist: seedSong.artist,
+    genre: seedSong.genre,
+    albumId: '',
+    duration: 0,
+    track: 0,
+    url: '',
+    bpm: djMatching?.currentBpm || seedSong.bpm,
+    key: djMatching?.currentKey || seedSong.key,
+    energy: djMatching?.currentEnergy || seedSong.energy,
+  };
+
+  const scoringContext = await buildScoringContext(
+    seedSongFull,
+    songIds,
+    userId,
+    queueContext?.artists
+  );
+
+  // 3. Enrich songs with DJ metadata if DJ matching is enabled
+  // Note: This may fail on server-side due to IndexedDB not being available
+  let enrichedSongs: Map<string, SongWithDJMetadata> = new Map();
+  if (djMatching?.enabled) {
+    try {
+      const enriched = await enrichSongsWithDJMetadata(songs);
+      for (const song of enriched) {
+        enrichedSongs.set(song.id, song);
+      }
+    } catch (error) {
+      // IndexedDB not available on server-side, continue without DJ metadata
+      // DJ scoring will use neutral 0.5 scores
+    }
+  }
+
+  // 4. Score all candidates
+  const mergedWeights = { ...SCORE_WEIGHTS, ...weights };
+  const scoredCandidates: ScoredCandidate[] = [];
+
+  for (const [songId, candidate] of candidates) {
+    const enriched = enrichedSongs.get(songId);
+    const scored = scoreCandidate(candidate, scoringContext, enriched, mergedWeights);
+    scoredCandidates.push(scored);
+  }
+
+  // 5. Sort by final score
+  scoredCandidates.sort((a, b) => b.finalScore - a.finalScore);
+
+  // 6. Apply diversity rules
+  const finalResults = applyDiversityRules(scoredCandidates, limit);
+
+  // 7. Build metadata
+  const sourceCounts: Record<string, number> = {};
+  for (const [, candidate] of candidates) {
+    for (const source of candidate.sources) {
+      sourceCounts[source.source] = (sourceCounts[source.source] || 0) + 1;
+    }
+  }
+
+  const avgScores = calculateAverageScores(finalResults);
+
+  console.log(`✅ [BlendedScorer] Returning ${finalResults.length} recommendations from ${candidates.size} candidates`);
+  console.log(`📊 [BlendedScorer] Source distribution: ${JSON.stringify(sourceCounts)}`);
+  console.log(`📊 [BlendedScorer] Avg scores - lastFm: ${avgScores.lastFm.toFixed(2)}, compound: ${avgScores.compound.toFixed(2)}, dj: ${avgScores.dj.toFixed(2)}, feedback: ${avgScores.feedback.toFixed(2)}`);
+
+  return {
+    songs: finalResults.map(r => r.song),
+    metadata: {
+      totalCandidates: candidates.size,
+      sourceCounts,
+      avgScores,
+      uniqueArtists: new Set(finalResults.map(r => r.song.artist?.toLowerCase())).size,
+    },
+  };
+}
+
+// ============================================================================
+// Diversity Rules
+// ============================================================================
+
+/**
+ * Apply diversity rules to avoid artist domination
+ *
+ * Rules:
+ * 1. Max 1 song per artist in final results
+ * 2. Ensure at least 2 different artists if possible
+ * 3. Slight randomization in top candidates for variety
+ */
+function applyDiversityRules(
+  scoredCandidates: ScoredCandidate[],
+  limit: number
+): ScoredCandidate[] {
+  const results: ScoredCandidate[] = [];
+  const artistsUsed = new Set<string>();
+
+  // Debug: log unique artists in candidates
+  const uniqueArtists = new Set(scoredCandidates.map(c => c.song.artist?.toLowerCase() || 'unknown'));
+  console.log(`🎯 [BlendedScorer] Diversity check: ${scoredCandidates.length} candidates, ${uniqueArtists.size} unique artists, limit=${limit}`);
+
+  // First pass: add best song from each artist
+  for (const candidate of scoredCandidates) {
+    if (results.length >= limit) break;
+
+    const artistLower = candidate.song.artist?.toLowerCase() || '';
+    const artistCount = artistsUsed.has(artistLower) ? 1 : 0;
+
+    if (artistCount < MAX_SONGS_PER_ARTIST) {
+      results.push(candidate);
+      artistsUsed.add(artistLower);
+    }
+  }
+
+  // Check if we need more diversity
+  if (results.length >= MIN_UNIQUE_ARTISTS && artistsUsed.size < MIN_UNIQUE_ARTISTS) {
+    // We have enough songs but not enough artists
+    // Try to swap some songs for different artists
+    const candidates2ndPass = scoredCandidates.filter(c =>
+      !results.includes(c) && !artistsUsed.has(c.song.artist?.toLowerCase() || '')
+    );
+
+    // Replace lowest-scored same-artist songs with different artists
+    for (const newCandidate of candidates2ndPass.slice(0, 3)) {
+      const replaceIdx = results.findIndex((r, idx) => {
+        // Find a duplicate artist to replace (prefer lower scored ones)
+        const rArtist = r.song.artist?.toLowerCase();
+        const duplicateCount = results.filter(x => x.song.artist?.toLowerCase() === rArtist).length;
+        return duplicateCount > 1 && idx > results.length / 2;
+      });
+
+      if (replaceIdx >= 0) {
+        results[replaceIdx] = newCandidate;
+        artistsUsed.add(newCandidate.song.artist?.toLowerCase() || '');
+      }
+    }
+  }
+
+  // Add slight randomization in top 20% to avoid staleness
+  const top20Percent = Math.ceil(results.length * 0.2);
+  if (top20Percent > 1) {
+    const topSection = results.slice(0, top20Percent);
+    // Fisher-Yates shuffle for top section
+    for (let i = topSection.length - 1; i > 0; i--) {
+      const j = Math.floor(Math.random() * (i + 1));
+      [topSection[i], topSection[j]] = [topSection[j], topSection[i]];
+    }
+    results.splice(0, top20Percent, ...topSection);
+  }
+
+  return results;
+}
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function buildTargetGenres(seedGenre?: string, queueGenres?: string[]): string[] {
+  const genres: string[] = [];
+
+  if (queueGenres && queueGenres.length > 0) {
+    genres.push(...queueGenres.slice(0, 5).map(g => normalizeGenre(g)));
+  }
+
+  if (seedGenre) {
+    const normalized = normalizeGenre(seedGenre);
+    if (!genres.includes(normalized)) {
+      genres.push(normalized);
+    }
+  }
+
+  return genres.filter(Boolean);
+}
+
+function calculateAverageScores(results: ScoredCandidate[]): Record<string, number> {
+  if (results.length === 0) {
+    return { lastFm: 0, compound: 0, dj: 0, feedback: 0, skip: 0, temporal: 0, diversity: 0 };
+  }
+
+  const totals = { lastFm: 0, compound: 0, dj: 0, feedback: 0, skip: 0, temporal: 0, diversity: 0 };
+
+  for (const r of results) {
+    totals.lastFm += r.scores.lastFm;
+    totals.compound += r.scores.compound;
+    totals.dj += r.scores.dj;
+    totals.feedback += r.scores.feedback;
+    totals.skip += r.scores.skip;
+    totals.temporal += r.scores.temporal;
+    totals.diversity += r.scores.diversity;
+  }
+
+  const count = results.length;
+  return {
+    lastFm: totals.lastFm / count,
+    compound: totals.compound / count,
+    dj: totals.dj / count,
+    feedback: totals.feedback / count,
+    skip: totals.skip / count,
+    temporal: totals.temporal / count,
+    diversity: totals.diversity / count,
+  };
+}
+
+// ============================================================================
+// Types for Metadata
+// ============================================================================
+
+export interface BlendedMetadata {
+  totalCandidates: number;
+  sourceCounts: Record<string, number>;
+  avgScores?: Record<string, number>;
+  uniqueArtists?: number;
+}
+
+// ============================================================================
+// Exports for Testing
+// ============================================================================
+
+export {
+  CANDIDATE_LIMITS,
+  MAX_SONGS_PER_ARTIST,
+  MIN_UNIQUE_ARTISTS,
+};

--- a/src/lib/services/bpm-analyzer.ts
+++ b/src/lib/services/bpm-analyzer.ts
@@ -1,0 +1,487 @@
+/**
+ * BPM Analyzer Service
+ *
+ * Detects BPM (beats per minute) from audio using Web Audio API.
+ * Uses a combination of onset detection and autocorrelation.
+ *
+ * Based on the beat detection algorithm from:
+ * - Joe Sullivan's beat detection tutorial
+ * - Web Audio API beat detection patterns
+ *
+ * @see https://joesul.li/van/beat-detection-using-web-audio/
+ */
+
+import { setMetadata, getMetadata, type AudioMetadataCache } from './audio-metadata-cache';
+
+// Analysis configuration
+const ANALYSIS_CONFIG = {
+  FFT_SIZE: 2048,
+  SAMPLE_RATE: 44100,
+  MIN_BPM: 60,
+  MAX_BPM: 200,
+  ANALYSIS_DURATION_MS: 30000, // Analyze first 30 seconds
+  PEAK_THRESHOLD: 0.8, // Threshold for peak detection
+  MIN_INTERVAL_MS: 250, // Minimum time between beats (240 BPM max)
+};
+
+// Store for active analyzers
+const activeAnalyzers = new Map<string, {
+  audioContext: AudioContext;
+  analyzerNode: AnalyserNode;
+  sourceNode: MediaElementAudioSourceNode;
+}>();
+
+/**
+ * BPM detection result
+ */
+export interface BPMResult {
+  bpm: number;
+  confidence: number; // 0-1, how confident we are in the result
+  method: string;
+  analyzedDuration: number; // Duration analyzed in seconds
+}
+
+/**
+ * Detect peaks in audio data for beat detection
+ */
+function detectPeaks(data: Float32Array, threshold: number = 0.5): number[] {
+  const peaks: number[] = [];
+  const windowSize = Math.floor(ANALYSIS_CONFIG.SAMPLE_RATE * 0.05); // 50ms window
+
+  for (let i = windowSize; i < data.length - windowSize; i++) {
+    const current = Math.abs(data[i]);
+
+    // Check if this is a local maximum
+    let isLocalMax = true;
+    let localSum = 0;
+
+    for (let j = i - windowSize; j < i + windowSize; j++) {
+      localSum += Math.abs(data[j]);
+      if (j !== i && Math.abs(data[j]) >= current) {
+        isLocalMax = false;
+      }
+    }
+
+    const localAvg = localSum / (windowSize * 2);
+
+    // Peak must be local maximum and above threshold
+    if (isLocalMax && current > threshold && current > localAvg * 1.5) {
+      // Avoid detecting peaks too close together
+      if (peaks.length === 0 || i - peaks[peaks.length - 1] > ANALYSIS_CONFIG.MIN_INTERVAL_MS * ANALYSIS_CONFIG.SAMPLE_RATE / 1000) {
+        peaks.push(i);
+      }
+    }
+  }
+
+  return peaks;
+}
+
+/**
+ * Calculate BPM from peak intervals
+ */
+function calculateBPMFromPeaks(peaks: number[], sampleRate: number): { bpm: number; confidence: number } {
+  if (peaks.length < 2) {
+    return { bpm: 0, confidence: 0 };
+  }
+
+  // Calculate intervals between peaks
+  const intervals: number[] = [];
+  for (let i = 1; i < peaks.length; i++) {
+    const interval = (peaks[i] - peaks[i - 1]) / sampleRate;
+    if (interval > 0) {
+      intervals.push(interval);
+    }
+  }
+
+  if (intervals.length === 0) {
+    return { bpm: 0, confidence: 0 };
+  }
+
+  // Group similar intervals (within 5% tolerance)
+  const groups: { interval: number; count: number }[] = [];
+
+  for (const interval of intervals) {
+    let foundGroup = false;
+    for (const group of groups) {
+      if (Math.abs(interval - group.interval) / group.interval < 0.05) {
+        group.interval = (group.interval * group.count + interval) / (group.count + 1);
+        group.count++;
+        foundGroup = true;
+        break;
+      }
+    }
+    if (!foundGroup) {
+      groups.push({ interval, count: 1 });
+    }
+  }
+
+  // Find the most common interval
+  groups.sort((a, b) => b.count - a.count);
+  const bestGroup = groups[0];
+
+  if (!bestGroup) {
+    return { bpm: 0, confidence: 0 };
+  }
+
+  // Convert interval to BPM
+  let bpm = 60 / bestGroup.interval;
+
+  // Normalize BPM to reasonable range
+  while (bpm < ANALYSIS_CONFIG.MIN_BPM) bpm *= 2;
+  while (bpm > ANALYSIS_CONFIG.MAX_BPM) bpm /= 2;
+
+  // Calculate confidence based on consistency of intervals
+  const confidence = Math.min(1, bestGroup.count / (intervals.length * 0.5));
+
+  return { bpm: Math.round(bpm), confidence };
+}
+
+/**
+ * Analyze audio buffer and detect BPM using onset detection
+ */
+function analyzeAudioBuffer(audioBuffer: AudioBuffer): BPMResult {
+  const channelData = audioBuffer.getChannelData(0); // Use first channel
+  const sampleRate = audioBuffer.sampleRate;
+
+  // Apply low-pass filter for bass frequencies (where beats are most prominent)
+  // Simple moving average as approximation
+  const windowSize = Math.floor(sampleRate / 200); // ~5ms window
+  const filtered = new Float32Array(channelData.length);
+
+  for (let i = 0; i < channelData.length; i++) {
+    let sum = 0;
+    const start = Math.max(0, i - windowSize);
+    const end = Math.min(channelData.length, i + windowSize);
+    for (let j = start; j < end; j++) {
+      sum += Math.abs(channelData[j]);
+    }
+    filtered[i] = sum / (end - start);
+  }
+
+  // Detect peaks
+  const peaks = detectPeaks(filtered, ANALYSIS_CONFIG.PEAK_THRESHOLD);
+
+  // Calculate BPM from peaks
+  const { bpm, confidence } = calculateBPMFromPeaks(peaks, sampleRate);
+
+  return {
+    bpm,
+    confidence,
+    method: 'onset-detection',
+    analyzedDuration: audioBuffer.duration,
+  };
+}
+
+/**
+ * Analyze BPM from an audio file URL
+ *
+ * @param audioUrl - URL of the audio file to analyze
+ * @param songId - Song ID for caching
+ * @returns BPM detection result
+ */
+export async function analyzeBPMFromUrl(audioUrl: string, songId?: string): Promise<BPMResult> {
+  // Check cache first
+  if (songId) {
+    const cached = await getMetadata(songId);
+    if (cached?.bpm && cached.confidence > 0.5) {
+      return {
+        bpm: cached.bpm,
+        confidence: cached.confidence,
+        method: 'cached',
+        analyzedDuration: 0,
+      };
+    }
+  }
+
+  try {
+    // Create audio context
+    const audioContext = new AudioContext({ sampleRate: ANALYSIS_CONFIG.SAMPLE_RATE });
+
+    // Fetch audio data
+    const response = await fetch(audioUrl);
+    const arrayBuffer = await response.arrayBuffer();
+
+    // Decode audio
+    const audioBuffer = await audioContext.decodeAudioData(arrayBuffer);
+
+    // Limit analysis to first N seconds
+    const maxSamples = Math.min(
+      audioBuffer.length,
+      ANALYSIS_CONFIG.ANALYSIS_DURATION_MS * ANALYSIS_CONFIG.SAMPLE_RATE / 1000
+    );
+
+    // Create a trimmed buffer if needed
+    let bufferToAnalyze = audioBuffer;
+    if (audioBuffer.length > maxSamples) {
+      const trimmedBuffer = audioContext.createBuffer(
+        1,
+        maxSamples,
+        audioBuffer.sampleRate
+      );
+      trimmedBuffer.copyToChannel(
+        audioBuffer.getChannelData(0).slice(0, maxSamples),
+        0
+      );
+      bufferToAnalyze = trimmedBuffer;
+    }
+
+    // Analyze
+    const result = analyzeAudioBuffer(bufferToAnalyze);
+
+    // Close audio context
+    await audioContext.close();
+
+    // Cache result if valid
+    if (songId && result.bpm > 0 && result.confidence > 0.3) {
+      const existingMetadata = await getMetadata(songId);
+      const metadata: AudioMetadataCache = {
+        id: songId,
+        bpm: result.bpm,
+        key: existingMetadata?.key,
+        energy: existingMetadata?.energy,
+        source: 'estimated',
+        confidence: result.confidence,
+        fetchedAt: Date.now(),
+        updatedAt: Date.now(),
+      };
+      await setMetadata(metadata);
+      console.log(`🎵 [BPM Analyzer] Analyzed ${songId}: ${result.bpm} BPM (${(result.confidence * 100).toFixed(0)}% confidence)`);
+    }
+
+    return result;
+  } catch (error) {
+    console.error('[BPM Analyzer] Analysis failed:', error);
+    return {
+      bpm: 0,
+      confidence: 0,
+      method: 'error',
+      analyzedDuration: 0,
+    };
+  }
+}
+
+/**
+ * Real-time BPM analysis from a playing audio element
+ * Analyzes in the background while music plays
+ *
+ * @param audioElement - The HTML audio element
+ * @param songId - Song ID for caching
+ * @param onResult - Callback when BPM is detected
+ */
+export function startRealtimeBPMAnalysis(
+  audioElement: HTMLAudioElement,
+  songId: string,
+  onResult?: (result: BPMResult) => void
+): () => void {
+  // Check if already analyzing this song
+  if (activeAnalyzers.has(songId)) {
+    console.log(`[BPM Analyzer] Already analyzing ${songId}`);
+    return () => {};
+  }
+
+  // Check cache first
+  getMetadata(songId).then(cached => {
+    if (cached?.bpm && cached.confidence > 0.5) {
+      console.log(`[BPM Analyzer] Using cached BPM for ${songId}: ${cached.bpm}`);
+      onResult?.({
+        bpm: cached.bpm,
+        confidence: cached.confidence,
+        method: 'cached',
+        analyzedDuration: 0,
+      });
+      return;
+    }
+  });
+
+  try {
+    const audioContext = new AudioContext();
+    const analyzerNode = audioContext.createAnalyser();
+    analyzerNode.fftSize = ANALYSIS_CONFIG.FFT_SIZE;
+
+    const sourceNode = audioContext.createMediaElementSource(audioElement);
+    sourceNode.connect(analyzerNode);
+    analyzerNode.connect(audioContext.destination);
+
+    activeAnalyzers.set(songId, { audioContext, analyzerNode, sourceNode });
+
+    // Collect samples over time
+    const samples: number[] = [];
+    const startTime = Date.now();
+    const dataArray = new Float32Array(analyzerNode.fftSize);
+
+    const collectSample = () => {
+      if (!activeAnalyzers.has(songId)) return;
+
+      const elapsed = Date.now() - startTime;
+      if (elapsed >= ANALYSIS_CONFIG.ANALYSIS_DURATION_MS) {
+        // Enough samples collected, analyze
+        const result = analyzeCollectedSamples(samples, audioContext.sampleRate);
+
+        // Cache result
+        if (result.bpm > 0 && result.confidence > 0.3) {
+          getMetadata(songId).then(existingMetadata => {
+            const metadata: AudioMetadataCache = {
+              id: songId,
+              bpm: result.bpm,
+              key: existingMetadata?.key,
+              energy: existingMetadata?.energy,
+              source: 'estimated',
+              confidence: result.confidence,
+              fetchedAt: Date.now(),
+              updatedAt: Date.now(),
+            };
+            setMetadata(metadata);
+          });
+
+          console.log(`🎵 [BPM Analyzer] Real-time analysis ${songId}: ${result.bpm} BPM (${(result.confidence * 100).toFixed(0)}% confidence)`);
+          onResult?.(result);
+        }
+
+        // Stop analyzing
+        stopRealtimeBPMAnalysis(songId);
+        return;
+      }
+
+      // Collect current energy level
+      analyzerNode.getFloatTimeDomainData(dataArray);
+      let energy = 0;
+      for (let i = 0; i < dataArray.length; i++) {
+        energy += dataArray[i] * dataArray[i];
+      }
+      samples.push(Math.sqrt(energy / dataArray.length));
+
+      // Continue collecting
+      requestAnimationFrame(collectSample);
+    };
+
+    // Start collecting after a short delay to allow audio to start
+    setTimeout(() => {
+      requestAnimationFrame(collectSample);
+    }, 500);
+
+    // Return cleanup function
+    return () => stopRealtimeBPMAnalysis(songId);
+  } catch (error) {
+    console.error('[BPM Analyzer] Failed to start real-time analysis:', error);
+    return () => {};
+  }
+}
+
+/**
+ * Analyze collected energy samples for BPM
+ */
+function analyzeCollectedSamples(samples: number[], _sampleRate: number): BPMResult {
+  if (samples.length < 100) {
+    return { bpm: 0, confidence: 0, method: 'insufficient-data', analyzedDuration: 0 };
+  }
+
+  // Find peaks in energy samples (collected at ~60fps)
+  const peaks: number[] = [];
+  const threshold = Math.max(...samples) * 0.5;
+
+  for (let i = 2; i < samples.length - 2; i++) {
+    if (
+      samples[i] > threshold &&
+      samples[i] > samples[i - 1] &&
+      samples[i] > samples[i - 2] &&
+      samples[i] > samples[i + 1] &&
+      samples[i] > samples[i + 2]
+    ) {
+      // Minimum 250ms between peaks
+      if (peaks.length === 0 || i - peaks[peaks.length - 1] > 15) { // ~250ms at 60fps
+        peaks.push(i);
+      }
+    }
+  }
+
+  if (peaks.length < 2) {
+    return { bpm: 0, confidence: 0, method: 'no-peaks', analyzedDuration: samples.length / 60 };
+  }
+
+  // Calculate intervals (in frames at ~60fps)
+  const intervals: number[] = [];
+  for (let i = 1; i < peaks.length; i++) {
+    intervals.push(peaks[i] - peaks[i - 1]);
+  }
+
+  // Find most common interval
+  const groups: { interval: number; count: number }[] = [];
+  for (const interval of intervals) {
+    let found = false;
+    for (const group of groups) {
+      if (Math.abs(interval - group.interval) / group.interval < 0.1) {
+        group.interval = (group.interval * group.count + interval) / (group.count + 1);
+        group.count++;
+        found = true;
+        break;
+      }
+    }
+    if (!found) {
+      groups.push({ interval, count: 1 });
+    }
+  }
+
+  groups.sort((a, b) => b.count - a.count);
+  const bestGroup = groups[0];
+
+  if (!bestGroup) {
+    return { bpm: 0, confidence: 0, method: 'no-groups', analyzedDuration: samples.length / 60 };
+  }
+
+  // Convert interval (in frames at 60fps) to BPM
+  let bpm = 60 / (bestGroup.interval / 60); // frames -> seconds -> BPM
+
+  // Normalize to reasonable range
+  while (bpm < ANALYSIS_CONFIG.MIN_BPM) bpm *= 2;
+  while (bpm > ANALYSIS_CONFIG.MAX_BPM) bpm /= 2;
+
+  const confidence = Math.min(1, bestGroup.count / (intervals.length * 0.4));
+
+  return {
+    bpm: Math.round(bpm),
+    confidence,
+    method: 'realtime-energy',
+    analyzedDuration: samples.length / 60,
+  };
+}
+
+/**
+ * Stop real-time BPM analysis for a song
+ */
+export function stopRealtimeBPMAnalysis(songId: string): void {
+  const analyzer = activeAnalyzers.get(songId);
+  if (analyzer) {
+    try {
+      analyzer.sourceNode.disconnect();
+      analyzer.analyzerNode.disconnect();
+      analyzer.audioContext.close();
+    } catch {
+      // Ignore errors during cleanup
+    }
+    activeAnalyzers.delete(songId);
+    console.log(`[BPM Analyzer] Stopped analysis for ${songId}`);
+  }
+}
+
+/**
+ * Stop all active BPM analyses
+ */
+export function stopAllBPMAnalysis(): void {
+  for (const songId of activeAnalyzers.keys()) {
+    stopRealtimeBPMAnalysis(songId);
+  }
+}
+
+/**
+ * Check if BPM analysis is currently active for a song
+ */
+export function isAnalyzing(songId: string): boolean {
+  return activeAnalyzers.has(songId);
+}
+
+/**
+ * Get the number of active analyzers
+ */
+export function getActiveAnalyzerCount(): number {
+  return activeAnalyzers.size;
+}

--- a/src/lib/services/compound-scoring.ts
+++ b/src/lib/services/compound-scoring.ts
@@ -147,7 +147,9 @@ export async function calculateCompoundScores(
     }
 
     // Calculate recency weight for this source song
-    const daysSincePlay = (now.getTime() - play.lastPlayed.getTime()) / (1000 * 60 * 60 * 24);
+    // Note: SQL aggregation returns string, need to convert to Date
+    const lastPlayedDate = new Date(play.lastPlayed);
+    const daysSincePlay = (now.getTime() - lastPlayedDate.getTime()) / (1000 * 60 * 60 * 24);
     const recencyWeight = Math.exp(-RECENCY_DECAY_RATE * daysSincePlay);
 
     // Accumulate scores for each similar track

--- a/src/lib/services/dj-match-scorer.ts
+++ b/src/lib/services/dj-match-scorer.ts
@@ -1,0 +1,531 @@
+/**
+ * DJ Match Scorer Service
+ *
+ * Calculates compatibility scores between songs for DJ-style transitions.
+ * Combines BPM, energy, and musical key into a single weighted score.
+ *
+ * Scoring weights (configurable):
+ * - BPM: 40% - Most important for smooth beatmatching
+ * - Energy: 35% - Second most important for flow
+ * - Key: 25% - Nice-to-have for harmonic mixing
+ */
+
+import { getCamelotKey, areCamelotKeysCompatible, type CamelotKey } from '@/lib/types/song';
+import type { Song } from '@/lib/types/song';
+import { estimateEnergy, calculateEnergyCompatibility } from './energy-estimator';
+import {
+  getMetadata,
+  getMetadataBatch,
+  setMetadata,
+  type AudioMetadataCache,
+} from './audio-metadata-cache';
+
+// Default scoring weights (from plan)
+export const DJ_WEIGHTS = {
+  bpm: 0.40,     // Most important for smooth transitions
+  energy: 0.35,  // Second most important for flow
+  key: 0.25,     // Nice-to-have for harmonic mixing
+};
+
+// BPM matching thresholds
+export const BPM_THRESHOLDS = {
+  PERFECT: 0.01,    // Within 1% = perfect match
+  TIGHT: 0.03,      // Within 3% = tight (user requirement)
+  GOOD: 0.05,       // Within 5% = good match
+  ACCEPTABLE: 0.08, // Within 8% = acceptable with pitch adjustment
+  HALFHALF: 0.03,   // Within 3% of half/double time
+};
+
+// Minimum DJ score threshold for recommendations
+export const MIN_DJ_SCORE_THRESHOLD = 0.5;
+
+/**
+ * Song with DJ metadata for scoring
+ */
+export interface SongWithDJMetadata extends Song {
+  bpm?: number;
+  key?: string;
+  energy?: number;
+}
+
+/**
+ * Result of calculating DJ score between two songs
+ */
+export interface DJScoreResult {
+  /** Overall weighted DJ score (0-1) */
+  totalScore: number;
+
+  /** Individual component scores */
+  scores: {
+    bpm: number;
+    energy: number;
+    key: number;
+  };
+
+  /** Detailed scoring information */
+  details: {
+    bpmDiff?: number;
+    bpmDiffPercent?: number;
+    bpmRelationship?: string;
+    energyDiff?: number;
+    energyRelationship?: string;
+    keyRelationship?: string;
+    camelotKeys?: { source: CamelotKey | null; target: CamelotKey | null };
+  };
+
+  /** Whether this is a recommended transition */
+  isRecommended: boolean;
+
+  /** Human-readable summary */
+  summary: string;
+}
+
+/**
+ * Calculate BPM match score between two songs
+ *
+ * @param bpm1 - First song BPM
+ * @param bpm2 - Second song BPM
+ * @param tolerance - BPM tolerance (default 3% as per user requirement)
+ * @returns Score 0-1 and relationship info
+ */
+export function scoreBPMMatch(
+  bpm1?: number,
+  bpm2?: number,
+  tolerance: number = BPM_THRESHOLDS.TIGHT
+): { score: number; diff?: number; diffPercent?: number; relationship: string } {
+  // If either BPM is missing, return neutral score
+  if (!bpm1 || !bpm2 || bpm1 <= 0 || bpm2 <= 0) {
+    return { score: 0.5, relationship: 'Unknown BPM' };
+  }
+
+  const diff = bpm2 - bpm1;
+  const diffPercent = Math.abs(diff / bpm1);
+
+  // Check for exact match
+  if (Math.abs(diff) < 1) {
+    return {
+      score: 1.0,
+      diff,
+      diffPercent,
+      relationship: 'Exact match',
+    };
+  }
+
+  // Check for perfect match (within 1%)
+  if (diffPercent <= BPM_THRESHOLDS.PERFECT) {
+    return {
+      score: 0.98,
+      diff,
+      diffPercent,
+      relationship: 'Perfect match',
+    };
+  }
+
+  // Check for tight match (within 3% - user requirement)
+  if (diffPercent <= BPM_THRESHOLDS.TIGHT) {
+    return {
+      score: 0.90 + (1 - diffPercent / BPM_THRESHOLDS.TIGHT) * 0.08,
+      diff,
+      diffPercent,
+      relationship: 'Seamless transition',
+    };
+  }
+
+  // Check for good match (within 5%)
+  if (diffPercent <= BPM_THRESHOLDS.GOOD) {
+    return {
+      score: 0.75 + (1 - diffPercent / BPM_THRESHOLDS.GOOD) * 0.15,
+      diff,
+      diffPercent,
+      relationship: 'Good match',
+    };
+  }
+
+  // Check for half-time relationship (target is ~50% of source)
+  const halfTimeDiff = Math.abs(bpm2 - bpm1 / 2);
+  const halfTimePercent = halfTimeDiff / (bpm1 / 2);
+  if (halfTimePercent <= BPM_THRESHOLDS.HALFHALF) {
+    return {
+      score: 0.80,
+      diff,
+      diffPercent,
+      relationship: 'Half-time match',
+    };
+  }
+
+  // Check for double-time relationship (target is ~200% of source)
+  const doubleTimeDiff = Math.abs(bpm2 - bpm1 * 2);
+  const doubleTimePercent = doubleTimeDiff / (bpm1 * 2);
+  if (doubleTimePercent <= BPM_THRESHOLDS.HALFHALF) {
+    return {
+      score: 0.80,
+      diff,
+      diffPercent,
+      relationship: 'Double-time match',
+    };
+  }
+
+  // Check for acceptable match (within 8%)
+  if (diffPercent <= BPM_THRESHOLDS.ACCEPTABLE) {
+    return {
+      score: 0.50 + (1 - diffPercent / BPM_THRESHOLDS.ACCEPTABLE) * 0.25,
+      diff,
+      diffPercent,
+      relationship: 'Requires tempo adjustment',
+    };
+  }
+
+  // Poor match - calculate declining score based on difference
+  const maxDiff = 0.20; // 20% is the worst we consider
+  if (diffPercent <= maxDiff) {
+    const score = 0.30 * (1 - (diffPercent - BPM_THRESHOLDS.ACCEPTABLE) / (maxDiff - BPM_THRESHOLDS.ACCEPTABLE));
+    return {
+      score: Math.max(0.1, score),
+      diff,
+      diffPercent,
+      relationship: 'Difficult transition',
+    };
+  }
+
+  // Very poor match
+  return {
+    score: 0.1,
+    diff,
+    diffPercent,
+    relationship: 'BPM mismatch',
+  };
+}
+
+/**
+ * Calculate energy match score between two songs
+ *
+ * @param energy1 - First song energy (0-1)
+ * @param energy2 - Second song energy (0-1)
+ * @returns Score 0-1 and relationship info
+ */
+export function scoreEnergyMatch(
+  energy1?: number,
+  energy2?: number
+): { score: number; diff?: number; relationship: string } {
+  // If either energy is missing, return neutral score
+  if (energy1 === undefined || energy2 === undefined) {
+    return { score: 0.5, relationship: 'Unknown energy' };
+  }
+
+  const result = calculateEnergyCompatibility(energy1, energy2, 'any');
+  const diff = energy2 - energy1;
+
+  return {
+    score: result.score,
+    diff,
+    relationship: result.relationship,
+  };
+}
+
+/**
+ * Calculate key match score using Camelot wheel compatibility
+ *
+ * @param key1 - First song key (e.g., "Am", "C", "F#m")
+ * @param key2 - Second song key
+ * @returns Score 0-1 and relationship info
+ */
+export function scoreKeyMatch(
+  key1?: string,
+  key2?: string
+): { score: number; relationship: string; camelotKeys?: { source: CamelotKey | null; target: CamelotKey | null } } {
+  // If either key is missing, return neutral score
+  if (!key1 || !key2) {
+    return { score: 0.5, relationship: 'Unknown key' };
+  }
+
+  const camelot1 = getCamelotKey(key1);
+  const camelot2 = getCamelotKey(key2);
+
+  // If we can't map to Camelot, return neutral
+  if (!camelot1 || !camelot2) {
+    return {
+      score: 0.5,
+      relationship: 'Key not recognized',
+      camelotKeys: { source: camelot1, target: camelot2 },
+    };
+  }
+
+  // Use existing Camelot compatibility function
+  const compatibility = areCamelotKeysCompatible(camelot1, camelot2);
+
+  return {
+    score: compatibility.score,
+    relationship: compatibility.relationship,
+    camelotKeys: { source: camelot1, target: camelot2 },
+  };
+}
+
+/**
+ * Calculate overall DJ compatibility score between two songs
+ * Combines BPM, energy, and key scores with configurable weights
+ *
+ * @param song1 - Source song (current playing)
+ * @param song2 - Target song (candidate for next)
+ * @param weights - Optional custom weights for scoring
+ * @returns Complete DJ score result
+ */
+export function calculateDJScore(
+  song1: SongWithDJMetadata,
+  song2: SongWithDJMetadata,
+  weights: typeof DJ_WEIGHTS = DJ_WEIGHTS
+): DJScoreResult {
+  // Calculate individual scores
+  const bpmResult = scoreBPMMatch(song1.bpm, song2.bpm);
+  const energyResult = scoreEnergyMatch(song1.energy, song2.energy);
+  const keyResult = scoreKeyMatch(song1.key, song2.key);
+
+  // Calculate weighted total score
+  const totalScore =
+    (bpmResult.score * weights.bpm) +
+    (energyResult.score * weights.energy) +
+    (keyResult.score * weights.key);
+
+  // Determine if this is a recommended transition
+  const isRecommended =
+    totalScore >= MIN_DJ_SCORE_THRESHOLD &&
+    bpmResult.score >= 0.5; // BPM is a hard requirement
+
+  // Generate summary
+  let summary = '';
+  if (totalScore >= 0.85) {
+    summary = 'Excellent DJ transition';
+  } else if (totalScore >= 0.70) {
+    summary = 'Good DJ transition';
+  } else if (totalScore >= 0.55) {
+    summary = 'Acceptable transition';
+  } else if (totalScore >= 0.40) {
+    summary = 'Challenging transition';
+  } else {
+    summary = 'Poor transition match';
+  }
+
+  return {
+    totalScore,
+    scores: {
+      bpm: bpmResult.score,
+      energy: energyResult.score,
+      key: keyResult.score,
+    },
+    details: {
+      bpmDiff: bpmResult.diff,
+      bpmDiffPercent: bpmResult.diffPercent,
+      bpmRelationship: bpmResult.relationship,
+      energyDiff: energyResult.diff,
+      energyRelationship: energyResult.relationship,
+      keyRelationship: keyResult.relationship,
+      camelotKeys: keyResult.camelotKeys,
+    },
+    isRecommended,
+    summary,
+  };
+}
+
+/**
+ * Enrich a song with DJ metadata from cache or estimation
+ *
+ * @param song - Song to enrich
+ * @returns Song with BPM, key, and energy populated
+ */
+export async function enrichSongWithDJMetadata(song: Song): Promise<SongWithDJMetadata> {
+  // Check if song already has metadata
+  if (song.bpm !== undefined && song.energy !== undefined) {
+    return song as SongWithDJMetadata;
+  }
+
+  // Try to get from cache
+  const cached = await getMetadata(song.id);
+  if (cached && cached.bpm !== undefined && cached.energy !== undefined) {
+    return {
+      ...song,
+      bpm: cached.bpm,
+      key: cached.key || song.key,
+      energy: cached.energy,
+    };
+  }
+
+  // Estimate energy if not available
+  const energyEstimate = estimateEnergy({
+    genre: song.genre,
+    bpm: song.bpm || cached?.bpm,
+    title: song.title || song.name,
+    artist: song.artist,
+  });
+
+  const enriched: SongWithDJMetadata = {
+    ...song,
+    bpm: song.bpm || cached?.bpm,
+    key: song.key || cached?.key,
+    energy: song.energy ?? cached?.energy ?? energyEstimate.energy,
+  };
+
+  // Cache the enriched data
+  const metadataToCache: AudioMetadataCache = {
+    id: song.id,
+    bpm: enriched.bpm,
+    key: enriched.key,
+    energy: enriched.energy,
+    source: enriched.bpm ? 'navidrome' : 'estimated',
+    confidence: energyEstimate.confidence,
+    fetchedAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  await setMetadata(metadataToCache);
+
+  return enriched;
+}
+
+/**
+ * Enrich multiple songs with DJ metadata efficiently
+ *
+ * @param songs - Songs to enrich
+ * @returns Songs with BPM, key, and energy populated
+ */
+export async function enrichSongsWithDJMetadata(songs: Song[]): Promise<SongWithDJMetadata[]> {
+  if (songs.length === 0) return [];
+
+  // Get cached metadata for all songs
+  const songIds = songs.map(s => s.id);
+  const cachedMetadata = await getMetadataBatch(songIds);
+
+  // Enrich each song
+  const enrichedSongs: SongWithDJMetadata[] = [];
+
+  for (const song of songs) {
+    const cached = cachedMetadata.get(song.id);
+
+    // Use cached values if available
+    const bpm = song.bpm || cached?.bpm;
+    const key = song.key || cached?.key;
+    let energy = song.energy ?? cached?.energy;
+
+    // Estimate energy if not available
+    if (energy === undefined) {
+      const estimate = estimateEnergy({
+        genre: song.genre,
+        bpm,
+        title: song.title || song.name,
+        artist: song.artist,
+      });
+      energy = estimate.energy;
+    }
+
+    enrichedSongs.push({
+      ...song,
+      bpm,
+      key,
+      energy,
+    });
+  }
+
+  return enrichedSongs;
+}
+
+/**
+ * Score and rank songs for DJ compatibility with a source song
+ *
+ * @param sourceSong - The current/source song
+ * @param candidateSongs - Songs to score and rank
+ * @param options - Scoring options
+ * @returns Sorted array of candidates with DJ scores
+ */
+export async function scoreAndRankForDJ(
+  sourceSong: Song,
+  candidateSongs: Song[],
+  options: {
+    minScore?: number;
+    maxResults?: number;
+    weights?: typeof DJ_WEIGHTS;
+    enrichMetadata?: boolean;
+  } = {}
+): Promise<Array<{ song: SongWithDJMetadata; djScore: DJScoreResult }>> {
+  const {
+    minScore = MIN_DJ_SCORE_THRESHOLD,
+    maxResults = 50,
+    weights = DJ_WEIGHTS,
+    enrichMetadata = true,
+  } = options;
+
+  // Enrich songs with metadata
+  let enrichedSource: SongWithDJMetadata;
+  let enrichedCandidates: SongWithDJMetadata[];
+
+  if (enrichMetadata) {
+    enrichedSource = await enrichSongWithDJMetadata(sourceSong);
+    enrichedCandidates = await enrichSongsWithDJMetadata(candidateSongs);
+  } else {
+    enrichedSource = sourceSong as SongWithDJMetadata;
+    enrichedCandidates = candidateSongs as SongWithDJMetadata[];
+  }
+
+  // Calculate DJ scores for all candidates
+  const scoredCandidates = enrichedCandidates.map(candidate => ({
+    song: candidate,
+    djScore: calculateDJScore(enrichedSource, candidate, weights),
+  }));
+
+  // Filter by minimum score and sort by total score descending
+  const filteredAndSorted = scoredCandidates
+    .filter(c => c.djScore.totalScore >= minScore)
+    .sort((a, b) => b.djScore.totalScore - a.djScore.totalScore)
+    .slice(0, maxResults);
+
+  console.log(`🎧 [DJ Scorer] Scored ${candidateSongs.length} candidates, ${filteredAndSorted.length} above threshold (${minScore})`);
+
+  return filteredAndSorted;
+}
+
+/**
+ * Find the best DJ transition candidates from a pool of songs
+ * Optimized for quick filtering when BPM is known
+ *
+ * @param sourceSong - The current song
+ * @param candidateSongs - Pool of candidate songs
+ * @param bpmTolerance - BPM tolerance (default 3%)
+ * @returns Top candidates sorted by DJ score
+ */
+export async function findBestDJTransitions(
+  sourceSong: SongWithDJMetadata,
+  candidateSongs: SongWithDJMetadata[],
+  bpmTolerance: number = BPM_THRESHOLDS.TIGHT
+): Promise<Array<{ song: SongWithDJMetadata; djScore: DJScoreResult }>> {
+  // If source has BPM, pre-filter candidates for efficiency
+  let filteredCandidates = candidateSongs;
+
+  if (sourceSong.bpm && sourceSong.bpm > 0) {
+    const minBpm = sourceSong.bpm * (1 - bpmTolerance * 2); // Double tolerance for initial filter
+    const maxBpm = sourceSong.bpm * (1 + bpmTolerance * 2);
+
+    // Also include half-time and double-time ranges
+    const halfTimeBpm = sourceSong.bpm / 2;
+    const doubleTimeBpm = sourceSong.bpm * 2;
+
+    filteredCandidates = candidateSongs.filter(c => {
+      if (!c.bpm || c.bpm <= 0) return true; // Include songs without BPM data
+
+      // Check main BPM range
+      if (c.bpm >= minBpm && c.bpm <= maxBpm) return true;
+
+      // Check half-time range
+      if (Math.abs(c.bpm - halfTimeBpm) / halfTimeBpm <= bpmTolerance * 2) return true;
+
+      // Check double-time range
+      if (Math.abs(c.bpm - doubleTimeBpm) / doubleTimeBpm <= bpmTolerance * 2) return true;
+
+      return false;
+    });
+
+    console.log(`🎧 [DJ Scorer] BPM pre-filter: ${candidateSongs.length} → ${filteredCandidates.length} candidates`);
+  }
+
+  // Score and rank filtered candidates
+  return scoreAndRankForDJ(sourceSong, filteredCandidates, {
+    enrichMetadata: false, // Already enriched
+    minScore: 0.4, // Lower threshold to return more options
+    maxResults: 20,
+  });
+}

--- a/src/lib/services/energy-estimator.ts
+++ b/src/lib/services/energy-estimator.ts
@@ -1,0 +1,423 @@
+/**
+ * Energy Estimator Service
+ *
+ * Estimates energy level (0-1) for songs when actual energy data isn't available.
+ * Uses genre, BPM, and other heuristics to provide reasonable estimates.
+ *
+ * Energy levels:
+ * - 0.0-0.3: Low energy (ambient, ballads, acoustic)
+ * - 0.3-0.5: Medium-low energy (chill, indie, folk)
+ * - 0.5-0.7: Medium energy (pop, rock, R&B)
+ * - 0.7-0.85: High energy (dance, electronic, hip-hop)
+ * - 0.85-1.0: Very high energy (metal, hardcore, EDM bangers)
+ */
+
+// Genre to base energy mapping
+const GENRE_ENERGY_MAP: Record<string, number> = {
+  // Very high energy (0.85-1.0)
+  'metal': 0.95,
+  'hardcore': 0.95,
+  'death metal': 0.95,
+  'black metal': 0.92,
+  'thrash metal': 0.93,
+  'metalcore': 0.90,
+  'dubstep': 0.90,
+  'hardstyle': 0.95,
+  'drum and bass': 0.88,
+  'dnb': 0.88,
+  'jungle': 0.85,
+  'gabber': 0.98,
+  'speedcore': 0.98,
+  'punk': 0.88,
+  'punk rock': 0.85,
+  'hardcore punk': 0.92,
+
+  // High energy (0.7-0.85)
+  'rock': 0.75,
+  'hard rock': 0.80,
+  'alternative rock': 0.72,
+  'grunge': 0.75,
+  'electronic': 0.78,
+  'edm': 0.82,
+  'house': 0.78,
+  'tech house': 0.80,
+  'techno': 0.80,
+  'trance': 0.82,
+  'progressive house': 0.75,
+  'electro': 0.80,
+  'hip-hop': 0.72,
+  'hip hop': 0.72,
+  'rap': 0.75,
+  'trap': 0.78,
+  'grime': 0.80,
+  'dancehall': 0.75,
+  'reggaeton': 0.78,
+  'funk': 0.72,
+  'disco': 0.75,
+  'ska': 0.75,
+
+  // Medium energy (0.5-0.7)
+  'pop': 0.65,
+  'synth-pop': 0.65,
+  'synthpop': 0.65,
+  'dance': 0.70,
+  'pop rock': 0.68,
+  'indie rock': 0.62,
+  'indie': 0.60,
+  'alternative': 0.60,
+  'britpop': 0.65,
+  'r&b': 0.58,
+  'rnb': 0.58,
+  'soul': 0.55,
+  'neo-soul': 0.52,
+  'gospel': 0.60,
+  'country': 0.55,
+  'country rock': 0.60,
+  'blues rock': 0.58,
+  'world': 0.55,
+  'latin': 0.62,
+  'salsa': 0.68,
+  'reggae': 0.50,
+  'dub': 0.48,
+
+  // Medium-low energy (0.3-0.5)
+  'folk': 0.42,
+  'folk rock': 0.48,
+  'singer-songwriter': 0.40,
+  'acoustic': 0.38,
+  'blues': 0.45,
+  'jazz': 0.45,
+  'smooth jazz': 0.35,
+  'bebop': 0.50,
+  'swing': 0.55,
+  'bossa nova': 0.35,
+  'lounge': 0.32,
+  'easy listening': 0.30,
+  'soft rock': 0.45,
+  'trip-hop': 0.42,
+  'downtempo': 0.38,
+  'chillout': 0.35,
+  'chill': 0.35,
+  'lo-fi': 0.35,
+  'lofi': 0.35,
+
+  // Low energy (0.0-0.3)
+  'ambient': 0.20,
+  'new age': 0.22,
+  'meditation': 0.15,
+  'classical': 0.40, // Varies widely, but average
+  'baroque': 0.35,
+  'romantic': 0.42,
+  'minimalist': 0.25,
+  'drone': 0.18,
+  'dark ambient': 0.22,
+  'sleep': 0.12,
+  'relaxation': 0.15,
+  'soundscape': 0.20,
+  'soundtrack': 0.45, // Varies widely
+  'score': 0.45,
+};
+
+// BPM to energy adjustment
+// Faster BPM generally means higher energy
+function getBpmEnergyAdjustment(bpm: number): number {
+  if (bpm <= 60) return -0.15;
+  if (bpm <= 80) return -0.08;
+  if (bpm <= 100) return -0.03;
+  if (bpm <= 120) return 0;
+  if (bpm <= 140) return 0.05;
+  if (bpm <= 160) return 0.10;
+  if (bpm <= 180) return 0.15;
+  return 0.20; // Very fast (180+ BPM)
+}
+
+// Normalize genre string for matching
+function normalizeGenre(genre: string): string {
+  return genre
+    .toLowerCase()
+    .trim()
+    .replace(/[\/\-_]/g, ' ') // Replace separators with spaces
+    .replace(/\s+/g, ' ')     // Normalize whitespace
+    .replace(/[^a-z0-9\s&]/g, ''); // Remove special chars except &
+}
+
+// Find best matching genre from our map
+function findMatchingGenre(genre: string): { genre: string; energy: number } | null {
+  const normalized = normalizeGenre(genre);
+
+  // Direct match
+  if (GENRE_ENERGY_MAP[normalized]) {
+    return { genre: normalized, energy: GENRE_ENERGY_MAP[normalized] };
+  }
+
+  // Check if genre contains any of our known genres
+  let bestMatch: { genre: string; energy: number; matchLength: number } | null = null;
+
+  for (const [knownGenre, energy] of Object.entries(GENRE_ENERGY_MAP)) {
+    if (normalized.includes(knownGenre) || knownGenre.includes(normalized)) {
+      const matchLength = knownGenre.length;
+      if (!bestMatch || matchLength > bestMatch.matchLength) {
+        bestMatch = { genre: knownGenre, energy, matchLength };
+      }
+    }
+  }
+
+  if (bestMatch) {
+    return { genre: bestMatch.genre, energy: bestMatch.energy };
+  }
+
+  // Check individual words in multi-genre strings
+  const words = normalized.split(' ');
+  for (const word of words) {
+    if (word.length >= 3 && GENRE_ENERGY_MAP[word]) {
+      return { genre: word, energy: GENRE_ENERGY_MAP[word] };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Estimate energy for a song based on available metadata
+ *
+ * @param options - Song metadata for estimation
+ * @returns Estimated energy (0-1) and confidence level
+ */
+export function estimateEnergy(options: {
+  genre?: string;
+  bpm?: number;
+  title?: string;
+  artist?: string;
+}): { energy: number; confidence: number; method: string } {
+  const { genre, bpm, title, artist } = options;
+  let energy = 0.5; // Default to medium energy
+  let confidence = 0.3; // Low confidence for default
+  let method = 'default';
+
+  // Step 1: Try to estimate from genre (most reliable)
+  if (genre) {
+    const genreMatch = findMatchingGenre(genre);
+    if (genreMatch) {
+      energy = genreMatch.energy;
+      confidence = 0.7;
+      method = `genre:${genreMatch.genre}`;
+    }
+  }
+
+  // Step 2: Adjust based on BPM if available
+  if (bpm && bpm > 0) {
+    const bpmAdjustment = getBpmEnergyAdjustment(bpm);
+    energy = Math.max(0, Math.min(1, energy + bpmAdjustment));
+
+    // BPM increases confidence if we have genre
+    if (method.startsWith('genre:')) {
+      confidence = Math.min(0.85, confidence + 0.1);
+      method += `,bpm:${bpm}`;
+    } else {
+      // BPM-only estimation
+      confidence = 0.5;
+      method = `bpm:${bpm}`;
+
+      // BPM-based energy estimation when no genre
+      if (bpm <= 70) energy = 0.35;
+      else if (bpm <= 90) energy = 0.45;
+      else if (bpm <= 110) energy = 0.55;
+      else if (bpm <= 130) energy = 0.65;
+      else if (bpm <= 150) energy = 0.75;
+      else if (bpm <= 170) energy = 0.85;
+      else energy = 0.90;
+    }
+  }
+
+  // Step 3: Heuristics from title/artist (last resort)
+  if (confidence < 0.5 && (title || artist)) {
+    const text = `${title || ''} ${artist || ''}`.toLowerCase();
+
+    // Energy boosting keywords
+    const highEnergyKeywords = [
+      'remix', 'dance', 'party', 'club', 'bass', 'drop', 'hard',
+      'fast', 'energy', 'fire', 'loud', 'intense', 'rage', 'wild',
+    ];
+
+    // Energy lowering keywords
+    const lowEnergyKeywords = [
+      'acoustic', 'unplugged', 'ballad', 'slow', 'soft', 'quiet',
+      'piano', 'stripped', 'ambient', 'relax', 'sleep', 'calm',
+      'peaceful', 'gentle', 'tender', 'lullaby',
+    ];
+
+    let keywordAdjustment = 0;
+    let keywordCount = 0;
+
+    for (const keyword of highEnergyKeywords) {
+      if (text.includes(keyword)) {
+        keywordAdjustment += 0.08;
+        keywordCount++;
+      }
+    }
+
+    for (const keyword of lowEnergyKeywords) {
+      if (text.includes(keyword)) {
+        keywordAdjustment -= 0.08;
+        keywordCount++;
+      }
+    }
+
+    if (keywordCount > 0) {
+      energy = Math.max(0, Math.min(1, energy + keywordAdjustment));
+      confidence = Math.min(0.6, confidence + (keywordCount * 0.05));
+      method += `,keywords:${keywordCount}`;
+    }
+  }
+
+  return {
+    energy: Math.round(energy * 100) / 100, // Round to 2 decimal places
+    confidence: Math.round(confidence * 100) / 100,
+    method,
+  };
+}
+
+/**
+ * Estimate energy for multiple songs efficiently
+ *
+ * @param songs - Array of song metadata
+ * @returns Map of song ID to energy estimation
+ */
+export function estimateEnergyBatch(
+  songs: Array<{
+    id: string;
+    genre?: string;
+    bpm?: number;
+    title?: string;
+    artist?: string;
+  }>
+): Map<string, { energy: number; confidence: number; method: string }> {
+  const results = new Map<string, { energy: number; confidence: number; method: string }>();
+
+  for (const song of songs) {
+    const estimation = estimateEnergy({
+      genre: song.genre,
+      bpm: song.bpm,
+      title: song.title,
+      artist: song.artist,
+    });
+
+    results.set(song.id, estimation);
+  }
+
+  return results;
+}
+
+/**
+ * Get all supported genres and their energy levels
+ * Useful for debugging and UI display
+ */
+export function getSupportedGenres(): Array<{ genre: string; energy: number }> {
+  return Object.entries(GENRE_ENERGY_MAP)
+    .map(([genre, energy]) => ({ genre, energy }))
+    .sort((a, b) => b.energy - a.energy);
+}
+
+/**
+ * Calculate energy compatibility between two songs
+ * Returns how well two songs flow together energy-wise
+ *
+ * @param energy1 - First song's energy (0-1)
+ * @param energy2 - Second song's energy (0-1)
+ * @param direction - Preferred energy direction ('rising', 'falling', 'stable')
+ * @returns Compatibility score (0-1)
+ */
+export function calculateEnergyCompatibility(
+  energy1: number,
+  energy2: number,
+  direction: 'rising' | 'falling' | 'stable' | 'any' = 'any'
+): { score: number; relationship: string } {
+  const diff = energy2 - energy1;
+  const absDiff = Math.abs(diff);
+
+  // Base compatibility on energy difference
+  // Small differences are always compatible
+  if (absDiff <= 0.1) {
+    return { score: 0.95, relationship: 'Same energy level' };
+  }
+
+  // Check direction preference
+  if (direction === 'rising' && diff > 0) {
+    // Rising energy is desired
+    if (diff <= 0.2) return { score: 0.90, relationship: 'Gentle energy rise' };
+    if (diff <= 0.35) return { score: 0.80, relationship: 'Moderate energy rise' };
+    return { score: 0.65, relationship: 'Large energy jump up' };
+  }
+
+  if (direction === 'falling' && diff < 0) {
+    // Falling energy is desired
+    if (absDiff <= 0.2) return { score: 0.90, relationship: 'Gentle energy drop' };
+    if (absDiff <= 0.35) return { score: 0.80, relationship: 'Moderate energy drop' };
+    return { score: 0.65, relationship: 'Large energy drop' };
+  }
+
+  if (direction === 'stable') {
+    // Want to maintain energy
+    if (absDiff <= 0.15) return { score: 0.85, relationship: 'Energy maintained' };
+    if (absDiff <= 0.25) return { score: 0.65, relationship: 'Slight energy change' };
+    return { score: 0.40, relationship: 'Energy level mismatch' };
+  }
+
+  // Direction is 'any' - moderate changes are fine
+  if (absDiff <= 0.2) return { score: 0.85, relationship: 'Similar energy' };
+  if (absDiff <= 0.35) return { score: 0.70, relationship: 'Moderate energy shift' };
+  if (absDiff <= 0.5) return { score: 0.50, relationship: 'Significant energy shift' };
+
+  return { score: 0.30, relationship: 'Energy mismatch' };
+}
+
+/**
+ * Suggest target energy for the next song in a DJ set
+ *
+ * @param currentEnergy - Current song's energy
+ * @param setPosition - Position in the set (0-1, where 0.5 is peak time)
+ * @param style - DJ style preference
+ * @returns Suggested energy range for next song
+ */
+export function suggestNextEnergy(
+  currentEnergy: number,
+  setPosition: number = 0.5,
+  style: 'buildup' | 'peak' | 'cooldown' | 'dynamic' = 'dynamic'
+): { min: number; max: number; target: number } {
+  let targetDelta = 0;
+
+  switch (style) {
+    case 'buildup':
+      // Gradually increase energy
+      targetDelta = 0.05 + (setPosition * 0.1);
+      break;
+
+    case 'peak':
+      // Maintain high energy
+      targetDelta = Math.random() * 0.1 - 0.05; // Small variations
+      break;
+
+    case 'cooldown':
+      // Gradually decrease energy
+      targetDelta = -0.05 - ((1 - setPosition) * 0.1);
+      break;
+
+    case 'dynamic':
+      // Follow a wave pattern based on set position
+      // Early set: build up, mid set: peak, late set: cool down
+      if (setPosition < 0.3) {
+        targetDelta = 0.05 + (setPosition * 0.15);
+      } else if (setPosition < 0.7) {
+        targetDelta = Math.random() * 0.15 - 0.05; // Peak variations
+      } else {
+        targetDelta = -0.05 - ((setPosition - 0.7) * 0.15);
+      }
+      break;
+  }
+
+  const target = Math.max(0, Math.min(1, currentEnergy + targetDelta));
+  const min = Math.max(0, target - 0.15);
+  const max = Math.min(1, target + 0.15);
+
+  return { min, max, target };
+}

--- a/src/lib/services/liked-songs-sync.ts
+++ b/src/lib/services/liked-songs-sync.ts
@@ -1,0 +1,314 @@
+/**
+ * Liked Songs Sync Service
+ *
+ * Syncs Navidrome starred songs to the recommendation feedback table.
+ * This gives liked songs a 25% weight in the profile-based recommendation system.
+ *
+ * Key behaviors:
+ * - Syncs starred songs as thumbs_up feedback with source='library'
+ * - Tracks un-starred songs to avoid double-counting
+ * - Runs as part of compound score calculation
+ *
+ * @see docs/architecture/profile-based-recommendations.md
+ */
+
+import { db } from '../db';
+import {
+  recommendationFeedback,
+  likedSongsSync,
+  type LikedSongsSyncInsert,
+} from '../db/schema';
+import { eq, and, inArray } from 'drizzle-orm';
+import { getStarredSongs } from './navidrome';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface SyncResult {
+  synced: number;
+  unstarred: number;
+  unchanged: number;
+  errors: number;
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get current temporal metadata for feedback records
+ */
+function getTemporalMetadata() {
+  const now = new Date();
+  const month = now.getMonth() + 1; // 1-12
+  const dayOfWeek = now.getDay() === 0 ? 7 : now.getDay(); // 1-7 (Monday = 1)
+  const hourOfDay = now.getHours(); // 0-23
+
+  // Determine season
+  let season: 'spring' | 'summer' | 'fall' | 'winter';
+  if (month >= 3 && month <= 5) {
+    season = 'spring';
+  } else if (month >= 6 && month <= 8) {
+    season = 'summer';
+  } else if (month >= 9 && month <= 11) {
+    season = 'fall';
+  } else {
+    season = 'winter';
+  }
+
+  return { month, dayOfWeek, hourOfDay, season };
+}
+
+// ============================================================================
+// Main Sync Functions
+// ============================================================================
+
+/**
+ * Sync Navidrome starred songs to the feedback table as thumbs_up
+ *
+ * This function:
+ * 1. Fetches all starred songs from Navidrome
+ * 2. Checks which songs are already synced
+ * 3. Adds new starred songs as thumbs_up feedback
+ * 4. Marks un-starred songs as inactive (doesn't delete feedback)
+ *
+ * @param userId - The user's ID
+ * @returns Sync result statistics
+ */
+export async function syncLikedSongsToFeedback(userId: string): Promise<SyncResult> {
+  console.log(`💜 [LikedSongsSync] Syncing starred songs for user ${userId}`);
+
+  const result: SyncResult = {
+    synced: 0,
+    unstarred: 0,
+    unchanged: 0,
+    errors: 0,
+  };
+
+  try {
+    // Step 1: Fetch starred songs from Navidrome
+    const starredSongs = await getStarredSongs();
+    console.log(`💜 [LikedSongsSync] Found ${starredSongs.length} starred songs in Navidrome`);
+
+    if (starredSongs.length === 0) {
+      console.log(`💜 [LikedSongsSync] No starred songs to sync`);
+      return result;
+    }
+
+    // Step 2: Get existing sync records for this user
+    const existingSync = await db
+      .select()
+      .from(likedSongsSync)
+      .where(eq(likedSongsSync.userId, userId));
+
+    const existingSyncMap = new Map(
+      existingSync.map(s => [s.songId, s])
+    );
+
+    // Step 3: Build set of current starred song IDs
+    const currentStarredIds = new Set(starredSongs.map(s => s.id));
+
+    // Step 4: Process each starred song
+    const temporal = getTemporalMetadata();
+
+    for (const song of starredSongs) {
+      const existing = existingSyncMap.get(song.id);
+
+      if (existing && existing.isActive === 1) {
+        // Already synced and active, no change needed
+        result.unchanged++;
+        continue;
+      }
+
+      try {
+        const songArtistTitle = `${song.artist || 'Unknown'} - ${song.title}`;
+
+        if (existing) {
+          // Was previously synced but marked inactive, reactivate
+          await db
+            .update(likedSongsSync)
+            .set({
+              isActive: 1,
+              syncedAt: new Date(),
+            })
+            .where(eq(likedSongsSync.id, existing.id));
+        } else {
+          // New starred song, create sync record
+          const syncRecord: LikedSongsSyncInsert = {
+            userId,
+            songId: song.id,
+            artist: song.artist || 'Unknown',
+            title: song.title,
+            isActive: 1,
+          };
+
+          await db
+            .insert(likedSongsSync)
+            .values(syncRecord)
+            .onConflictDoUpdate({
+              target: [likedSongsSync.userId, likedSongsSync.songId],
+              set: {
+                isActive: 1,
+                syncedAt: new Date(),
+              },
+            });
+        }
+
+        // Upsert feedback record as thumbs_up with source='library'
+        await db
+          .insert(recommendationFeedback)
+          .values({
+            userId,
+            songId: song.id,
+            songArtistTitle,
+            feedbackType: 'thumbs_up',
+            source: 'library',
+            month: temporal.month,
+            season: temporal.season,
+            dayOfWeek: temporal.dayOfWeek,
+            hourOfDay: temporal.hourOfDay,
+          })
+          .onConflictDoNothing();
+
+        result.synced++;
+      } catch (error) {
+        console.error(`💜 [LikedSongsSync] Error syncing song ${song.id}:`, error);
+        result.errors++;
+      }
+    }
+
+    // Step 5: Mark un-starred songs as inactive
+    const previouslyActiveSongIds = existingSync
+      .filter(s => s.isActive === 1)
+      .map(s => s.songId);
+
+    const unstarredIds = previouslyActiveSongIds.filter(id => !currentStarredIds.has(id));
+
+    if (unstarredIds.length > 0) {
+      await db
+        .update(likedSongsSync)
+        .set({ isActive: 0 })
+        .where(
+          and(
+            eq(likedSongsSync.userId, userId),
+            inArray(likedSongsSync.songId, unstarredIds)
+          )
+        );
+
+      result.unstarred = unstarredIds.length;
+      console.log(`💜 [LikedSongsSync] Marked ${unstarredIds.length} songs as un-starred`);
+    }
+
+    console.log(`💜 [LikedSongsSync] Sync complete: ${result.synced} synced, ${result.unstarred} un-starred, ${result.unchanged} unchanged, ${result.errors} errors`);
+
+    return result;
+  } catch (error) {
+    console.error(`💜 [LikedSongsSync] Failed to sync liked songs:`, error);
+    throw error;
+  }
+}
+
+/**
+ * Get all actively liked song IDs for a user
+ * Used for filtering and boosting recommendations
+ *
+ * @param userId - The user's ID
+ * @returns Set of song IDs that are currently liked
+ */
+export async function getLikedSongIds(userId: string): Promise<Set<string>> {
+  const likedSongs = await db
+    .select({ songId: likedSongsSync.songId })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    );
+
+  return new Set(likedSongs.map(s => s.songId));
+}
+
+/**
+ * Get liked songs by a specific artist for a user
+ * Used for genre-based recommendations
+ *
+ * @param userId - The user's ID
+ * @param artist - Artist name to filter by
+ * @returns Array of liked song IDs by this artist
+ */
+export async function getLikedSongsByArtist(
+  userId: string,
+  artist: string
+): Promise<string[]> {
+  const normalizedArtist = artist.toLowerCase();
+
+  const likedSongs = await db
+    .select({ songId: likedSongsSync.songId })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    );
+
+  // Filter by artist (case-insensitive)
+  // Note: For better performance, we could add a normalized_artist column
+  const artistSongs = await db
+    .select()
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    );
+
+  return artistSongs
+    .filter(s => s.artist.toLowerCase() === normalizedArtist)
+    .map(s => s.songId);
+}
+
+/**
+ * Check if a song is liked by the user
+ *
+ * @param userId - The user's ID
+ * @param songId - The song ID to check
+ * @returns True if the song is liked
+ */
+export async function isSongLiked(userId: string, songId: string): Promise<boolean> {
+  const result = await db
+    .select({ isActive: likedSongsSync.isActive })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.songId, songId)
+      )
+    )
+    .limit(1);
+
+  return result.length > 0 && result[0].isActive === 1;
+}
+
+/**
+ * Get the count of liked songs for a user
+ *
+ * @param userId - The user's ID
+ * @returns Number of liked songs
+ */
+export async function getLikedSongsCount(userId: string): Promise<number> {
+  const result = await db
+    .select({ songId: likedSongsSync.songId })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    );
+
+  return result.length;
+}

--- a/src/lib/services/navidrome.ts
+++ b/src/lib/services/navidrome.ts
@@ -237,6 +237,19 @@ export interface SubsonicSong {
   rating?: number;
   loved?: boolean;
   bitrate?: number;
+  // DJ-related metadata (from ID3 tags if available)
+  bpm?: number;           // Beats per minute (TBPM tag)
+  musicBrainzId?: string; // MusicBrainz ID for external lookups
+}
+
+// Extended song metadata for DJ features
+export interface ExtendedSongMetadata {
+  id: string;
+  bpm?: number;           // BPM from ID3 TBPM tag
+  key?: string;           // Musical key from ID3 TKEY tag (e.g., "Am", "C", "F#m")
+  energy?: number;        // Energy level 0-1 (estimated if not available)
+  fetchedAt: number;      // Timestamp when metadata was fetched
+  source: 'navidrome' | 'estimated'; // Where the data came from
 }
 
 export interface NavidromePlaylist {
@@ -1802,6 +1815,101 @@ export async function getMostPlayedSongs(limit: number = 5): Promise<SubsonicSon
  * Get recently played songs
  * Uses Navidrome's getNowPlaying or getAlbumList2 with type=recent
  */
+/**
+ * Get extended metadata for a single song
+ * Uses Subsonic API getSong to fetch detailed song info including BPM/key from ID3 tags
+ *
+ * @param songId - The Navidrome song ID
+ * @returns Extended song metadata with BPM, key, etc.
+ */
+export async function getSongWithExtendedMetadata(songId: string): Promise<ExtendedSongMetadata> {
+  try {
+    // Use Subsonic getSong endpoint which returns full song details
+    const endpoint = `/rest/getSong?id=${encodeURIComponent(songId)}`;
+    const data = await apiFetch(endpoint) as any;
+
+    // Handle Subsonic response structure
+    const song = data['subsonic-response']?.song || data.song;
+
+    if (!song) {
+      throw new ServiceError('NAVIDROME_API_ERROR', `Song not found: ${songId}`);
+    }
+
+    // Extract BPM and key from response
+    // Navidrome may expose these via custom fields or standard Subsonic fields
+    const bpm = song.bpm ? parseInt(song.bpm) : undefined;
+    const key = song.musicBrainzId ? undefined : undefined; // Key is not standard in Subsonic API
+
+    // Note: Navidrome/Subsonic API doesn't expose key directly
+    // We'll need to rely on the metadata cache and estimation for key
+
+    return {
+      id: songId,
+      bpm: bpm && !isNaN(bpm) ? bpm : undefined,
+      key: undefined, // Key detection will be handled separately
+      energy: undefined, // Energy estimation will be handled separately
+      fetchedAt: Date.now(),
+      source: bpm ? 'navidrome' : 'estimated',
+    };
+  } catch (error) {
+    console.warn(`Failed to get extended metadata for song ${songId}:`, error);
+    return {
+      id: songId,
+      bpm: undefined,
+      key: undefined,
+      energy: undefined,
+      fetchedAt: Date.now(),
+      source: 'estimated',
+    };
+  }
+}
+
+/**
+ * Get extended metadata for multiple songs in batch
+ * More efficient than calling getSongWithExtendedMetadata for each song
+ *
+ * @param songIds - Array of Navidrome song IDs
+ * @returns Map of songId to extended metadata
+ */
+export async function getSongsWithExtendedMetadata(songIds: string[]): Promise<Map<string, ExtendedSongMetadata>> {
+  const results = new Map<string, ExtendedSongMetadata>();
+
+  if (songIds.length === 0) return results;
+
+  // Navidrome doesn't have a batch getSong endpoint, so we'll use the native API
+  // which returns more fields when querying by ID
+  try {
+    const songs = await getSongsByIds(songIds);
+
+    for (const song of songs) {
+      // The native API may include genre which we can use for energy estimation
+      results.set(song.id, {
+        id: song.id,
+        bpm: undefined, // Native API doesn't expose BPM
+        key: undefined,
+        energy: undefined,
+        fetchedAt: Date.now(),
+        source: 'estimated',
+      });
+    }
+
+    // For songs with missing data, try to get via Subsonic API (slower but more complete)
+    const missingSongIds = songIds.filter(id => !results.has(id));
+    for (const songId of missingSongIds.slice(0, 10)) { // Limit to avoid too many requests
+      try {
+        const metadata = await getSongWithExtendedMetadata(songId);
+        results.set(songId, metadata);
+      } catch {
+        // Skip failed songs
+      }
+    }
+  } catch (error) {
+    console.warn('Failed to get batch extended metadata:', error);
+  }
+
+  return results;
+}
+
 export async function getRecentlyPlayedSongs(limit: number = 10): Promise<SubsonicSong[]> {
   try {
     // Get recently played albums

--- a/src/lib/services/navidrome.ts
+++ b/src/lib/services/navidrome.ts
@@ -1443,8 +1443,6 @@ export async function searchSongsByCriteria(criteria: {
     const matchedSongs: SubsonicSong[] = [];
     const seedSongIds: string[] = [];
 
-    console.log('🎯 Smart Playlist Criteria:', JSON.stringify(criteria, null, 2));
-
     // Strategy 1: If artists specified, find seed songs and get recommendations
     if (criteria.artists && criteria.artists.length > 0) {
       console.log('🎨 Building recommendations from seed artists:', criteria.artists);
@@ -1672,18 +1670,11 @@ export async function getTopArtists(limit: number = 5): Promise<ArtistWithDetail
     const endpoint = `/rest/getAlbumList2?type=frequent&size=100`;
     const data = await apiFetch(endpoint) as any;
 
-    console.log('🎨 [getTopArtists] Raw API response:', JSON.stringify(data, null, 2));
-
     // Extract albums from response
     const albums = data?.['subsonic-response']?.albumList2?.album ||
                    data?.albumList2?.album ||
                    data?.album ||
                    [];
-
-    console.log('🎨 [getTopArtists] Found albums:', albums.length);
-    if (albums.length > 0) {
-      console.log('🎨 [getTopArtists] First album sample:', JSON.stringify(albums[0], null, 2));
-    }
 
     if (!albums || albums.length === 0) {
       // Fallback to song count method

--- a/src/lib/services/profile-recommendations.ts
+++ b/src/lib/services/profile-recommendations.ts
@@ -1,0 +1,533 @@
+/**
+ * Profile-Based Recommendation Service
+ *
+ * Main service for the profile-based AI DJ recommendation system.
+ * Uses pre-computed profile data to generate recommendations with ZERO API calls.
+ *
+ * Profile Score Formula:
+ * profileScore = (
+ *   compoundScore * 0.30 +           // Pre-computed listening correlation
+ *   likedBoost * 0.25 +              // Is this a liked/starred song?
+ *   similarityScore * 0.20 +         // How similar to seed (from cache)
+ *   artistAffinityScore * 0.15 +     // User's affinity for this artist
+ *   (1 - skipPenalty) * 0.05 +       // Avoid frequently skipped
+ *   temporalBoost * 0.05             // Time-of-day/season match
+ * )
+ *
+ * @see docs/architecture/profile-based-recommendations.md
+ */
+
+import { db } from '../db';
+import {
+  trackSimilarities,
+  compoundScores,
+  likedSongsSync,
+} from '../db/schema';
+import { eq, and, gte, desc, inArray, ne, sql } from 'drizzle-orm';
+import type { Song } from '@/lib/types/song';
+import { getCompoundScoredRecommendations } from './compound-scoring';
+import { getLikedSongIds } from './liked-songs-sync';
+import {
+  getArtistAffinity,
+  getArtistAffinities,
+  getTemporalGenreBoost,
+  getCurrentTimeContext,
+} from './artist-affinity';
+import { calculateSkipScores } from './skip-scoring';
+import { searchSongsQuick as searchSongs } from './navidrome';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+// Profile score weights
+const COMPOUND_WEIGHT = 0.30;      // Pre-computed listening correlation
+const LIKED_WEIGHT = 0.25;         // Liked/starred songs (strong explicit signal)
+const SIMILARITY_WEIGHT = 0.20;   // Similarity to seed song
+const ARTIST_AFFINITY_WEIGHT = 0.15;  // User's artist affinity
+const SKIP_AVOIDANCE_WEIGHT = 0.05;   // Avoid frequently skipped
+const TEMPORAL_WEIGHT = 0.05;     // Time-of-day/season match
+
+// Diversity constraints
+const MAX_SONGS_PER_ARTIST = 1;    // Maximum songs from same artist in results
+const MAX_SIMILAR_GENRE_RATIO = 0.7;  // Maximum 70% from same genre
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ProfileRecommendationOptions {
+  /** Maximum number of recommendations to return */
+  limit?: number;
+  /** Song IDs to exclude */
+  excludeSongIds?: string[];
+  /** Artist names to exclude */
+  excludeArtists?: string[];
+  /** Enforce diversity constraints */
+  enforceDiversity?: boolean;
+}
+
+export interface ScoredCandidate {
+  songId: string;
+  artist: string;
+  title: string;
+  genre?: string;
+  profileScore: number;
+  components: {
+    compoundScore: number;
+    likedBoost: number;
+    similarityScore: number;
+    artistAffinity: number;
+    skipAvoidance: number;
+    temporalBoost: number;
+  };
+}
+
+// ============================================================================
+// Helper Functions
+// ============================================================================
+
+/**
+ * Get cached similar tracks for a seed song (NO API CALL)
+ */
+async function getCachedSimilarTracks(
+  artist: string,
+  title: string,
+  limit: number = 50
+): Promise<Array<{ songId: string; artist: string; title: string; matchScore: number }>> {
+  const similarTracks = await db
+    .select({
+      songId: trackSimilarities.targetSongId,
+      artist: trackSimilarities.targetArtist,
+      title: trackSimilarities.targetTitle,
+      matchScore: trackSimilarities.matchScore,
+    })
+    .from(trackSimilarities)
+    .where(
+      and(
+        eq(trackSimilarities.sourceArtist, artist),
+        eq(trackSimilarities.sourceTitle, title),
+        gte(trackSimilarities.expiresAt, new Date())
+      )
+    )
+    .orderBy(desc(trackSimilarities.matchScore))
+    .limit(limit);
+
+  // Filter out null songIds (tracks not in library)
+  return similarTracks.filter(t => t.songId !== null) as Array<{
+    songId: string;
+    artist: string;
+    title: string;
+    matchScore: number;
+  }>;
+}
+
+/**
+ * Get liked songs from the same genre as the seed song
+ */
+async function getLikedSongsInGenre(
+  userId: string,
+  seedGenre: string | undefined,
+  limit: number = 20
+): Promise<string[]> {
+  if (!seedGenre) return [];
+
+  // Get all liked song IDs
+  const likedSongs = await db
+    .select({
+      songId: likedSongsSync.songId,
+    })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    )
+    .limit(limit * 2); // Get extra to filter
+
+  return likedSongs.map(s => s.songId);
+}
+
+/**
+ * Merge candidates from different sources and deduplicate
+ */
+function mergeCandidates(
+  similarTracks: Array<{ songId: string; artist: string; title: string; matchScore: number }>,
+  compoundRecommendations: Array<{ songId: string; artist: string; title: string; recencyWeightedScore: number }>,
+  likedSongIds: string[]
+): Map<string, { artist: string; title: string; similarityScore: number; isFromCompound: boolean; isLiked: boolean }> {
+  const candidateMap = new Map<string, {
+    artist: string;
+    title: string;
+    similarityScore: number;
+    isFromCompound: boolean;
+    isLiked: boolean;
+  }>();
+
+  // Add similar tracks
+  for (const track of similarTracks) {
+    candidateMap.set(track.songId, {
+      artist: track.artist,
+      title: track.title,
+      similarityScore: track.matchScore,
+      isFromCompound: false,
+      isLiked: false,
+    });
+  }
+
+  // Add compound recommendations (merge if already present)
+  for (const rec of compoundRecommendations) {
+    const existing = candidateMap.get(rec.songId);
+    if (existing) {
+      existing.isFromCompound = true;
+    } else {
+      candidateMap.set(rec.songId, {
+        artist: rec.artist,
+        title: rec.title,
+        similarityScore: 0, // Not directly similar to seed
+        isFromCompound: true,
+        isLiked: false,
+      });
+    }
+  }
+
+  // Mark liked songs
+  for (const songId of likedSongIds) {
+    const existing = candidateMap.get(songId);
+    if (existing) {
+      existing.isLiked = true;
+    }
+  }
+
+  return candidateMap;
+}
+
+/**
+ * Enforce diversity constraints on scored candidates
+ */
+function enforceDiversity(
+  candidates: ScoredCandidate[],
+  maxPerArtist: number = MAX_SONGS_PER_ARTIST
+): ScoredCandidate[] {
+  const artistCounts = new Map<string, number>();
+  const result: ScoredCandidate[] = [];
+
+  // Sort by profile score descending
+  const sorted = [...candidates].sort((a, b) => b.profileScore - a.profileScore);
+
+  for (const candidate of sorted) {
+    const normalizedArtist = candidate.artist.toLowerCase();
+    const currentCount = artistCounts.get(normalizedArtist) || 0;
+
+    if (currentCount < maxPerArtist) {
+      result.push(candidate);
+      artistCounts.set(normalizedArtist, currentCount + 1);
+    }
+  }
+
+  return result;
+}
+
+// ============================================================================
+// Main Recommendation Function
+// ============================================================================
+
+/**
+ * Get profile-based recommendations for a seed song
+ *
+ * This function:
+ * 1. Gets cached similar tracks for seed (NO API call)
+ * 2. Gets top compound-scored songs (pre-computed)
+ * 3. Gets liked songs
+ * 4. Merges all candidates
+ * 5. Scores each candidate using profile weights
+ * 6. Applies diversity rules
+ * 7. Returns top N recommendations
+ *
+ * @param userId - The user's ID
+ * @param seedSong - The currently playing song
+ * @param options - Recommendation options
+ * @returns Array of recommended songs
+ */
+export async function getProfileBasedRecommendations(
+  userId: string,
+  seedSong: Song,
+  options: ProfileRecommendationOptions = {}
+): Promise<Song[]> {
+  const {
+    limit = 1, // Default to 1 for drip-feed model
+    excludeSongIds = [],
+    excludeArtists = [],
+    enforceDiversity: shouldEnforceDiversity = true,
+  } = options;
+
+  console.log(`🎯 [ProfileRec] Getting recommendations for "${seedSong.artist} - ${seedSong.title || seedSong.name}"`);
+
+  const seedTitle = seedSong.title || seedSong.name;
+  const seedArtist = seedSong.artist || 'Unknown';
+  const seedGenre = seedSong.genre;
+
+  // Step 1: Get cached similar tracks (NO API call)
+  const similarTracks = await getCachedSimilarTracks(seedArtist, seedTitle, 50);
+  console.log(`🎯 [ProfileRec] Found ${similarTracks.length} cached similar tracks`);
+
+  // Step 2: Get top compound-scored songs (pre-computed)
+  const compoundRecommendations = await getCompoundScoredRecommendations(userId, {
+    limit: 30,
+    excludeSongIds,
+    excludeArtists,
+  });
+  console.log(`🎯 [ProfileRec] Found ${compoundRecommendations.length} compound-scored songs`);
+
+  // Step 3: Get liked songs
+  const likedSongIds = await getLikedSongIds(userId);
+  const likedSongIdsArray = Array.from(likedSongIds);
+  console.log(`🎯 [ProfileRec] User has ${likedSongIds.size} liked songs`);
+
+  // Step 4: Merge candidates
+  const candidateMap = mergeCandidates(similarTracks, compoundRecommendations, likedSongIdsArray);
+  console.log(`🎯 [ProfileRec] Merged ${candidateMap.size} unique candidates`);
+
+  if (candidateMap.size === 0) {
+    console.log(`🎯 [ProfileRec] No candidates found, returning empty`);
+    return [];
+  }
+
+  // Filter out excluded songs and artists
+  const excludeSet = new Set([...excludeSongIds, seedSong.id]);
+  const excludeArtistsLower = excludeArtists.map(a => a.toLowerCase());
+
+  for (const [songId, candidate] of candidateMap) {
+    if (excludeSet.has(songId) || excludeArtistsLower.includes(candidate.artist.toLowerCase())) {
+      candidateMap.delete(songId);
+    }
+  }
+
+  console.log(`🎯 [ProfileRec] ${candidateMap.size} candidates after exclusions`);
+
+  // Step 5: Score each candidate
+  const candidateSongIds = Array.from(candidateMap.keys());
+
+  // Get artist affinities for all candidate artists
+  const candidateArtists = Array.from(new Set(
+    Array.from(candidateMap.values()).map(c => c.artist)
+  ));
+  const artistAffinities = await getArtistAffinities(userId, candidateArtists);
+
+  // Get compound scores for candidates
+  const compoundScoreMap = new Map<string, number>();
+  for (const rec of compoundRecommendations) {
+    // Normalize to 0-1 range (assuming max practical score is around 5)
+    compoundScoreMap.set(rec.songId, Math.min(rec.recencyWeightedScore / 5, 1));
+  }
+
+  // Create mock songs for skip scoring
+  const mockSongs: Song[] = Array.from(candidateMap.entries()).map(([songId, candidate]) => ({
+    id: songId,
+    name: candidate.title,
+    title: candidate.title,
+    artist: candidate.artist,
+    albumId: '',
+    duration: 0,
+    track: 0,
+    url: '',
+  }));
+
+  // Get skip scores
+  const skipScores = await calculateSkipScores(mockSongs, { userId });
+
+  // Score candidates
+  const scoredCandidates: ScoredCandidate[] = [];
+
+  for (const [songId, candidate] of candidateMap) {
+    // Get component scores
+    const compoundScore = compoundScoreMap.get(songId) || 0;
+    const likedBoost = candidate.isLiked ? 1.0 : 0;
+    const similarityScore = candidate.similarityScore;
+    const artistAffinity = artistAffinities.get(candidate.artist.toLowerCase()) || 0;
+
+    // Skip avoidance (invert skip penalty)
+    const skipScore = skipScores.get(songId);
+    const skipAvoidance = skipScore ? (1 - skipScore.skipPenalty) : 1.0;
+
+    // Temporal boost (would need genre info - default to 0 for now)
+    const temporalBoost = seedGenre ? await getTemporalGenreBoost(userId, seedGenre) : 0;
+
+    // Calculate weighted profile score
+    const profileScore = (
+      compoundScore * COMPOUND_WEIGHT +
+      likedBoost * LIKED_WEIGHT +
+      similarityScore * SIMILARITY_WEIGHT +
+      artistAffinity * ARTIST_AFFINITY_WEIGHT +
+      skipAvoidance * SKIP_AVOIDANCE_WEIGHT +
+      temporalBoost * TEMPORAL_WEIGHT
+    );
+
+    scoredCandidates.push({
+      songId,
+      artist: candidate.artist,
+      title: candidate.title,
+      genre: seedGenre, // Placeholder - would need to look up actual genre
+      profileScore,
+      components: {
+        compoundScore,
+        likedBoost,
+        similarityScore,
+        artistAffinity,
+        skipAvoidance,
+        temporalBoost,
+      },
+    });
+  }
+
+  console.log(`🎯 [ProfileRec] Scored ${scoredCandidates.length} candidates`);
+
+  // Step 6: Apply diversity rules
+  let finalCandidates = scoredCandidates;
+  if (shouldEnforceDiversity) {
+    finalCandidates = enforceDiversity(scoredCandidates, MAX_SONGS_PER_ARTIST);
+    console.log(`🎯 [ProfileRec] ${finalCandidates.length} candidates after diversity enforcement`);
+  }
+
+  // Step 7: Get top N and fetch full song data
+  const topCandidates = finalCandidates
+    .sort((a, b) => b.profileScore - a.profileScore)
+    .slice(0, limit);
+
+  if (topCandidates.length === 0) {
+    console.log(`🎯 [ProfileRec] No candidates remaining after filtering`);
+    return [];
+  }
+
+  // Log top candidates for debugging
+  console.log(`🎯 [ProfileRec] Top ${topCandidates.length} candidates:`);
+  for (const candidate of topCandidates) {
+    console.log(`   - "${candidate.artist} - ${candidate.title}" (score: ${candidate.profileScore.toFixed(3)})`);
+    console.log(`     compound=${candidate.components.compoundScore.toFixed(2)}, liked=${candidate.components.likedBoost.toFixed(2)}, similar=${candidate.components.similarityScore.toFixed(2)}, artist=${candidate.components.artistAffinity.toFixed(2)}`);
+  }
+
+  // Fetch full song data from Navidrome
+  const songs: Song[] = [];
+
+  for (const candidate of topCandidates) {
+    try {
+      // Search for the song by artist and title
+      const searchResults = await searchSongs(
+        `${candidate.artist} ${candidate.title}`,
+        3
+      );
+
+      // Find matching song
+      const matchingSong = searchResults.find(s =>
+        s.id === candidate.songId ||
+        (s.artist?.toLowerCase() === candidate.artist.toLowerCase() &&
+         (s.title?.toLowerCase() === candidate.title.toLowerCase() ||
+          s.name?.toLowerCase() === candidate.title.toLowerCase()))
+      );
+
+      if (matchingSong) {
+        songs.push(matchingSong);
+      } else if (searchResults.length > 0) {
+        // Fallback to first search result if exact match not found
+        songs.push(searchResults[0]);
+      }
+    } catch (error) {
+      console.error(`🎯 [ProfileRec] Failed to fetch song "${candidate.artist} - ${candidate.title}":`, error);
+    }
+  }
+
+  console.log(`🎯 [ProfileRec] Returning ${songs.length} recommendations`);
+  return songs;
+}
+
+/**
+ * Get recommendations purely from liked songs (for cold start)
+ *
+ * @param userId - The user's ID
+ * @param limit - Maximum number of recommendations
+ * @returns Array of liked songs (shuffled)
+ */
+export async function getRecommendationsFromLikedSongs(
+  userId: string,
+  limit: number = 5
+): Promise<Song[]> {
+  const likedSongs = await db
+    .select()
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    )
+    .orderBy(sql`RANDOM()`)
+    .limit(limit * 2);
+
+  const songs: Song[] = [];
+
+  for (const liked of likedSongs) {
+    try {
+      const searchResults = await searchSongs(
+        `${liked.artist} ${liked.title}`,
+        1
+      );
+
+      if (searchResults.length > 0) {
+        songs.push(searchResults[0]);
+      }
+
+      if (songs.length >= limit) break;
+    } catch (error) {
+      console.error(`🎯 [ProfileRec] Failed to fetch liked song "${liked.artist} - ${liked.title}":`, error);
+    }
+  }
+
+  return songs;
+}
+
+/**
+ * Check if user has enough profile data for profile-based recommendations
+ *
+ * @param userId - The user's ID
+ * @returns True if user has sufficient profile data
+ */
+export async function hasProfileData(userId: string): Promise<boolean> {
+  // Check if user has any compound scores
+  const scores = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(compoundScores)
+    .where(eq(compoundScores.userId, userId));
+
+  const compoundCount = scores[0]?.count || 0;
+
+  // Check if user has any liked songs synced
+  const liked = await db
+    .select({ count: sql<number>`count(*)` })
+    .from(likedSongsSync)
+    .where(
+      and(
+        eq(likedSongsSync.userId, userId),
+        eq(likedSongsSync.isActive, 1)
+      )
+    );
+
+  const likedCount = liked[0]?.count || 0;
+
+  // User has profile data if they have either compound scores or liked songs
+  return compoundCount > 0 || likedCount > 0;
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export {
+  COMPOUND_WEIGHT,
+  LIKED_WEIGHT,
+  SIMILARITY_WEIGHT,
+  ARTIST_AFFINITY_WEIGHT,
+  SKIP_AVOIDANCE_WEIGHT,
+  TEMPORAL_WEIGHT,
+  MAX_SONGS_PER_ARTIST,
+};

--- a/src/lib/services/smart-playlist-evaluator.ts
+++ b/src/lib/services/smart-playlist-evaluator.ts
@@ -27,7 +27,6 @@ interface SmartPlaylistRules {
  * Evaluate smart playlist rules and return matching songs
  */
 export async function evaluateSmartPlaylistRules(rules: SmartPlaylistRules): Promise<SubsonicSong[]> {
-  console.log('🔍 Evaluating smart playlist rules:', JSON.stringify(rules, null, 2));
 
   try {
     // Get all songs from library
@@ -129,8 +128,6 @@ function applyCondition(songs: SubsonicSong[], condition: RuleCondition): Subson
 
   const field = Object.keys(fieldValue)[0];
   const value = fieldValue[field];
-
-  console.log(`  📌 Applying condition: ${operator} ${field} ${JSON.stringify(value)}`);
 
   return songs.filter(song => {
     const songValue = getSongField(song, field);

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -1154,17 +1154,15 @@ export const useAudioStore = create<AudioState>()(
         const preferencesState = usePreferencesStore.getState();
         const { recommendationSettings } = preferencesState.preferences;
 
-        // Build exclusions list - recent songs in queue
-        const recentlyPlayed = state.playlist.slice(
-          Math.max(0, state.currentSongIndex - 10),
-          state.currentSongIndex + 5
-        ).map(song => song.id);
+        // Build exclusions list - ALL songs in queue (prevent duplicates)
+        // This fixes the "duplicate key" React errors when same song is added twice
+        const allPlaylistSongIds = state.playlist.map(song => song.id);
 
         const recentlyRecommended = state.aiDJRecentlyRecommended
           .filter(rec => Date.now() - rec.timestamp < 7200000) // 2 hour window
           .map(rec => rec.songId);
 
-        const allExclusions = [...new Set([...recentlyRecommended, ...recentlyPlayed])];
+        const allExclusions = [...new Set([...recentlyRecommended, ...allPlaylistSongIds])];
 
         // Call API - use larger batch for nudge mode
         const batchSize = Math.max(recommendationSettings.aiDJBatchSize || 3, 5);

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -302,9 +302,9 @@ export const useAudioStore = create<AudioState>()(
     aiDJArtistBatchCounts: new Map<string, {count: number; lastQueued: number}>(),
     aiDJArtistFatigueCooldowns: new Map<string, number>(),
     aiDJUserActionInProgress: false,
-    // Crossfade initial state
+    // Crossfade initial state (default 0 = opt-in, user sets via Settings > Playback)
     crossfadeEnabled: true,
-    crossfadeDuration: 8.0,
+    crossfadeDuration: 0,
     lastClearedQueue: null,
     queuePanelOpen: false,
     recentlyPlayedIds: [],

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -984,7 +984,22 @@ export const useAudioStore = create<AudioState>()(
         }
 
         // Add recommendations to queue
-        const newPlaylist = [...state.playlist, ...recommendations];
+        // For drip-feed: insert RIGHT AFTER current song (plays next)
+        // For threshold refill: append to end of queue
+        let newPlaylist: Song[];
+        if (isDripTrigger) {
+          // Insert after current song position
+          const insertIndex = state.currentSongIndex + 1;
+          newPlaylist = [
+            ...state.playlist.slice(0, insertIndex),
+            ...recommendations,
+            ...state.playlist.slice(insertIndex),
+          ];
+          console.log(`🎵 AI DJ: Drip recommendation inserted at position ${insertIndex} (plays next)`);
+        } else {
+          // Threshold refill - append to end
+          newPlaylist = [...state.playlist, ...recommendations];
+        }
         const newQueuedIds = new Set(state.aiQueuedSongIds);
 
         // Track newly recommended songs with artist info

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -38,6 +38,8 @@ export interface RecommendationSettings {
   // Queue Seeding - inject recommendations throughout queue immediately
   aiDJSeedQueueEnabled?: boolean; // Seed recommendations throughout queue when AI DJ is enabled
   aiDJSeedDensity?: number; // How many recommendations per 10 songs (1-5, default: 2)
+  // Drip-feed model: add 1 recommendation every N songs (2-5, default: 3)
+  aiDJDripInterval?: number;
   // Playlist Autoplay Queueing with Smart Transitions
   autoplayEnabled: boolean; // Master toggle for autoplay when playlist ends
   autoplayBlendMode: 'crossfade' | 'silence' | 'reverb_tail'; // Transition effect between songs

--- a/src/lib/stores/preferences.ts
+++ b/src/lib/stores/preferences.ts
@@ -31,6 +31,13 @@ export interface RecommendationSettings {
   harmonicMixingEnabled?: boolean; // Show BPM/key compatibility in recommendations
   harmonicMixingMode?: 'strict' | 'flexible' | 'off'; // Strictness of harmonic matching
   bpmTolerance?: number; // Max BPM difference percentage (default: 6%)
+  // DJ Matching Settings (BPM/Energy/Key)
+  djMatchingEnabled?: boolean; // Enable BPM/energy/key scoring for AI DJ recommendations
+  bpmAnalysisEnabled?: boolean; // Auto-analyze BPM during playback using Web Audio API
+  djMatchingMinScore?: number; // Minimum DJ score threshold (0-1, default: 0.5)
+  // Queue Seeding - inject recommendations throughout queue immediately
+  aiDJSeedQueueEnabled?: boolean; // Seed recommendations throughout queue when AI DJ is enabled
+  aiDJSeedDensity?: number; // How many recommendations per 10 songs (1-5, default: 2)
   // Playlist Autoplay Queueing with Smart Transitions
   autoplayEnabled: boolean; // Master toggle for autoplay when playlist ends
   autoplayBlendMode: 'crossfade' | 'silence' | 'reverb_tail'; // Transition effect between songs

--- a/src/lib/utils/preference-merge.ts
+++ b/src/lib/utils/preference-merge.ts
@@ -55,6 +55,8 @@ export const DEFAULT_RECOMMENDATION_SETTINGS: RecommendationSettings = {
   // Queue Seeding defaults
   aiDJSeedQueueEnabled: false, // Disabled by default - user opt-in
   aiDJSeedDensity: 2, // 2 recommendations per 10 songs
+  // Drip-feed model
+  aiDJDripInterval: 3, // Add 1 recommendation every 3 songs (default)
   // Playlist Autoplay Queueing with Smart Transitions
   autoplayEnabled: false,
   autoplayBlendMode: 'crossfade',

--- a/src/lib/utils/preference-merge.ts
+++ b/src/lib/utils/preference-merge.ts
@@ -48,6 +48,13 @@ export const DEFAULT_RECOMMENDATION_SETTINGS: RecommendationSettings = {
   harmonicMixingEnabled: true,
   harmonicMixingMode: 'flexible',
   bpmTolerance: 6,
+  // DJ Matching defaults
+  djMatchingEnabled: true, // Enable by default for better DJ experience
+  bpmAnalysisEnabled: false, // Disabled by default (requires user opt-in for performance)
+  djMatchingMinScore: 0.5, // 50% minimum threshold
+  // Queue Seeding defaults
+  aiDJSeedQueueEnabled: false, // Disabled by default - user opt-in
+  aiDJSeedDensity: 2, // 2 recommendations per 10 songs
   // Playlist Autoplay Queueing with Smart Transitions
   autoplayEnabled: false,
   autoplayBlendMode: 'crossfade',

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -58,6 +58,7 @@ import { Route as ApiRecommendationsExportRouteImport } from './routes/api/recom
 import { Route as ApiRecommendationsDiscoveryAnalyticsRouteImport } from './routes/api/recommendations/discovery-analytics'
 import { Route as ApiRecommendationsClearRouteImport } from './routes/api/recommendations/clear'
 import { Route as ApiRecommendationsAnalyticsRouteImport } from './routes/api/recommendations/analytics'
+import { Route as ApiProfileUpdateRouteImport } from './routes/api/profile/update'
 import { Route as ApiPlaylistsSyncRouteImport } from './routes/api/playlists/sync'
 import { Route as ApiPlaylistsJoinRouteImport } from './routes/api/playlists/join'
 import { Route as ApiPlaylistsImportRouteImport } from './routes/api/playlists/import'
@@ -90,6 +91,7 @@ import { Route as ApiLastfmSearchRouteImport } from './routes/api/lastfm/search'
 import { Route as ApiDownloadsQueueRouteImport } from './routes/api/downloads/queue'
 import { Route as ApiDiscoveryFeedInteractionsRouteImport } from './routes/api/discovery-feed/interactions'
 import { Route as ApiDiscoveryFeedAnalyticsRouteImport } from './routes/api/discovery-feed/analytics'
+import { Route as ApiDebugLogsRouteImport } from './routes/api/debug/logs'
 import { Route as ApiBackgroundDiscoveryTriggerRouteImport } from './routes/api/background-discovery/trigger'
 import { Route as ApiBackgroundDiscoverySuggestionsRouteImport } from './routes/api/background-discovery/suggestions'
 import { Route as ApiBackgroundDiscoveryStatusRouteImport } from './routes/api/background-discovery/status'
@@ -385,6 +387,11 @@ const ApiRecommendationsAnalyticsRoute =
     path: '/analytics',
     getParentRoute: () => ApiRecommendationsRoute,
   } as any)
+const ApiProfileUpdateRoute = ApiProfileUpdateRouteImport.update({
+  id: '/api/profile/update',
+  path: '/api/profile/update',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiPlaylistsSyncRoute = ApiPlaylistsSyncRouteImport.update({
   id: '/api/playlists/sync',
   path: '/api/playlists/sync',
@@ -550,6 +557,11 @@ const ApiDiscoveryFeedAnalyticsRoute =
     path: '/api/discovery-feed/analytics',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiDebugLogsRoute = ApiDebugLogsRouteImport.update({
+  id: '/api/debug/logs',
+  path: '/api/debug/logs',
+  getParentRoute: () => rootRouteImport,
+} as any)
 const ApiBackgroundDiscoveryTriggerRoute =
   ApiBackgroundDiscoveryTriggerRouteImport.update({
     id: '/api/background-discovery/trigger',
@@ -814,6 +826,7 @@ export interface FileRoutesByFullPath {
   '/api/background-discovery/status': typeof ApiBackgroundDiscoveryStatusRoute
   '/api/background-discovery/suggestions': typeof ApiBackgroundDiscoverySuggestionsRouteWithChildren
   '/api/background-discovery/trigger': typeof ApiBackgroundDiscoveryTriggerRoute
+  '/api/debug/logs': typeof ApiDebugLogsRoute
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
@@ -846,6 +859,7 @@ export interface FileRoutesByFullPath {
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
   '/api/playlists/join': typeof ApiPlaylistsJoinRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
+  '/api/profile/update': typeof ApiProfileUpdateRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
   '/api/recommendations/discovery-analytics': typeof ApiRecommendationsDiscoveryAnalyticsRoute
@@ -935,6 +949,7 @@ export interface FileRoutesByTo {
   '/api/background-discovery/status': typeof ApiBackgroundDiscoveryStatusRoute
   '/api/background-discovery/suggestions': typeof ApiBackgroundDiscoverySuggestionsRouteWithChildren
   '/api/background-discovery/trigger': typeof ApiBackgroundDiscoveryTriggerRoute
+  '/api/debug/logs': typeof ApiDebugLogsRoute
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
@@ -967,6 +982,7 @@ export interface FileRoutesByTo {
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
   '/api/playlists/join': typeof ApiPlaylistsJoinRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
+  '/api/profile/update': typeof ApiProfileUpdateRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
   '/api/recommendations/discovery-analytics': typeof ApiRecommendationsDiscoveryAnalyticsRoute
@@ -1060,6 +1076,7 @@ export interface FileRoutesById {
   '/api/background-discovery/status': typeof ApiBackgroundDiscoveryStatusRoute
   '/api/background-discovery/suggestions': typeof ApiBackgroundDiscoverySuggestionsRouteWithChildren
   '/api/background-discovery/trigger': typeof ApiBackgroundDiscoveryTriggerRoute
+  '/api/debug/logs': typeof ApiDebugLogsRoute
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
@@ -1092,6 +1109,7 @@ export interface FileRoutesById {
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
   '/api/playlists/join': typeof ApiPlaylistsJoinRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
+  '/api/profile/update': typeof ApiProfileUpdateRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
   '/api/recommendations/discovery-analytics': typeof ApiRecommendationsDiscoveryAnalyticsRoute
@@ -1185,6 +1203,7 @@ export interface FileRouteTypes {
     | '/api/background-discovery/status'
     | '/api/background-discovery/suggestions'
     | '/api/background-discovery/trigger'
+    | '/api/debug/logs'
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
@@ -1217,6 +1236,7 @@ export interface FileRouteTypes {
     | '/api/playlists/import'
     | '/api/playlists/join'
     | '/api/playlists/sync'
+    | '/api/profile/update'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
     | '/api/recommendations/discovery-analytics'
@@ -1306,6 +1326,7 @@ export interface FileRouteTypes {
     | '/api/background-discovery/status'
     | '/api/background-discovery/suggestions'
     | '/api/background-discovery/trigger'
+    | '/api/debug/logs'
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
@@ -1338,6 +1359,7 @@ export interface FileRouteTypes {
     | '/api/playlists/import'
     | '/api/playlists/join'
     | '/api/playlists/sync'
+    | '/api/profile/update'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
     | '/api/recommendations/discovery-analytics'
@@ -1430,6 +1452,7 @@ export interface FileRouteTypes {
     | '/api/background-discovery/status'
     | '/api/background-discovery/suggestions'
     | '/api/background-discovery/trigger'
+    | '/api/debug/logs'
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
@@ -1462,6 +1485,7 @@ export interface FileRouteTypes {
     | '/api/playlists/import'
     | '/api/playlists/join'
     | '/api/playlists/sync'
+    | '/api/profile/update'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
     | '/api/recommendations/discovery-analytics'
@@ -1547,6 +1571,7 @@ export interface RootRouteChildren {
   ApiBackgroundDiscoveryStatusRoute: typeof ApiBackgroundDiscoveryStatusRoute
   ApiBackgroundDiscoverySuggestionsRoute: typeof ApiBackgroundDiscoverySuggestionsRouteWithChildren
   ApiBackgroundDiscoveryTriggerRoute: typeof ApiBackgroundDiscoveryTriggerRoute
+  ApiDebugLogsRoute: typeof ApiDebugLogsRoute
   ApiDiscoveryFeedAnalyticsRoute: typeof ApiDiscoveryFeedAnalyticsRoute
   ApiDiscoveryFeedInteractionsRoute: typeof ApiDiscoveryFeedInteractionsRoute
   ApiDownloadsQueueRoute: typeof ApiDownloadsQueueRoute
@@ -1579,6 +1604,7 @@ export interface RootRouteChildren {
   ApiPlaylistsImportRoute: typeof ApiPlaylistsImportRoute
   ApiPlaylistsJoinRoute: typeof ApiPlaylistsJoinRoute
   ApiPlaylistsSyncRoute: typeof ApiPlaylistsSyncRoute
+  ApiProfileUpdateRoute: typeof ApiProfileUpdateRoute
   MusicIdentityShareTokenRoute: typeof MusicIdentityShareTokenRoute
   PlaylistsJoinShareCodeRoute: typeof PlaylistsJoinShareCodeRoute
   ApiDiscoveryFeedIndexRoute: typeof ApiDiscoveryFeedIndexRoute
@@ -1952,6 +1978,13 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiRecommendationsAnalyticsRouteImport
       parentRoute: typeof ApiRecommendationsRoute
     }
+    '/api/profile/update': {
+      id: '/api/profile/update'
+      path: '/api/profile/update'
+      fullPath: '/api/profile/update'
+      preLoaderRoute: typeof ApiProfileUpdateRouteImport
+      parentRoute: typeof rootRouteImport
+    }
     '/api/playlists/sync': {
       id: '/api/playlists/sync'
       path: '/api/playlists/sync'
@@ -2174,6 +2207,13 @@ declare module '@tanstack/react-router' {
       path: '/api/discovery-feed/analytics'
       fullPath: '/api/discovery-feed/analytics'
       preLoaderRoute: typeof ApiDiscoveryFeedAnalyticsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/debug/logs': {
+      id: '/api/debug/logs'
+      path: '/api/debug/logs'
+      fullPath: '/api/debug/logs'
+      preLoaderRoute: typeof ApiDebugLogsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/background-discovery/trigger': {
@@ -2659,6 +2699,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiBackgroundDiscoverySuggestionsRoute:
     ApiBackgroundDiscoverySuggestionsRouteWithChildren,
   ApiBackgroundDiscoveryTriggerRoute: ApiBackgroundDiscoveryTriggerRoute,
+  ApiDebugLogsRoute: ApiDebugLogsRoute,
   ApiDiscoveryFeedAnalyticsRoute: ApiDiscoveryFeedAnalyticsRoute,
   ApiDiscoveryFeedInteractionsRoute: ApiDiscoveryFeedInteractionsRoute,
   ApiDownloadsQueueRoute: ApiDownloadsQueueRoute,
@@ -2692,6 +2733,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaylistsImportRoute: ApiPlaylistsImportRoute,
   ApiPlaylistsJoinRoute: ApiPlaylistsJoinRoute,
   ApiPlaylistsSyncRoute: ApiPlaylistsSyncRoute,
+  ApiProfileUpdateRoute: ApiProfileUpdateRoute,
   MusicIdentityShareTokenRoute: MusicIdentityShareTokenRoute,
   PlaylistsJoinShareCodeRoute: PlaylistsJoinShareCodeRoute,
   ApiDiscoveryFeedIndexRoute: ApiDiscoveryFeedIndexRoute,

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -13,12 +13,13 @@ import appCss from "~/styles.css?url";
 
 import { ThemeProvider } from "~/components/theme-provider";
 import { Toaster } from "~/components/ui/sonner";
-import { AudioPlayer } from "~/components/ui/audio-player";
+import { PlayerBar } from "~/components/layout/PlayerBar";
 import { QueuePanel } from "~/components/ui/queue-panel";
 import { MobileNav } from "~/components/ui/mobile-nav";
 import { AppLayout } from "~/components/layout";
 import { useAudioStore } from "~/lib/stores/audio";
 import { useServiceWorker } from "~/lib/hooks/useServiceWorker";
+import { useEruda } from "~/lib/hooks/useEruda";
 
 export const Route = createRootRouteWithContext<{
   queryClient: QueryClient;
@@ -29,7 +30,7 @@ export const Route = createRootRouteWithContext<{
     // better-auth's cookieCache is also enabled server-side to reduce server-to-db calls, see /src/lib/auth/auth.ts
     const user = await context.queryClient.ensureQueryData({
       ...authQueryOptions(),
-      revalidateIfStale: true,
+      revalidateIfStale: false,
     });
     return { user };
   },
@@ -135,6 +136,9 @@ function RootComponent() {
   // Register service worker for PWA functionality
   useServiceWorker();
 
+  // Load Eruda debug console if ?debug=true in URL
+  useEruda();
+
   // Use new AppLayout for main app routes (dashboard, library, playlists, dj, settings, music-identity)
   const useNewLayout = currentPath.startsWith('/dashboard') ||
                        currentPath.startsWith('/library') ||
@@ -166,7 +170,7 @@ function RootComponent() {
           {hasActiveSong && !isAuthPage && (
             <>
               <div className={`transition-all duration-300 fixed bottom-0 left-0 right-0 z-50 pb-[env(safe-area-inset-bottom)] ${isPlaying ? 'bg-background border-t' : 'opacity-50'}`}>
-                <AudioPlayer />
+                <PlayerBar />
               </div>
               <QueuePanel />
             </>

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -167,12 +167,14 @@ function RootComponent() {
           <div className={`transition-all duration-300 ${hasActiveSong && !isAuthPage ? 'pb-24 md:pb-20' : ''}`}>
             <Outlet />
           </div>
-          {hasActiveSong && !isAuthPage && (
+          {/* CRITICAL: Always render PlayerBar to preserve audio elements across state changes.
+             Unmounting destroys <audio> elements and kills playback. Hide visually instead. */}
+          {!isAuthPage && (
             <>
-              <div className={`transition-all duration-300 fixed bottom-0 left-0 right-0 z-50 pb-[env(safe-area-inset-bottom)] ${isPlaying ? 'bg-background border-t' : 'opacity-50'}`}>
+              <div className={`transition-all duration-300 fixed bottom-0 left-0 right-0 z-50 pb-[env(safe-area-inset-bottom)] ${!hasActiveSong ? 'hidden' : isPlaying ? 'bg-background border-t' : 'opacity-50'}`}>
                 <PlayerBar />
               </div>
-              <QueuePanel />
+              {hasActiveSong && <QueuePanel />}
             </>
           )}
         </>

--- a/src/routes/api/debug/logs.ts
+++ b/src/routes/api/debug/logs.ts
@@ -1,0 +1,47 @@
+/**
+ * Remote Debug Logging Endpoint
+ *
+ * Receives logs from client and prints to server console.
+ * Enable client-side with ?debug=true
+ */
+
+import { createFileRoute } from "@tanstack/react-router";
+
+export async function POST({ request }: { request: Request }) {
+  try {
+    const { level, args, timestamp, userAgent, url } = await request.json();
+
+    const time = new Date(timestamp).toLocaleTimeString();
+    const prefix = {
+      log: '📱',
+      info: 'ℹ️ ',
+      warn: '⚠️ ',
+      error: '❌',
+    }[level as string] || '📱';
+
+    // Print to server console
+    console.log(`${prefix} [${time}] [CLIENT] ${args.join(' ')}`);
+
+    // Log extra context for errors
+    if (level === 'error') {
+      console.log(`   ↳ URL: ${url}`);
+      console.log(`   ↳ UA: ${userAgent?.slice(0, 80)}`);
+    }
+
+    return new Response(JSON.stringify({ ok: true }), {
+      status: 200,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  } catch (error) {
+    return new Response(JSON.stringify({ error: 'Invalid log data' }), {
+      status: 400,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }
+}
+
+export const Route = createFileRoute("/api/debug/logs")({
+  server: {
+    handlers: { POST },
+  },
+});

--- a/src/routes/api/preferences.ts
+++ b/src/routes/api/preferences.ts
@@ -34,6 +34,13 @@ const PreferencesSchema = z.object({
     harmonicMixingEnabled: z.boolean().optional(),
     harmonicMixingMode: z.enum(['strict', 'flexible', 'off']).optional(),
     bpmTolerance: z.number().min(0).max(20).optional(),
+    // DJ Matching Settings (BPM/Energy/Key)
+    djMatchingEnabled: z.boolean().optional(),
+    bpmAnalysisEnabled: z.boolean().optional(),
+    djMatchingMinScore: z.number().min(0).max(1).optional(),
+    // Queue Seeding Settings
+    aiDJSeedQueueEnabled: z.boolean().optional(),
+    aiDJSeedDensity: z.number().min(1).max(5).optional(),
   }).optional(),
   playbackSettings: z.object({
     volume: z.number().min(0).max(1).optional(),

--- a/src/routes/api/profile/update.ts
+++ b/src/routes/api/profile/update.ts
@@ -1,0 +1,131 @@
+/**
+ * Profile Update API Endpoint
+ *
+ * Triggers a full user profile recalculation for AI DJ recommendations.
+ * This includes:
+ * - Syncing liked songs to feedback table
+ * - Calculating compound scores from listening history
+ * - Calculating artist affinities
+ * - Calculating temporal preferences
+ *
+ * Should be called:
+ * - On app startup (if profile data is stale)
+ * - After significant listening activity (10+ plays)
+ * - Via user-triggered refresh
+ */
+
+import type { APIEvent } from '@solidjs/start/server';
+import { getSession } from '@/lib/auth/session';
+import { calculateFullUserProfile } from '@/lib/services/compound-scoring';
+
+export async function POST(event: APIEvent) {
+  try {
+    // Verify authentication
+    const session = await getSession(event.request);
+    if (!session?.userId) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userId = session.userId;
+    console.log(`👤 [ProfileAPI] Profile update requested for user ${userId}`);
+
+    // Parse optional parameters from request body
+    let daysBack = 14; // Default lookback
+    try {
+      const body = await event.request.json();
+      if (body.daysBack && typeof body.daysBack === 'number') {
+        daysBack = Math.min(Math.max(body.daysBack, 7), 90); // Clamp between 7-90 days
+      }
+    } catch {
+      // No body or invalid JSON - use defaults
+    }
+
+    // Calculate full user profile
+    const result = await calculateFullUserProfile(userId, daysBack);
+
+    return new Response(
+      JSON.stringify({
+        success: true,
+        message: 'Profile updated successfully',
+        data: {
+          compoundScores: result.compoundScores,
+          artistAffinities: result.artistAffinities,
+          temporalPreferences: result.temporalPreferences,
+          likedSongsSynced: result.likedSongsSync.synced,
+          likedSongsUnstarred: result.likedSongsSync.unstarred,
+        },
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('👤 [ProfileAPI] Error updating profile:', error);
+
+    return new Response(
+      JSON.stringify({
+        error: 'Failed to update profile',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}
+
+export async function GET(event: APIEvent) {
+  try {
+    // Verify authentication
+    const session = await getSession(event.request);
+    if (!session?.userId) {
+      return new Response(
+        JSON.stringify({ error: 'Unauthorized' }),
+        { status: 401, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const userId = session.userId;
+
+    // Import services dynamically to avoid circular dependencies
+    const { getTopArtistsByAffinity, getPreferredGenresForNow } = await import('@/lib/services/artist-affinity');
+    const { getLikedSongsCount } = await import('@/lib/services/liked-songs-sync');
+    const { hasProfileData } = await import('@/lib/services/profile-recommendations');
+
+    // Get profile summary
+    const [topArtists, preferredGenres, likedCount, hasProfile] = await Promise.all([
+      getTopArtistsByAffinity(userId, 10),
+      getPreferredGenresForNow(userId, 5),
+      getLikedSongsCount(userId),
+      hasProfileData(userId),
+    ]);
+
+    return new Response(
+      JSON.stringify({
+        hasProfile,
+        likedSongsCount: likedCount,
+        topArtists: topArtists.map(a => ({
+          artist: a.artist,
+          score: Math.round(a.affinityScore * 100) / 100,
+          playCount: a.playCount,
+          likedCount: a.likedCount,
+        })),
+        preferredGenresNow: preferredGenres.map(g => ({
+          genre: g.genre,
+          score: Math.round(g.preferenceScore * 100) / 100,
+          playCount: g.playCount,
+        })),
+      }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } }
+    );
+  } catch (error) {
+    console.error('👤 [ProfileAPI] Error getting profile:', error);
+
+    return new Response(
+      JSON.stringify({
+        error: 'Failed to get profile',
+        message: error instanceof Error ? error.message : 'Unknown error',
+      }),
+      { status: 500, headers: { 'Content-Type': 'application/json' } }
+    );
+  }
+}

--- a/src/routes/dashboard/index.tsx
+++ b/src/routes/dashboard/index.tsx
@@ -177,6 +177,16 @@ function DashboardIndex() {
     }
   }, [session, loadPreferences]);
 
+  // Sync crossfade settings from preferences to audio store
+  useEffect(() => {
+    if (preferences?.playbackSettings?.crossfadeDuration !== undefined) {
+      const audioStore = useAudioStore.getState();
+      if (audioStore.crossfadeDuration !== preferences.playbackSettings.crossfadeDuration) {
+        audioStore.setCrossfadeDuration(preferences.playbackSettings.crossfadeDuration);
+      }
+    }
+  }, [preferences?.playbackSettings?.crossfadeDuration]);
+
   // Check for legacy feedback and prompt migration
   useEffect(() => {
     if (!session) return;


### PR DESCRIPTION
## Summary
- Complete rewrite of crossfade to use dual-deck audio system (Deck A/B)
- Extensive iOS Safari fixes for background playback and lock screen controls
- Profile-based AI DJ recommendations with drip-feed model
- DJ matching features (BPM/Energy/Key) and queue seeding
- "More Like This" button for queue panel

## iOS Crossfade Fixes
- Increase crossfade ready timeout from 2s to 5s for iOS buffering
- Handle pause during crossfade gracefully
- Fix safety timeout to complete crossfade when incoming deck is playing (iOS throttles intervals when screen locked)
- Clear old deck source immediately (iOS can suspend page before setTimeout fires)
- Debounce Media Session play/pause for Bluetooth disconnect/reconnect
- Only register Media Session handlers on active deck

## AI DJ Improvements
- Profile-based recommendations using compound scoring
- Drip-feed model: adds 1 recommendation every N songs instead of batch dumps
- Blended recommendation scorer with multi-signal personalization
- DJ matching toggle for BPM/Energy/Key similarity

## Debug Tooling
- Remote debug logging via useEruda hook
- Server-side log streaming for mobile debugging
- Enable via `?debug=true` URL param

## Test plan
- [x] Crossfade works in foreground
- [x] Crossfade works with screen locked
- [x] Lock screen controls update correctly after crossfade
- [x] Bluetooth disconnect/reconnect doesn't cause stuck state
- [x] Pause during crossfade aborts cleanly
- [x] AI DJ adds recommendations periodically

🤖 Generated with [Claude Code](https://claude.com/claude-code)