### PR TITLE
fix: Cross-device sync skip/prev/play commands not propagating to act…

### DIFF
--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -30,7 +30,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import { queryKeys } from '@/lib/query';
-import { usePlaybackSync, sendPlaybackMessage } from '@/lib/hooks/usePlaybackSync';
+import { usePlaybackSync, sendPlaybackMessage, sendRemoteCommand } from '@/lib/hooks/usePlaybackSync';
 import { ResumePlaybackPrompt } from './ResumePlaybackPrompt';
 import { FullscreenPlayer } from './FullscreenPlayer';
 
@@ -462,6 +462,46 @@ export function PlayerBar() {
     }
   }, [setCurrentTime, getActiveDeck]);
 
+  // --- Remote control wrappers ---
+  // When this device is NOT the active player (another device is playing),
+  // transport controls (play/pause/skip) should send a remote command via WS
+  // to the active player instead of modifying local state. The active player
+  // receives the command in handleIncomingMessage → 'remote_command' case and
+  // executes the action (e.g., store.nextSong()), then broadcasts its updated
+  // state back to all devices. Without this, skip/prev on a non-playing device
+  // only updates local state — the playing device ignores the state sync
+  // because it considers itself authoritative (applyServerState guard).
+  const isRemoteControlMode = isRemotePlaying && !isPlaying;
+
+  const remoteAwareNext = useCallback(() => {
+    if (isRemoteControlMode) {
+      sendRemoteCommand('next');
+    } else {
+      handleNextSong();
+    }
+  }, [isRemoteControlMode, handleNextSong]);
+
+  const remoteAwarePrevious = useCallback(() => {
+    if (isRemoteControlMode) {
+      sendRemoteCommand('previous');
+    } else {
+      previousSong();
+    }
+  }, [isRemoteControlMode, previousSong]);
+
+  const remoteAwareTogglePlayPause = useCallback(() => {
+    if (isRemoteControlMode) {
+      // Remote device is playing and we want to pause it
+      sendRemoteCommand('pause');
+    } else if (!isPlaying && remoteDevice?.isPlaying) {
+      // Remote device is playing, local wants to take over — use normal
+      // togglePlayPause which triggers playback takeover via timestamp logic
+      togglePlayPause();
+    } else {
+      togglePlayPause();
+    }
+  }, [isRemoteControlMode, isPlaying, remoteDevice?.isPlaying, togglePlayPause]);
+
   const changeVolume = useCallback((newVolume: number) => {
     const clampedVolume = Math.max(0, Math.min(1, newVolume));
     setVolume(clampedVolume);
@@ -536,12 +576,12 @@ export function PlayerBar() {
     crossfadeInProgressRef,
     setGainImmediate,
     resumeContext,
-    onPreviousTrack: previousSong,
-    onNextTrack: handleNextSong,
+    onPreviousTrack: remoteAwarePrevious,
+    onNextTrack: remoteAwareNext,
   });
 
   usePlayerKeyboardShortcuts({
-    togglePlayPause,
+    togglePlayPause: remoteAwareTogglePlayPause,
     seek,
     changeVolume,
     toggleLike: handleToggleLike,
@@ -772,7 +812,7 @@ export function PlayerBar() {
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              onClick={previousSong}
+              onClick={remoteAwarePrevious}
             >
               <SkipBack className="h-4 w-4" />
             </Button>
@@ -781,12 +821,12 @@ export function PlayerBar() {
               variant="default"
               size="sm"
               className="h-10 w-10 p-0 rounded-full"
-              onClick={togglePlayPause}
+              onClick={remoteAwareTogglePlayPause}
               disabled={isLoading}
             >
               {isLoading ? (
                 <Loader2 className="h-5 w-5 animate-spin" />
-              ) : isPlaying ? (
+              ) : isPlaying || isRemoteControlMode ? (
                 <Pause className="h-5 w-5" />
               ) : (
                 <Play className="h-5 w-5 ml-0.5" />
@@ -797,7 +837,7 @@ export function PlayerBar() {
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              onClick={handleNextSong}
+              onClick={remoteAwareNext}
             >
               <SkipForward className="h-4 w-4" />
             </Button>
@@ -881,7 +921,7 @@ export function PlayerBar() {
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              onClick={previousSong}
+              onClick={remoteAwarePrevious}
             >
               <SkipBack className="h-4 w-4" />
             </Button>
@@ -889,12 +929,12 @@ export function PlayerBar() {
               variant="default"
               size="sm"
               className="h-10 w-10 p-0 rounded-full"
-              onClick={togglePlayPause}
+              onClick={remoteAwareTogglePlayPause}
               disabled={isLoading}
             >
               {isLoading ? (
                 <Loader2 className="h-5 w-5 animate-spin" />
-              ) : isPlaying ? (
+              ) : isPlaying || isRemoteControlMode ? (
                 <Pause className="h-5 w-5" />
               ) : (
                 <Play className="h-5 w-5 ml-0.5" />
@@ -904,7 +944,7 @@ export function PlayerBar() {
               variant="ghost"
               size="sm"
               className="h-8 w-8 p-0"
-              onClick={handleNextSong}
+              onClick={remoteAwareNext}
             >
               <SkipForward className="h-4 w-4" />
             </Button>
@@ -1021,9 +1061,9 @@ export function PlayerBar() {
         isLikePending={isLikePending}
         isShuffled={isShuffled}
         repeatMode={repeatMode}
-        onTogglePlayPause={togglePlayPause}
-        onPrevious={previousSong}
-        onNext={handleNextSong}
+        onTogglePlayPause={remoteAwareTogglePlayPause}
+        onPrevious={remoteAwarePrevious}
+        onNext={remoteAwareNext}
         onSeek={seek}
         onToggleLike={handleToggleLike}
         onToggleShuffle={toggleShuffle}

--- a/src/lib/hooks/usePlaybackSync.ts
+++ b/src/lib/hooks/usePlaybackSync.ts
@@ -36,6 +36,31 @@ export function sendPlaybackMessage(type: string, payload?: Record<string, unkno
 }
 
 /**
+ * Send a remote command (play/pause/next/previous/seek/volume) to the active
+ * player device via WebSocket.
+ *
+ * This uses the 'command' message type which the server broadcasts to ALL
+ * connected devices (including the sender). The receiving handler at
+ * handleIncomingMessage → 'remote_command' executes the action only on the
+ * device that is currently playing (the active player).
+ *
+ * Use this when the local device is NOT the active player — e.g., when
+ * viewing a remote playback session and pressing skip/play/pause. Without
+ * this, those actions only update local state and rely on state sync, which
+ * gets blocked by the "playing device is authoritative" guard in
+ * applyServerState().
+ */
+export function sendRemoteCommand(action: string, value?: unknown): void {
+  if (!_wsRef || _wsRef.readyState !== WebSocket.OPEN) return;
+  const deviceInfo = getDeviceInfo();
+  _wsRef.send(JSON.stringify({
+    type: 'command',
+    deviceId: deviceInfo.deviceId,
+    payload: { action, value },
+  }));
+}
+
+/**
  * Debounce a function call. Returns a cancel function.
  */
 function createDebounced(fn: () => void, delay: number): { trigger: () => void; cancel: () => void; flush: () => void } {
@@ -276,7 +301,12 @@ function handleIncomingMessage(
     }
 
     case 'remote_command': {
-      // Another device sent a command to this device
+      // A non-playing device sent a transport command (next/prev/play/pause/seek)
+      // to this device via sendRemoteCommand(). The server broadcasts 'command'
+      // messages to ALL devices (broadcastToAllDevices), but only the active
+      // player (isPlaying === true) executes the action. After execution, the
+      // store subscription detects the state change and broadcasts a state_update
+      // so all devices converge.
       const payload = msg.payload as { action: string; value?: unknown } | undefined;
       if (!payload) break;
 
@@ -484,12 +514,20 @@ export function usePlaybackSync(): void {
         useAudioStore.setState(tsUpdate);
       }
 
-      if (playStateChanged) {
-        // Play state changes broadcast immediately (no debounce) so the
-        // remote device pauses/resumes without a perceptible delay.
+      // Detect if the current song index changed (skip/next/prev) — these
+      // should broadcast immediately so the remote active player switches
+      // tracks without waiting for the 2s debounce. Playlist length and
+      // shuffle changes are less time-sensitive and can stay debounced.
+      const songIndexChanged = prev.currentSongIndex !== state.currentSongIndex;
+
+      if (playStateChanged || songIndexChanged) {
+        // Play state and song index changes broadcast immediately (no debounce)
+        // so the remote device pauses/resumes/skips without perceptible delay.
         broadcastStateViaWS(wsRef.current);
         pushStateToServer();
       } else if (queueChanged || volumeChanged) {
+        // Playlist length, shuffle, and volume changes use debounced sync
+        // to avoid flooding the server with rapid updates.
         debouncedSync.trigger();
       }
     });

--- a/src/lib/services/playback-websocket.ts
+++ b/src/lib/services/playback-websocket.ts
@@ -88,7 +88,10 @@ export function setupPlaybackWebSocket(
             break;
 
           case 'command':
-            // Forward command to all devices
+            // Forward transport commands (play/pause/next/prev/seek/volume) to ALL
+            // devices including the sender. Sent by sendRemoteCommand() when a
+            // non-playing device triggers a control action. The receiving handler
+            // only executes on the device with isPlaying === true.
             broadcastToAllDevices(userId, {
               type: 'remote_command',
               payload: message.payload as PlaybackCommand,

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -1669,13 +1669,20 @@ export const useAudioStore = create<AudioState>()(
       const merged: Partial<AudioState> = {};
       let changed = false;
 
-      // When this device is actively playing, it is the authoritative source —
-      // don't overwrite queue or position, only update remote device indicator.
-      // This prevents losing playback when another device syncs state.
       const localIsPlaying = local.isPlaying;
 
-      // Queue fields: only apply if server is newer/equal AND local is NOT actively playing.
-      if (!localIsPlaying && server.queueUpdatedAt >= (local.queueUpdatedAt ?? '')) {
+      // Queue fields (playlist, currentIndex, shuffle):
+      //   - If local is NOT playing: accept if server timestamp >= local (standard merge).
+      //   - If local IS playing: only accept if server timestamp is STRICTLY newer.
+      //     This allows a remote device's explicit skip/next to propagate to the
+      //     active player, while preventing equal-timestamp echoes from overwriting
+      //     the playing device's own queue state. (Fix for: phone skip not affecting
+      //     desktop playback — the old code blocked ALL queue updates when playing.)
+      const acceptQueue = localIsPlaying
+        ? server.queueUpdatedAt > (local.queueUpdatedAt ?? '')
+        : server.queueUpdatedAt >= (local.queueUpdatedAt ?? '');
+
+      if (acceptQueue) {
         merged.playlist = server.queue.map(fromSyncSong);
         merged.currentSongIndex = server.currentIndex;
         merged.isShuffled = server.isShuffled;
@@ -1683,8 +1690,14 @@ export const useAudioStore = create<AudioState>()(
         changed = true;
       }
 
-      // Position: only apply if server is newer/equal AND local is NOT actively playing.
-      if (!localIsPlaying && server.positionUpdatedAt >= (local.positionUpdatedAt ?? '')) {
+      // Position (currentTime):
+      //   - Same logic: non-playing devices accept >= (catch up to active player),
+      //     playing devices only accept strictly newer (remote seek override).
+      const acceptPosition = localIsPlaying
+        ? server.positionUpdatedAt > (local.positionUpdatedAt ?? '')
+        : server.positionUpdatedAt >= (local.positionUpdatedAt ?? '');
+
+      if (acceptPosition) {
         merged.currentTime = server.currentPositionMs / 1000;
         merged.positionUpdatedAt = server.positionUpdatedAt;
         changed = true;


### PR DESCRIPTION
…ive player

The playing device blocked ALL remote queue updates via a !localIsPlaying guard in applyServerState(), causing skip/prev from a non-playing device (e.g., phone controlling desktop) to be silently ignored. Additionally, the 'command' WS message type was fully defined in the protocol but never sent by any client code.

- Add sendRemoteCommand() to send transport commands (next/prev/play/pause) via WS to the active player device
- Wire PlayerBar controls to use remote commands when in remote control mode (another device is playing)
- Fix applyServerState() conflict resolution: playing devices now accept queue updates with strictly newer timestamps instead of blocking all updates
- Make song index changes broadcast immediately instead of through 2s debounce