### PR TITLE
feat: Aurral add-artist fallback when global search returns empty

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -28,6 +28,14 @@
 - [x] Logout page invalidation — clear query cache on sign-out for instant redirect to login
 - [x] Redesign login page — improve visual design, branding, and UX
 
+## Library / Browse / Search
+
+- [x] **Silent artist truncation in browse** — `getArtists(start, limit)` in `src/lib/services/navidrome/library.ts:15` used `_end=${start + limit - 1}` but Navidrome (react-admin) treats `_end` as exclusive, returning `limit - 1` rows. Juan's library has ≥5044 artists; browse was dropping ~45+. Fixed across `getArtists`, `getAlbums`, `getSongs`, `getSongsByArtist`, `getSongsGlobal`, and `searchArtistsByName`. Also bumped browse/search fetch cap from 5000 → 10000.
+- [x] **Aurral/Lidarr add-artist fallback rendered card for empty matches** — queries like `zzqqnope_not_a_real_artist` yielded "Not in your library. Found on MusicBrainz: [no artist]" with an Add to Lidarr button. Tightened guard in `src/routes/library/search.tsx`'s `ArtistAddFallback` to require a non-empty `artistName` (and reject the `[no artist]` sentinel) in addition to `mbid`.
+- [x] **"0 artists in your library" flashed under Artists header while loading** — now shows "Loading…" until the query resolves.
+- [ ] **Browse fetches all artists upfront** — on slow-3G the skeleton is still visible at 5s because we pull the full artist list (up to 10k) for client-side filtering. Consider server-side pagination with infinite scroll, or a lighter "index" endpoint (just id+name+counts).
+- [ ] **Navidrome tag-splitter creates artist fragments** — artists appear as `" esq."` and `" Inc."` (note leading spaces), clearly fragments from splitting "X, esq." / "Y, Inc." on commas during scan. Fix lives in Navidrome scanner config, not AIDJ. Flagging so we don't try to work around it client-side.
+
 ## DevOps
 
 - [ ] Switch Coolify deployment back to `main` branch and merge `feat/web-audio-crossfade` into `main`

--- a/docs/architecture/crossfade-playback-decisions.md
+++ b/docs/architecture/crossfade-playback-decisions.md
@@ -1,0 +1,194 @@
+# Crossfade: How Playback Decisions Are Made
+
+The crossfade subsystem is not just "fade out, fade in." It drives most of the
+hot-path playback decisions: when to advance to the next song, when to record a
+play in listening history, when to scrobble, when to evict a song from the
+queue, and when to suppress duplicate transitions. This document maps those
+decisions to the files and refs that own them.
+
+## Architecture
+
+**Dual decks.** Two `HTMLAudioElement` instances, referenced as Deck A and
+Deck B, routed through Web Audio `GainNode`s into a `masterGain`. Only one
+deck is "active" at any time (`activeDeckRef: 'A' | 'B'`); the other preloads
+the next song during a crossfade. Gain ramps are scheduled on the audio
+thread (`scheduleGainRamp`) so they keep running when the JS thread is
+throttled (backgrounded tab, GC pauses).
+
+**Key files.**
+
+| File | Role |
+|---|---|
+| `src/lib/hooks/useCrossfade.ts` | Owns `startCrossfade`, `abortCrossfade`, `completeCrossfade`. Talks to Web Audio graph. |
+| `src/lib/hooks/useDeckEventHandlers.ts` | Listens to `timeupdate`/`ended`/`stalled`/`canplay` on both decks. Decides when to trigger `startCrossfade`. Owns onEnded scrobble/record path. |
+| `src/lib/hooks/useSongLoader.ts` | Loads the current song into the active deck. Owns the 10s load timeout (`skipUnavailableSong`). |
+| `src/components/layout/PlayerBar.tsx` | Host component. Creates the shared refs, wires the callbacks, owns `recordListeningHistory` and `handleNextSong`. |
+
+## Shared refs (the state machine)
+
+These refs cross hook boundaries — they *are* the contract between the
+subsystems.
+
+| Ref | Written by | Read by | Purpose |
+|---|---|---|---|
+| `crossfadeInProgressRef` | `useCrossfade` | `useCrossfade`, `useDeckEventHandlers`, `useStallRecovery`, `useSongLoader` | Gate. `true` means a crossfade is ramping — suppress onEnded, suppress new crossfade starts, suppress stall recovery. |
+| `crossfadeAbortedAtRef` | `useCrossfade.abortCrossfade` (unconditionally, `useCrossfade.ts:127`) | `useDeckEventHandlers` timeupdate gate (10s cooldown, line 154) and onEnded gate (3s suppression, line 246) | Retry cooldown. Stamped on **every** abort so the timeupdate loop doesn't immediately re-enter `startCrossfade`. |
+| `hasScrobbledRef` / `scrobbleThresholdReachedRef` | onEnded, onCrossfadeComplete, handleNextSong, onCrossfadeAbort+songHasEnded branch, useSongLoader cleanup | Same sites | Prevents double-scrobble for the same song across overlapping transition paths. |
+| `currentSongIdRef` | `useSongLoader`, onCrossfadeComplete | All listening-history / scrobble sites | The outgoing song's ID, captured before the deck swaps. |
+| `playbackSnapshotRef` | timeupdate (`useDeckEventHandlers.ts:125`) | onCrossfadeComplete, onCrossfadeAbort, handleNextSong | Last known `(currentTime, duration, songId)` for the outgoing song. Used when the active deck has already been reassigned to the next song. |
+
+## Decision points
+
+### 1. When to start a crossfade
+
+Owner: `useDeckEventHandlers.ts:148-174` (timeupdate handler).
+
+All of the following must hold:
+
+- `xfadeDuration > 0` and `timeRemaining <= xfadeDuration` and `timeRemaining > 0.5`
+- `!crossfadeInProgressRef.current`
+- `Date.now() - crossfadeAbortedAtRef.current >= 10_000` (retry cooldown)
+- `repeatMode !== 'one'`
+- Not the last song, unless `repeatMode === 'all'` or shuffle is on
+- `playlist.length > 1`
+
+If all pass, `startCrossfade(nextSongData, xfadeDuration)` is called. Note that
+`timeRemaining` uses `effectiveDuration` — the audio element's `duration` when
+finite, else the store's metadata duration (for transcoded/chunked streams
+where `duration === Infinity`).
+
+### 2. When to abort a crossfade
+
+Owner: `useCrossfade.ts:122-158` (`abortCrossfade`).
+
+Triggers:
+
+- **5s `canplaythrough` timeout** (line 286-294) — inactive deck never reached
+  readyState >= 3. Reason string contains `timeout`.
+- **`play()` rejection** (line 203-206) — typically autoplay policy blocking a
+  backgrounded tab. Reason: `play() failed - likely autoplay blocked`.
+- **User pause during ramp** (line 181-188) — store subscription sees
+  `isPlaying` flip false.
+- **Safety timeout** after `xfadeDuration + 5s` (line 297-308) if the inactive
+  deck isn't playing and past 1s.
+- **Completion-time check** (line 197-200) — inactive deck was expected to be
+  playing but stopped mid-ramp.
+
+Every abort does the following **in order**:
+
+1. Stamp `crossfadeAbortedAtRef.current = Date.now()` — unconditionally. This
+   is the single most important invariant in the subsystem; without it the
+   timeupdate loop re-enters `startCrossfade` dozens of times per second.
+2. Restore gains (active=1.0, inactive=0) and cancel any scheduled ramps.
+3. Pause and clear `src` on the inactive deck.
+4. Classify: `isLoadFailure = reason.includes('timeout') || reason.includes('never became ready')`.
+5. Check `songHasEnded` on the active deck (`currentTime >= duration - 0.5` or `ended`).
+6. Fire `onCrossfadeAbort(nextSongData, isLoadFailure)` **only if**
+   `isLoadFailure || songHasEnded`. Otherwise the callback is silent — the
+   song is still playing, we'll try again on the next natural end.
+
+### 3. When to record listening history and scrobble
+
+Four paths converge on `recordListeningHistory` + `scrobbleSong(id, true)` for
+the **outgoing** song. They are mutually exclusive via
+`hasScrobbledRef` / crossfade gates.
+
+| Path | File / Line | Trigger |
+|---|---|---|
+| Natural end (no crossfade) | `useDeckEventHandlers.ts:251-262` (onEnded) | `ended` event fires and neither `crossfadeInProgressRef` nor the 3s abort window apply. |
+| Crossfade completed | `PlayerBar.tsx:257-286` (`onCrossfadeComplete`) | Ramp finished, new deck swapped in. |
+| Crossfade aborted but old song ended | `PlayerBar.tsx:307-326` (`onCrossfadeAbort` + `songHasEnded`) | Load timeout or play() reject landed right as the current song ran out. Without this branch the scrobble is lost, because the onEnded 3s suppression will swallow it. |
+| Manual skip (Next button) | `PlayerBar.tsx:212-233` (`handleNextSong`) | User pressed Next. Records with `userInitiatedSkip=true`. |
+
+Known gap (not yet fixed, flagged earlier in session):
+`useSongLoader.ts:325-330` cleanup path scrobbles Navidrome when the
+`scrobbleThresholdReached` flag is set, but does **not** call
+`recordListeningHistory`. A song that unmounts without any of the four paths
+above firing won't land in our DB even though Navidrome records it.
+
+### 4. When to remove a song from the queue
+
+Owner: `PlayerBar.tsx:297-305` (`onCrossfadeAbort`).
+
+Gated on `isLoadFailure` only. The subtlety: before this gate existed, *any*
+crossfade abort — including `play()` rejections caused by autoplay policy —
+would evict the next song and toast "unavailable." That evicted playable
+songs during background playback. Now:
+
+- Load timeout / never-ready → evict + toast "Skipped X — unavailable".
+- Autoplay reject / user pause / safety timeout → leave in queue; let
+  `useSongLoader`'s own 10s load timeout handle genuinely broken files.
+
+### 5. When to advance (nextSong)
+
+Called from:
+
+- `useDeckEventHandlers.ts:298` — after onEnded, once scrobble/record are done.
+- `useDeckEventHandlers.ts:179-183` — `[INFINITY]` safety net for
+  chunked/transcoded streams that never fire `ended`. Advances without
+  recording history. (Known gap — rare since we switched to `format=raw` in
+  the stream proxy, which preserves Content-Length.)
+- `PlayerBar.tsx:285` (`onCrossfadeComplete`) — after the old deck's play has
+  been recorded.
+- `PlayerBar.tsx:330` (`onCrossfadeAbort` + `songHasEnded`) — same reasoning,
+  on the abort path.
+- `handleNextSong` — user pressed Next.
+
+## Suppression windows
+
+Two short windows are critical for not double-counting plays:
+
+**3s onEnded suppression after any abort** (`useDeckEventHandlers.ts:246-249`).
+When `abortCrossfade` fires at the tail of a song, the onEnded event follows
+within ~200ms for the old deck. Without this gate the play would be scrobbled
+twice: once by the abort+songHasEnded branch and once by onEnded.
+
+**10s timeupdate cooldown after any abort** (`useDeckEventHandlers.ts:154`).
+Prevents the timeupdate handler — which fires every ~250ms — from
+immediately re-calling `startCrossfade` the moment an abort returns control.
+Without this, autoplay-blocked aborts retry until the song ends, each retry
+doing a full deck teardown.
+
+## Interaction diagram (happy path + main failure mode)
+
+```
+timeupdate on active deck
+    │
+    ├─ timeRemaining <= xfadeDuration && !inProgress && !cooldown
+    │     └─► startCrossfade
+    │           ├─ inactive.src = next.url; inactive.load()
+    │           ├─ wait canplaythrough (5s timeout)
+    │           ├─ inactive.play()
+    │           │     ├─ resolved → schedule gain ramps → completeCrossfade
+    │           │     │                                      └─► onCrossfadeComplete
+    │           │     │                                            └─► scrobble + record + nextSong
+    │           │     └─ rejected → abortCrossfade('play() failed…')
+    │           │                       ├─ stamp crossfadeAbortedAtRef
+    │           │                       ├─ restore gains, pause inactive deck
+    │           │                       └─ onCrossfadeAbort(song, isLoadFailure=false)
+    │           │                             ├─ songHasEnded? scrobble+record+nextSong
+    │           │                             └─ else: do nothing — song still playing
+    │           └─ canplaythrough never fires → abortCrossfade('timeout…')
+    │                 └─ onCrossfadeAbort(song, isLoadFailure=true)
+    │                       ├─ evict from queue + toast
+    │                       └─ songHasEnded? scrobble+record+nextSong
+    │
+    └─ ended (active deck)
+          ├─ crossfadeInProgressRef? skip (crossfade owns this transition)
+          ├─ within 3s of abort? skip (abort owns this transition)
+          └─ else: scrobble + record + nextSong
+```
+
+## Invariants
+
+- `abortCrossfade` stamps `crossfadeAbortedAtRef` **before** any other work,
+  unconditionally.
+- Queue eviction is gated on `isLoadFailure` and `isLoadFailure` alone.
+- Exactly one of (onEnded, onCrossfadeComplete, onCrossfadeAbort+songHasEnded,
+  handleNextSong) records a play per song — enforced by `hasScrobbledRef`
+  plus the 3s onEnded suppression after aborts.
+- `playbackSnapshotRef` is the authoritative `(currentTime, duration)` for
+  the outgoing song. Never read `activeDeck.currentTime` directly in a
+  transition path — on rapid skips the deck may already hold the next song.
+- `currentSongIdRef` is updated inside `onCrossfadeComplete` *after* the
+  outgoing song is scrobbled/recorded and *before* `nextSong()` runs.

--- a/docs/architecture/crossfade-playback-decisions.md
+++ b/docs/architecture/crossfade-playback-decisions.md
@@ -63,14 +63,18 @@ Owner: `useCrossfade.ts:122-158` (`abortCrossfade`).
 
 Triggers:
 
-- **5s `canplaythrough` timeout** (line 286-294) — inactive deck never reached
-  readyState >= 3. Reason string contains `timeout`.
+- **10s `canplaythrough` timeout** (line 286-300) — inactive deck never reached
+  readyState >= 2. At the deadline the fallback accepts `readyState >= 3`
+  cleanly and `readyState >= 2` with a warning (plays anyway, may stutter
+  briefly as data buffers). Only `readyState < 2` aborts with reason
+  containing `timeout`.
 - **`play()` rejection** (line 203-206) — typically autoplay policy blocking a
   backgrounded tab. Reason: `play() failed - likely autoplay blocked`.
 - **User pause during ramp** (line 181-188) — store subscription sees
   `isPlaying` flip false.
-- **Safety timeout** after `xfadeDuration + 5s` (line 297-308) if the inactive
-  deck isn't playing and past 1s.
+- **Safety timeout** after `xfadeDuration + 10s` (line 302-314) if the inactive
+  deck isn't playing and past 1s. Must exceed the 10s canplaythrough window so
+  the two don't race.
 - **Completion-time check** (line 197-200) — inactive deck was expected to be
   playing but stopped mid-ramp.
 

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -283,6 +283,21 @@ export function PlayerBar() {
       hasScrobbledRef.current = false;
       scrobbleThresholdReachedRef.current = false;
       nextSong();
+
+      // Queue mutations during the crossfade (addToQueueNext, AI DJ insertions,
+      // removals) can shift the crossfaded song off of currentSongIndex+1.
+      // nextSong() only increments by 1, so after advancing, playlist[currentSongIndex]
+      // may not match the song that's actually playing on the new active deck.
+      // If we don't correct this, useSongLoader will later load the mismatched
+      // song onto the active deck and interrupt playback.
+      const postState = useAudioStore.getState();
+      if (postState.playlist[postState.currentSongIndex]?.id !== song.id) {
+        const actualIndex = postState.playlist.findIndex(s => s.id === song.id);
+        if (actualIndex >= 0) {
+          console.log(`[XFADE] Playlist shifted during crossfade — correcting currentSongIndex ${postState.currentSongIndex} → ${actualIndex}`);
+          useAudioStore.setState({ currentSongIndex: actualIndex });
+        }
+      }
     },
     onCrossfadeAbort: (song, isLoadFailure) => {
       if (song) {

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -36,7 +36,7 @@ import { ResumePlaybackPrompt } from './ResumePlaybackPrompt';
 import { FullscreenPlayer } from './FullscreenPlayer';
 
 // Import extracted hooks
-import { useDualDeckAudio, hasRealSong, Song } from '@/lib/hooks/useDualDeckAudio';
+import { useDualDeckAudio, hasRealSong, Song, SILENT_AUDIO_DATA_URL } from '@/lib/hooks/useDualDeckAudio';
 import { useCrossfade } from '@/lib/hooks/useCrossfade';
 import { useStallRecovery } from '@/lib/hooks/useStallRecovery';
 import { useMediaSession } from '@/lib/hooks/useMediaSession';
@@ -498,6 +498,35 @@ export function PlayerBar() {
         }
         resumeContext();
 
+        // Prime the inactive deck against autoplay policy. Browsers require
+        // a user gesture on each HTMLAudioElement before .play() can run
+        // autonomously; without this, every crossfade's inactiveDeck.play()
+        // is rejected with NotAllowedError and the ramp never starts.
+        // PWA visibility loss can revoke prior authorization, so re-prime on
+        // every user-initiated play rather than just on first gesture.
+        const inactive = getInactiveDeck();
+        if (inactive && inactive !== audio) {
+          const originalSrc = inactive.getAttribute('src');
+          // A play() on an element with no src resolves immediately on some
+          // browsers but still registers the gesture. Using a silent data URL
+          // is the safest portable prime.
+          if (!originalSrc) {
+            inactive.src = SILENT_AUDIO_DATA_URL;
+          }
+          inactive.play()
+            .then(() => {
+              inactive.pause();
+              // Restore clean state — only strip the silent source we just set.
+              if (!originalSrc) {
+                inactive.removeAttribute('src');
+                inactive.load();
+              }
+            })
+            .catch(() => {
+              // Priming is best-effort; don't block the active deck's play.
+            });
+        }
+
         audio.play().catch((e) => {
           setIsLoading(false);
           console.error('Play failed:', e);
@@ -505,7 +534,7 @@ export function PlayerBar() {
       }
       setIsPlaying(!isPlaying);
     }
-  }, [isPlaying, setIsPlaying, getActiveDeck, webAudioInitialized, deckARef, deckBRef, initializeGraph, setMasterVolume, volume, resumeContext]);
+  }, [isPlaying, setIsPlaying, getActiveDeck, getInactiveDeck, webAudioInitialized, deckARef, deckBRef, initializeGraph, setMasterVolume, volume, resumeContext]);
 
   const seek = useCallback((time: number) => {
     const audio = getActiveDeck();

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -328,8 +328,12 @@ export function PlayerBar() {
           crossfadeAbortedAtRef.current = Date.now();
           nextSong();
         } else {
-          console.log(`[XFADE] Crossfade aborted but song still playing — removed failed song, will advance naturally`);
-          // Don't set cooldown — onEnded needs to fire when the current song finishes
+          console.log(`[XFADE] Crossfade aborted but song still playing — will advance naturally`);
+          // Stamp the cooldown so timeupdate doesn't immediately re-enter
+          // startCrossfade on the next tick. Without this, an autoplay-blocked
+          // abort thrashes the inactive deck dozens of times per second and
+          // never lets the current song reach onEnded → no scrobble, no history.
+          crossfadeAbortedAtRef.current = Date.now();
         }
       }
     },

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -283,20 +283,24 @@ export function PlayerBar() {
       scrobbleThresholdReachedRef.current = false;
       nextSong();
     },
-    onCrossfadeAbort: (song) => {
+    onCrossfadeAbort: (song, isLoadFailure) => {
       if (song) {
         const state = useAudioStore.getState();
         const activeDeck = getActiveDeck();
         const songHasEnded = activeDeck && activeDeck.duration > 0 &&
           (activeDeck.currentTime >= activeDeck.duration - 0.5 || activeDeck.ended);
 
-        // Remove the failed song from queue so it's not retried
-        const nextIndex = state.currentSongIndex + 1;
-        if (nextIndex < state.playlist.length && state.playlist[nextIndex]?.id === song.id) {
-          const songName = song.name || song.title || 'Unknown';
-          console.log(`[XFADE] Removing unavailable song "${songName}" from queue (index ${nextIndex})`);
-          toast.warning(`Skipped "${songName}" — unavailable`);
-          state.removeFromQueue(nextIndex);
+        // Only evict when the song genuinely can't load. Autoplay-policy rejects
+        // or user pauses leave the song in the queue so useSongLoader can retry;
+        // its own 10s timeout handles truly broken files.
+        if (isLoadFailure) {
+          const nextIndex = state.currentSongIndex + 1;
+          if (nextIndex < state.playlist.length && state.playlist[nextIndex]?.id === song.id) {
+            const songName = song.name || song.title || 'Unknown';
+            console.log(`[XFADE] Removing unavailable song "${songName}" from queue (index ${nextIndex})`);
+            toast.warning(`Skipped "${songName}" — unavailable`);
+            state.removeFromQueue(nextIndex);
+          }
         }
 
         if (songHasEnded) {

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -248,6 +248,7 @@ export function PlayerBar() {
     getInactiveDeck,
     activeDeckRef,
     crossfadeInProgressRef, // Pass the shared ref
+    crossfadeAbortedAtRef,
     scheduleGainRamp,
     cancelGainRamp,
     setGainImmediate,
@@ -324,16 +325,11 @@ export function PlayerBar() {
           }
           hasScrobbledRef.current = false;
           scrobbleThresholdReachedRef.current = false;
-          // Set cooldown to prevent timeupdate from re-triggering crossfade
-          crossfadeAbortedAtRef.current = Date.now();
+          // Cooldown is stamped inside useCrossfade's abortCrossfade — no
+          // need to re-stamp here.
           nextSong();
         } else {
           console.log(`[XFADE] Crossfade aborted but song still playing — will advance naturally`);
-          // Stamp the cooldown so timeupdate doesn't immediately re-enter
-          // startCrossfade on the next tick. Without this, an autoplay-blocked
-          // abort thrashes the inactive deck dozens of times per second and
-          // never lets the current song reach onEnded → no scrobble, no history.
-          crossfadeAbortedAtRef.current = Date.now();
         }
       }
     },

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -301,6 +301,23 @@ export function PlayerBar() {
 
         if (songHasEnded) {
           console.log(`[XFADE] Crossfade aborted & song ended — advancing to next`);
+          // Record the outgoing song: onEnded will be suppressed by the
+          // abort cooldown below, so this is our only chance to scrobble it.
+          const outgoingSong = currentSong;
+          const outgoingSongId = currentSongIdRef.current;
+          const snapshot = playbackSnapshotRef.current;
+          const outgoingPlayDuration = snapshot.songId === outgoingSongId ? snapshot.currentTime : activeDeck?.currentTime;
+          const outgoingSongDuration = snapshot.songId === outgoingSongId ? snapshot.duration : activeDeck?.duration;
+          if (outgoingSong && outgoingSongId && !hasScrobbledRef.current) {
+            hasScrobbledRef.current = true;
+            scrobbleSong(outgoingSongId, true)
+              .then(() => {
+                queryClient.invalidateQueries({ queryKey: ['most-played-songs'] });
+                queryClient.invalidateQueries({ queryKey: ['top-artists'] });
+              })
+              .catch(console.error);
+            recordListeningHistory(outgoingSong, outgoingSongId, outgoingPlayDuration, outgoingSongDuration);
+          }
           hasScrobbledRef.current = false;
           scrobbleThresholdReachedRef.current = false;
           // Set cooldown to prevent timeupdate from re-triggering crossfade

--- a/src/components/library/ArtistMetadataHero.tsx
+++ b/src/components/library/ArtistMetadataHero.tsx
@@ -79,7 +79,7 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
   // Cross-reference similar artists with the user's library
   const { data: libraryArtists = [] } = useQuery({
     queryKey: ['artists'],
-    queryFn: () => getArtists(0, 5000),
+    queryFn: () => getArtists(0, 10000),
     staleTime: 5 * 60 * 1000,
   });
 

--- a/src/components/library/ArtistsList.tsx
+++ b/src/components/library/ArtistsList.tsx
@@ -16,7 +16,7 @@ import { getArtistGradient, getArtistInitials } from '@/lib/utils/artist-avatar'
 
 const PAGE_SIZE = 60;
 
-function LazyArtistAvatar({
+export function LazyArtistAvatar({
   artistId,
   name,
   savedImageUrl,
@@ -100,7 +100,7 @@ interface ArtistCardProps {
   savedImageUrl?: string;
 }
 
-function ArtistCard({ artist, savedImageUrl }: ArtistCardProps) {
+export function ArtistCard({ artist, savedImageUrl }: ArtistCardProps) {
   const { playSong } = useAudioStore();
 
   const handlePlay = async (e: React.MouseEvent) => {

--- a/src/components/library/ArtistsList.tsx
+++ b/src/components/library/ArtistsList.tsx
@@ -189,7 +189,7 @@ export function ArtistsList() {
     error,
   } = useQuery({
     queryKey: ['artists'],
-    queryFn: () => getArtists(0, 5000),
+    queryFn: () => getArtists(0, 10000),
     staleTime: 5 * 60 * 1000,
   });
 
@@ -240,7 +240,7 @@ export function ArtistsList() {
   return (
     <PageLayout
       title="Artists"
-      description={`${filtered.length} artists in your library`}
+      description={isLoading ? 'Loading…' : `${filtered.length} artists in your library`}
       icon={<Users className="h-5 w-5" />}
       backLink="/dashboard"
       backLabel="Dashboard"

--- a/src/components/library/ArtistsList.tsx
+++ b/src/components/library/ArtistsList.tsx
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useState, useRef, useEffect } from 'react';
 import { getArtists } from '@/lib/services/navidrome';
-import { Users, Search, Play, Music } from 'lucide-react';
-import { Input } from '@/components/ui/input';
-import { Badge } from '@/components/ui/badge';
+import { Users, Play, Music, Search as SearchIcon } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Link } from '@tanstack/react-router';
@@ -136,11 +134,12 @@ export function ArtistCard({ artist, savedImageUrl }: ArtistCardProps) {
             savedImageUrl={savedImageUrl}
           />
         </div>
-        {/* Hover Play Button */}
+        {/* Play Button — always tappable on touch, hover-reveal on desktop */}
         <Button
           size="icon"
-          className="absolute bottom-1 right-1 w-9 h-9 rounded-full shadow-lg shadow-primary/30 opacity-0 group-hover:opacity-100 transition-all duration-200 translate-y-1 group-hover:translate-y-0"
+          className="absolute bottom-1 right-1 w-9 h-9 rounded-full shadow-lg shadow-primary/30 transition-all duration-200 opacity-100 md:opacity-0 md:translate-y-1 md:group-hover:opacity-100 md:group-hover:translate-y-0"
           onClick={handlePlay}
+          aria-label={`Play ${artist.name}`}
         >
           <Play className="h-4 w-4 fill-current" />
         </Button>
@@ -171,10 +170,16 @@ function ArtistCardSkeleton() {
   );
 }
 
-const FILTERS = ['All', 'Most Albums', 'A-Z'] as const;
+const FILTERS = ['Most Albums', 'A-Z'] as const;
+
+type ArtistWithCounts = {
+  id: string;
+  name: string;
+  albumCount?: number;
+  songCount?: number;
+};
 
 export function ArtistsList() {
-  const [search, setSearch] = useState('');
   const [activeFilter, setActiveFilter] = useState<string>('A-Z');
   const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
@@ -200,10 +205,10 @@ export function ArtistsList() {
     staleTime: 5 * 60 * 1000,
   });
 
-  // Filter
-  let filtered = search
-    ? artists.filter((a) => a.name.toLowerCase().includes(search.toLowerCase()))
-    : artists;
+  // Filter out ghost artists (no albums and no songs — tag-only residue)
+  let filtered = (artists as ArtistWithCounts[]).filter(
+    (a) => (a.albumCount ?? 0) > 0 || (a.songCount ?? 0) > 0
+  );
 
   // Sort
   if (activeFilter === 'A-Z') {
@@ -216,11 +221,6 @@ export function ArtistsList() {
 
   const visible = filtered.slice(0, visibleCount);
   const hasMore = visibleCount < filtered.length;
-
-  const handleSearchChange = (value: string) => {
-    setSearch(value);
-    setVisibleCount(PAGE_SIZE);
-  };
 
   if (error) {
     return (
@@ -245,18 +245,9 @@ export function ArtistsList() {
       backLink="/dashboard"
       backLabel="Dashboard"
     >
-      {/* Search + Filters */}
+      {/* Filters + Search link */}
       <PageSection>
-        <div className="space-y-3">
-          <div className="relative max-w-md">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
-            <Input
-              placeholder="Search artists..."
-              value={search}
-              onChange={(e) => handleSearchChange(e.target.value)}
-              className="pl-9 h-10 bg-card/50 backdrop-blur-sm border-border/50 rounded-xl text-sm"
-            />
-          </div>
+        <div className="flex items-center justify-between gap-3 flex-wrap">
           <div className="flex gap-2 flex-wrap">
             {FILTERS.map((f) => (
               <button
@@ -273,6 +264,13 @@ export function ArtistsList() {
               </button>
             ))}
           </div>
+          <Link
+            to="/library/search"
+            className="inline-flex items-center gap-1.5 text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <SearchIcon className="h-3.5 w-3.5" />
+            Search library
+          </Link>
         </div>
       </PageSection>
 
@@ -287,19 +285,8 @@ export function ArtistsList() {
         ) : visible.length === 0 ? (
           <EmptyState
             title="No artists found"
-            description={
-              search
-                ? `No results for "${search}"`
-                : 'Check your library configuration.'
-            }
+            description="Check your library configuration."
             icon={<Music className="h-6 w-6" />}
-            action={
-              search && (
-                <Button variant="outline" onClick={() => setSearch('')}>
-                  Clear Search
-                </Button>
-              )
-            }
           />
         ) : (
           <>

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -13,7 +13,7 @@ export interface UseCrossfadeOptions {
   getGainValue: (deck: 'A' | 'B') => number;
   resumeContext: () => Promise<boolean>;
   onCrossfadeComplete: (nextSong: Song) => void;
-  onCrossfadeAbort: (nextSong: Song | null) => void;
+  onCrossfadeAbort: (nextSong: Song | null, isLoadFailure: boolean) => void;
   canPlayHandlerRef?: React.MutableRefObject<(() => void) | null>;
   errorHandlerRef?: React.MutableRefObject<((e: Event) => void) | null>;
   setActiveDeck: (deck: 'A' | 'B', reason: string, opts?: SetActiveDeckOptions) => boolean;
@@ -147,7 +147,7 @@ export function useCrossfade({
         (activeDeck.currentTime >= activeDeck.duration - 0.5 || activeDeck.ended);
 
       if (isLoadFailure || songHasEnded) {
-        onCrossfadeAbortRef.current(nextSongData);
+        onCrossfadeAbortRef.current(nextSongData, isLoadFailure);
       }
     };
 

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -282,18 +282,28 @@ export function useCrossfade({
 
     inactiveDeck.addEventListener('canplaythrough', onCanPlayThrough);
 
-    // Timeout fallback in case canplaythrough doesn't fire
+    // Timeout fallback in case canplaythrough doesn't fire.
+    // 10s gives cold-cache / first-byte-slow Navidrome streams room to reach
+    // a playable state after a shuffle. At the deadline, accept readyState >= 2
+    // (HAVE_CURRENT_DATA) — enough to start, with any remaining data buffering
+    // mid-ramp. A brief stutter is preferable to evicting a playable song.
     setTimeout(() => {
       if (!crossfadeInProgressRef.current || crossfadeCanPlayFiredRef.current) return;
       if (inactiveDeck.readyState >= 3) {
-        console.log(`[XFADE] Timeout fallback: forcing canplaythrough`);
+        console.log(`[XFADE] Timeout fallback (readyState=${inactiveDeck.readyState}): forcing canplaythrough`);
+        onCanPlayThrough();
+      } else if (inactiveDeck.readyState >= 2) {
+        console.warn(`[XFADE] Timeout fallback (readyState=${inactiveDeck.readyState}, HAVE_CURRENT_DATA): starting playback anyway — may stutter`);
         onCanPlayThrough();
       } else {
         abortCrossfade('timeout - deck never became ready');
       }
-    }, 5000);
+    }, 10000);
 
-    // Safety timeout: if crossfade is still in progress after duration + 5s
+    // Safety timeout: if crossfade is still in progress after duration + 10s.
+    // Must exceed the 10s canplaythrough window above so they don't race —
+    // a short xfadeDuration (e.g. 3s) would otherwise fire safety first and
+    // misclassify a still-loading deck as a hard failure.
     setTimeout(() => {
       if (!crossfadeInProgressRef.current) return;
 
@@ -305,7 +315,7 @@ export function useCrossfade({
         console.warn(`⚠️ [XFADE] Safety timeout: incoming deck not playing - aborting`);
         abortCrossfade('safety timeout exceeded');
       }
-    }, (xfadeDuration + 5) * 1000);
+    }, (xfadeDuration + 10) * 1000);
   // eslint-disable-next-line react-hooks/exhaustive-deps -- onCrossfadeComplete/onCrossfadeAbort accessed via stable refs
   }, [getActiveDeck, getInactiveDeck, activeDeckRef, crossfadeInProgressRef, clearCrossfade, canPlayHandlerRef, errorHandlerRef, scheduleGainRamp, cancelGainRamp, setGainImmediate, setActiveDeck, resumeContext]);
 

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -7,6 +7,7 @@ export interface UseCrossfadeOptions {
   getInactiveDeck: () => HTMLAudioElement | null;
   activeDeckRef: React.MutableRefObject<'A' | 'B'>;
   crossfadeInProgressRef: React.MutableRefObject<boolean>; // Shared ref from parent
+  crossfadeAbortedAtRef: React.MutableRefObject<number>; // Stamped on every abort; drives retry cooldown
   scheduleGainRamp: (deck: 'A' | 'B', target: number, durationSec: number, curve?: 'linear' | 'equalpower') => void;
   cancelGainRamp: (deck: 'A' | 'B') => void;
   setGainImmediate: (deck: 'A' | 'B', value: number) => void;
@@ -42,6 +43,7 @@ export function useCrossfade({
   getInactiveDeck,
   activeDeckRef,
   crossfadeInProgressRef, // Shared ref from parent
+  crossfadeAbortedAtRef,
   scheduleGainRamp,
   cancelGainRamp,
   setGainImmediate,
@@ -119,6 +121,10 @@ export function useCrossfade({
     // Helper to abort crossfade and reset state
     const abortCrossfade = (reason: string) => {
       console.warn(`⚠️ [XFADE] Aborting crossfade: ${reason}`);
+      // Stamp cooldown unconditionally so timeupdate doesn't immediately
+      // re-enter startCrossfade on the next tick. Without this, autoplay-
+      // blocked aborts thrash the inactive deck dozens of times per second.
+      crossfadeAbortedAtRef.current = Date.now();
       inactiveDeck.removeEventListener('canplaythrough', onCanPlayThrough);
       clearCrossfade();
       crossfadeInProgressRef.current = false;

--- a/src/lib/hooks/useDualDeckAudio.ts
+++ b/src/lib/hooks/useDualDeckAudio.ts
@@ -46,9 +46,12 @@ export interface UseDualDeckAudioReturn {
  * - Provides helpers to get active/inactive deck
  * - Centralized setActiveDeck with cooldown to prevent DESYNC ping-pong
  *
- * Note: Deck priming is no longer needed — Web Audio API handles
- * both decks through a single AudioContext, avoiding the iOS
- * single-channel restriction on HTMLAudioElement.
+ * Note: The Web Audio API avoids iOS's single-channel HTMLAudioElement
+ * restriction by routing both decks through a single AudioContext — but
+ * the autoplay gesture policy is separate and still applies per element.
+ * The inactive deck must be primed via a user-gesture-initiated play()
+ * (see PlayerBar.togglePlayPause) or its later crossfade play() call
+ * will be rejected with NotAllowedError.
  */
 export function useDualDeckAudio(): UseDualDeckAudioReturn {
   // Audio element refs

--- a/src/lib/hooks/useSongLoader.ts
+++ b/src/lib/hooks/useSongLoader.ts
@@ -338,7 +338,21 @@ export function useSongLoader({
         // Safety timeout: skip song if it doesn't load within 10 seconds.
         // Browser native error events can take 30+ seconds; this prevents
         // long silences that cause AudioContext suspension on mobile.
+        //
+        // Stale-timeout guard: if a crossfade completed in the intervening 10s,
+        // completeCrossfade reset this deck's src (readyState → 0) and moved
+        // playback to the other deck. Without these guards we'd evict the now-
+        // playing song at the store's currentSongIndex based on a stale deck.
         loadTimeoutId = setTimeout(() => {
+          if (audio !== getActiveDeck()) {
+            console.log(`[PLAYER] Load timeout fired on stale deck (crossfade swapped) — ignoring`);
+            return;
+          }
+          const liveState = useAudioStore.getState();
+          if (liveState.playlist[liveState.currentSongIndex]?.id !== song.id) {
+            console.log(`[PLAYER] Load timeout fired for superseded song — ignoring`);
+            return;
+          }
           if (audio.readyState < 2) {
             console.warn(`[PLAYER] Song load timeout (10s) — readyState=${audio.readyState}`);
             audio.removeEventListener('canplay', handleCanPlay);

--- a/src/lib/services/aurral.ts
+++ b/src/lib/services/aurral.ts
@@ -177,27 +177,49 @@ async function ensureAuthenticated(): Promise<string> {
 
 // ─── HTTP Client ─────────────────────────────────────────────────────────────
 
-const MAX_RETRIES = 3;
+const MAX_RETRIES = 2;
 const BASE_DELAY = 1000;
+const REQUEST_TIMEOUT_MS = 10_000;
 const RETRYABLE_CODES = [408, 429, 500, 502, 503, 504];
 
-async function aurralFetch<T>(path: string, options?: RequestInit & { retries?: number }): Promise<T> {
+async function aurralFetch<T>(path: string, options?: RequestInit & { retries?: number; timeoutMs?: number }): Promise<T> {
   const aurral = await getAurralConfig();
   if (!aurral) throw new Error('Aurral not configured');
 
   const retries = options?.retries ?? MAX_RETRIES;
+  const timeoutMs = options?.timeoutMs ?? REQUEST_TIMEOUT_MS;
 
   for (let attempt = 0; attempt <= retries; attempt++) {
     const token = await ensureAuthenticated();
 
-    const res = await fetch(`${aurral.url}${path}`, {
-      ...options,
-      headers: {
-        'Authorization': `Bearer ${token}`,
-        'Content-Type': 'application/json',
-        ...options?.headers,
-      },
-    });
+    // Per-attempt AbortController so a hung Aurral can't block indefinitely.
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
+
+    let res: Response;
+    try {
+      res = await fetch(`${aurral.url}${path}`, {
+        ...options,
+        headers: {
+          'Authorization': `Bearer ${token}`,
+          'Content-Type': 'application/json',
+          ...options?.headers,
+        },
+        signal: controller.signal,
+      });
+    } catch (err) {
+      clearTimeout(timeoutId);
+      const isAbort = err instanceof Error && err.name === 'AbortError';
+      if (isAbort && attempt < retries) {
+        // One quick retry on timeout; if still hung, surface the error.
+        continue;
+      }
+      if (isAbort) {
+        throw new Error(`Aurral request timed out after ${timeoutMs}ms: ${path}`);
+      }
+      throw err;
+    }
+    clearTimeout(timeoutId);
 
     // Re-auth on 401 (token expired)
     if (res.status === 401 && attempt < retries) {

--- a/src/lib/services/navidrome/library.ts
+++ b/src/lib/services/navidrome/library.ts
@@ -12,7 +12,7 @@ import type {
 
 export async function getArtists(start: number = 0, limit: number = 1000): Promise<Artist[]> {
   try {
-    const endpoint = `/api/artist?_start=${start}&_end=${start + limit - 1}`;
+    const endpoint = `/api/artist?_start=${start}&_end=${start + limit}`;
     const data = await apiFetch(endpoint) as Artist[];
     return data || [];
   } catch (error) {
@@ -38,7 +38,7 @@ export async function searchArtistsByName(query: string, limit: number = 20): Pr
       return artists.map((a) => ({ id: a.id, name: a.name }));
     }
 
-    const nativeEndpoint = `/api/artist?name=${encodeURIComponent(query)}&_start=0&_end=${limit - 1}`;
+    const nativeEndpoint = `/api/artist?name=${encodeURIComponent(query)}&_start=0&_end=${limit}`;
     const nativeResults = await apiFetch(nativeEndpoint) as Artist[];
     return nativeResults || [];
   } catch (error) {
@@ -75,7 +75,7 @@ export async function getArtistsWithDetails(start: number = 0, limit: number = 1
 
 export async function getAlbums(artistId: string, start: number = 0, limit: number = 50): Promise<Album[]> {
   try {
-    const data = await apiFetch(`/api/album?artist_id=${artistId}&_start=${start}&_end=${start + limit - 1}`) as Album[];
+    const data = await apiFetch(`/api/album?artist_id=${artistId}&_start=${start}&_end=${start + limit}`) as Album[];
     return data || [];
   } catch (error) {
     throw new ServiceError('NAVIDROME_API_ERROR', `Failed to fetch albums: ${error instanceof Error ? error.message : 'Unknown error'}`);
@@ -95,7 +95,7 @@ export async function getAlbumDetail(id: string): Promise<AlbumDetail> {
 
 export async function getSongs(albumId: string, start: number = 0, limit: number = 50): Promise<Song[]> {
   try {
-    const data = await apiFetch(`/api/song?album_id=${albumId}&_start=${start}&_end=${start + limit - 1}`) as RawSong[];
+    const data = await apiFetch(`/api/song?album_id=${albumId}&_start=${start}&_end=${start + limit}`) as RawSong[];
     const songs = data.map((song) => ({
       ...song,
       url: `/api/navidrome/stream/${song.id}`,
@@ -108,7 +108,7 @@ export async function getSongs(albumId: string, start: number = 0, limit: number
 
 export async function getSongsByArtist(artistId: string, start: number = 0, limit: number = 100): Promise<Song[]> {
   try {
-    const data = await apiFetch(`/api/song?artist_id=${artistId}&_start=${start}&_end=${start + limit - 1}&_sort=title&_order=ASC`) as RawSong[];
+    const data = await apiFetch(`/api/song?artist_id=${artistId}&_start=${start}&_end=${start + limit}&_sort=title&_order=ASC`) as RawSong[];
     const songs = data.map((song) => ({
       ...song,
       url: `/api/navidrome/stream/${song.id}`,
@@ -144,7 +144,7 @@ export async function getSongsByIds(songIds: string[]): Promise<Song[]> {
 
 export async function getSongsGlobal(start: number = 0, limit: number = 50): Promise<Song[]> {
   try {
-    const data = await apiFetch(`/api/song?_start=${start}&_end=${start + limit - 1}`) as RawSong[];
+    const data = await apiFetch(`/api/song?_start=${start}&_end=${start + limit}`) as RawSong[];
     const songs = data.map((song) => ({
       ...song,
       url: `/api/navidrome/stream/${song.id}`,

--- a/src/routes/api/navidrome/stream/$id.ts
+++ b/src/routes/api/navidrome/stream/$id.ts
@@ -82,9 +82,16 @@ export const Route = createFileRoute("/api/navidrome/stream/$id")({
     headers.set('Accept', '*/*');
 
     try {
+      // Pipe the client's AbortSignal to the upstream fetch so that when the
+      // browser cancels a stream (e.g. inactive deck src cleared on crossfade
+      // abort, or song skip) the connection to Navidrome is released instead
+      // of sitting open until the file finishes. After many songs these
+      // orphaned connections exhaust Navidrome's pool and new streams stop
+      // reaching readyState >= 3 within the 5s canplaythrough window.
       const response = await fetch(streamUrl.toString(), {
         method: 'GET',
         headers,
+        signal: request.signal,
       });
 
       console.log('Navidrome response:', response.status, response.statusText);
@@ -130,6 +137,11 @@ export const Route = createFileRoute("/api/navidrome/stream/$id")({
       });
       
     } catch (error) {
+      // Client-cancelled requests are expected (crossfade abort, skip) — don't
+      // pollute logs or treat them as server errors.
+      if (error instanceof Error && error.name === 'AbortError') {
+        return new Response(null, { status: 499 });
+      }
       console.error('Proxy fetch error:', error);
       return new Response(`Proxy error: ${String(error)}`, { status: 500 });
     }

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -59,7 +59,7 @@ function SearchPage() {
   // instant results and give us albumCount for free (missing from search3.view).
   const { data: allArtists = [], isLoading: isLoadingAllArtists } = useQuery({
     queryKey: ['artists'],
-    queryFn: () => getArtists(0, 5000),
+    queryFn: () => getArtists(0, 10000),
     enabled: query.trim().length > 0,
     staleTime: 5 * 60 * 1000,
   });
@@ -402,7 +402,14 @@ function ArtistAddFallback({ query }: { query: string }) {
     );
   }
 
-  if (!metadata || !metadata.mbid) {
+  // Aurral occasionally returns a metadata record with an mbid but no real
+  // artistName (observed as an empty string or the sentinel "[no artist]"),
+  // which would surface an Add-to-Lidarr button for a ghost. Treat those as
+  // no-match so we never offer to add an unidentified artist.
+  const mbArtistName = metadata?.artistName?.trim();
+  const hasValidMatch = !!(metadata && metadata.mbid && mbArtistName && mbArtistName !== '[no artist]');
+
+  if (!hasValidMatch) {
     return (
       <Card>
         <CardContent className="p-8 sm:p-12 text-center space-y-3">

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -1,5 +1,5 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
-import { useMemo, useState } from 'react';
+import { createFileRoute, redirect, useNavigate } from '@tanstack/react-router';
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { search, getArtists } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
@@ -19,6 +19,9 @@ import { PageLayout } from '@/components/ui/page-layout';
 import { toast } from '@/lib/toast';
 
 export const Route = createFileRoute('/library/search')({
+  validateSearch: (search: Record<string, unknown>): { q?: string } => ({
+    q: typeof search.q === 'string' && search.q.trim().length > 0 ? search.q : undefined,
+  }),
   beforeLoad: async ({ context }) => {
     if (!context.user) {
       throw redirect({ to: '/login' });
@@ -27,9 +30,23 @@ export const Route = createFileRoute('/library/search')({
   component: SearchPage,
 });
 
+// Navidrome's /api/artist endpoint returns extra runtime fields beyond the
+// base type — albumCount, songCount, size. We read them here to filter out
+// ghost artist entries (featured-credit, composer-only, or zero-music rows).
+type ArtistWithCounts = { id: string; name: string; albumCount?: number; songCount?: number };
+
 function SearchPage() {
-  const [query, setQuery] = useState('');
+  const navigate = useNavigate({ from: '/library/search' });
+  const { q } = Route.useSearch();
+  const query = q ?? '';
   const { playSong, setAIUserActionInProgress } = useAudioStore();
+
+  const setQuery = (value: string) => {
+    navigate({
+      search: () => (value.trim().length > 0 ? { q: value } : {}),
+      replace: true,
+    });
+  };
 
   const { data: songs = [], isLoading: isLoadingSongs, error } = useQuery({
     queryKey: ['search', query],
@@ -60,11 +77,30 @@ function SearchPage() {
   });
 
   const matchedArtists = useMemo(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return [];
-    return allArtists
-      .filter((a) => a.name.toLowerCase().includes(q))
-      .slice(0, 20);
+    const needle = query.trim().toLowerCase();
+    if (!needle) return [];
+    const runtimeArtists = allArtists as ArtistWithCounts[];
+
+    const matching = runtimeArtists.filter((a) => {
+      const hasMusic = (a.albumCount ?? 0) > 0 || (a.songCount ?? 0) > 0;
+      return hasMusic && a.name.toLowerCase().includes(needle);
+    });
+
+    // Dedupe by normalized name — Navidrome sometimes creates multiple artist
+    // rows with the same display name (imported at different times, different
+    // MBIDs). Keep the one with the most music.
+    const byName = new Map<string, ArtistWithCounts>();
+    for (const artist of matching) {
+      const key = artist.name.trim().toLowerCase();
+      const existing = byName.get(key);
+      const score = (artist.albumCount ?? 0) * 100 + (artist.songCount ?? 0);
+      const existingScore = existing ? (existing.albumCount ?? 0) * 100 + (existing.songCount ?? 0) : -1;
+      if (!existing || score > existingScore) {
+        byName.set(key, artist);
+      }
+    }
+
+    return Array.from(byName.values()).slice(0, 20);
   }, [allArtists, query]);
 
   const isLoading = isLoadingSongs || (isLoadingAllArtists && allArtists.length === 0);

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -1,14 +1,14 @@
-import { createFileRoute, redirect } from '@tanstack/react-router';
+import { createFileRoute, Link, redirect } from '@tanstack/react-router';
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { search } from '@/lib/services/navidrome';
+import { search, searchArtistsByName } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { NavidromeErrorBoundary } from '@/components/navidrome-error-boundary';
-import { Search as SearchIcon, Plus, Download, CheckCircle2, AlertCircle } from 'lucide-react';
+import { Search as SearchIcon, Plus, Download, CheckCircle2, AlertCircle, User as UserIcon, ChevronRight } from 'lucide-react';
 import { AddToPlaylistButton } from '@/components/playlists/AddToPlaylistButton';
 import { AddToQueueButton } from '@/components/playlists/AddToQueueButton';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
@@ -30,11 +30,19 @@ function SearchPage() {
   const [query, setQuery] = useState('');
   const { playSong, setAIUserActionInProgress } = useAudioStore();
 
-  const { data: songs = [], isLoading, error } = useQuery({
+  const { data: songs = [], isLoading: isLoadingSongs, error } = useQuery({
     queryKey: ['search', query],
     queryFn: () => search(query.trim(), 0, 50),
     enabled: query.trim().length > 0,
   });
+
+  const { data: artists = [], isLoading: isLoadingArtists } = useQuery({
+    queryKey: ['search-artists', query],
+    queryFn: () => searchArtistsByName(query.trim(), 10),
+    enabled: query.trim().length > 0,
+  });
+
+  const isLoading = isLoadingSongs || isLoadingArtists;
 
   // Fetch feedback for displayed songs
   const songIds = songs.map(song => song.id);
@@ -79,7 +87,9 @@ function SearchPage() {
               />
               {query.trim().length > 0 && (
                 <p className="text-sm text-muted-foreground">
-                  {isLoading ? 'Searching...' : `Found ${songs.length} result${songs.length !== 1 ? 's' : ''}`}
+                  {isLoading
+                    ? 'Searching...'
+                    : `Found ${artists.length} artist${artists.length !== 1 ? 's' : ''} and ${songs.length} song${songs.length !== 1 ? 's' : ''}`}
                 </p>
               )}
             </div>
@@ -120,10 +130,55 @@ function SearchPage() {
               </p>
             </CardContent>
           </Card>
-        ) : songs.length === 0 ? (
+        ) : songs.length === 0 && artists.length === 0 ? (
           <ArtistAddFallback query={query.trim()} />
         ) : (
-          <div aria-live="polite" className="space-y-2">
+          <div aria-live="polite" className="space-y-6">
+            {artists.length > 0 && (
+              <section className="space-y-2">
+                <div className="flex items-baseline justify-between px-1">
+                  <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                    Artists
+                  </h2>
+                  <span className="text-xs text-muted-foreground">{artists.length}</span>
+                </div>
+                <div className="space-y-2">
+                  {artists.map((artist) => (
+                    <Link
+                      key={artist.id}
+                      to="/library/artists/$id"
+                      params={{ id: artist.id }}
+                      className="block"
+                    >
+                      <Card className="transition-all hover:shadow-md hover:border-primary/50">
+                        <CardContent className="p-3 sm:p-4">
+                          <div className="flex items-center gap-3">
+                            <div className="h-10 w-10 sm:h-12 sm:w-12 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+                              <UserIcon className="h-5 w-5 text-muted-foreground" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <div className="font-semibold truncate">{artist.name}</div>
+                              <div className="text-xs text-muted-foreground">View discography</div>
+                            </div>
+                            <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
+                          </div>
+                        </CardContent>
+                      </Card>
+                    </Link>
+                  ))}
+                </div>
+              </section>
+            )}
+
+            {songs.length > 0 && (
+              <section className="space-y-2">
+                <div className="flex items-baseline justify-between px-1">
+                  <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                    Songs
+                  </h2>
+                  <span className="text-xs text-muted-foreground">{songs.length}</span>
+                </div>
+                <div className="space-y-2">
             {songs.map((song) => (
               <Card
                 key={song.id}
@@ -240,6 +295,9 @@ function SearchPage() {
                 </CardContent>
               </Card>
             ))}
+                </div>
+              </section>
+            )}
           </div>
         )}
       </PageLayout>

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -1,17 +1,18 @@
-import { createFileRoute, Link, redirect } from '@tanstack/react-router';
-import { useState } from 'react';
+import { createFileRoute, redirect } from '@tanstack/react-router';
+import { useMemo, useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { search, searchArtistsByName } from '@/lib/services/navidrome';
+import { search, getArtists } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { NavidromeErrorBoundary } from '@/components/navidrome-error-boundary';
-import { Search as SearchIcon, Plus, Download, CheckCircle2, AlertCircle, User as UserIcon, ChevronRight } from 'lucide-react';
+import { Search as SearchIcon, Plus, Download, CheckCircle2, AlertCircle } from 'lucide-react';
 import { AddToPlaylistButton } from '@/components/playlists/AddToPlaylistButton';
 import { AddToQueueButton } from '@/components/playlists/AddToQueueButton';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
+import { ArtistCard } from '@/components/library/ArtistsList';
 import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
 import { useArtistMetadata, useAddArtistToLibrary } from '@/lib/hooks/useArtistMetadata';
 import { PageLayout } from '@/components/ui/page-layout';
@@ -36,13 +37,37 @@ function SearchPage() {
     enabled: query.trim().length > 0,
   });
 
-  const { data: artists = [], isLoading: isLoadingArtists } = useQuery({
-    queryKey: ['search-artists', query],
-    queryFn: () => searchArtistsByName(query.trim(), 10),
+  // Reuse the cached full artist list from the browse page (shared query key).
+  // First visit costs one fetch; subsequent searches filter client-side for
+  // instant results and give us albumCount for free (missing from search3.view).
+  const { data: allArtists = [], isLoading: isLoadingAllArtists } = useQuery({
+    queryKey: ['artists'],
+    queryFn: () => getArtists(0, 5000),
     enabled: query.trim().length > 0,
+    staleTime: 5 * 60 * 1000,
   });
 
-  const isLoading = isLoadingSongs || isLoadingArtists;
+  const { data: allArtistImages = {} } = useQuery({
+    queryKey: ['all-artist-images'],
+    queryFn: async () => {
+      const res = await fetch('/api/cover-art/all-artist-images');
+      if (!res.ok) return {};
+      const json = await res.json() as { data?: { images?: Record<string, string> } };
+      return json.data?.images ?? {};
+    },
+    enabled: query.trim().length > 0,
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const matchedArtists = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return [];
+    return allArtists
+      .filter((a) => a.name.toLowerCase().includes(q))
+      .slice(0, 20);
+  }, [allArtists, query]);
+
+  const isLoading = isLoadingSongs || (isLoadingAllArtists && allArtists.length === 0);
 
   // Fetch feedback for displayed songs
   const songIds = songs.map(song => song.id);
@@ -89,7 +114,7 @@ function SearchPage() {
                 <p className="text-sm text-muted-foreground">
                   {isLoading
                     ? 'Searching...'
-                    : `Found ${artists.length} artist${artists.length !== 1 ? 's' : ''} and ${songs.length} song${songs.length !== 1 ? 's' : ''}`}
+                    : `Found ${matchedArtists.length} artist${matchedArtists.length !== 1 ? 's' : ''} and ${songs.length} song${songs.length !== 1 ? 's' : ''}`}
                 </p>
               )}
             </div>
@@ -130,41 +155,30 @@ function SearchPage() {
               </p>
             </CardContent>
           </Card>
-        ) : songs.length === 0 && artists.length === 0 ? (
+        ) : songs.length === 0 && matchedArtists.length === 0 ? (
           <ArtistAddFallback query={query.trim()} />
         ) : (
           <div aria-live="polite" className="space-y-6">
-            {artists.length > 0 && (
-              <section className="space-y-2">
+            {matchedArtists.length > 0 && (
+              <section className="space-y-3">
                 <div className="flex items-baseline justify-between px-1">
-                  <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
-                    Artists
-                  </h2>
-                  <span className="text-xs text-muted-foreground">{artists.length}</span>
+                  <div className="flex items-baseline gap-2">
+                    <h2 className="text-sm font-semibold uppercase tracking-wide text-muted-foreground">
+                      Artists in library
+                    </h2>
+                    <span className="text-xs text-green-600 dark:text-green-400 font-medium">
+                      • Available
+                    </span>
+                  </div>
+                  <span className="text-xs text-muted-foreground">{matchedArtists.length}</span>
                 </div>
-                <div className="space-y-2">
-                  {artists.map((artist) => (
-                    <Link
+                <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-3 sm:gap-4">
+                  {matchedArtists.map((artist) => (
+                    <ArtistCard
                       key={artist.id}
-                      to="/library/artists/$id"
-                      params={{ id: artist.id }}
-                      className="block"
-                    >
-                      <Card className="transition-all hover:shadow-md hover:border-primary/50">
-                        <CardContent className="p-3 sm:p-4">
-                          <div className="flex items-center gap-3">
-                            <div className="h-10 w-10 sm:h-12 sm:w-12 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
-                              <UserIcon className="h-5 w-5 text-muted-foreground" />
-                            </div>
-                            <div className="flex-1 min-w-0">
-                              <div className="font-semibold truncate">{artist.name}</div>
-                              <div className="text-xs text-muted-foreground">View discography</div>
-                            </div>
-                            <ChevronRight className="h-5 w-5 text-muted-foreground flex-shrink-0" />
-                          </div>
-                        </CardContent>
-                      </Card>
-                    </Link>
+                      artist={artist}
+                      savedImageUrl={allArtistImages[artist.name.toLowerCase()]}
+                    />
                   ))}
                 </div>
               </section>

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -3,16 +3,19 @@ import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import { search } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
+import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Skeleton } from '@/components/ui/skeleton';
 import { NavidromeErrorBoundary } from '@/components/navidrome-error-boundary';
-import { Search as SearchIcon } from 'lucide-react';
+import { Search as SearchIcon, Plus, Download, CheckCircle2, AlertCircle } from 'lucide-react';
 import { AddToPlaylistButton } from '@/components/playlists/AddToPlaylistButton';
 import { AddToQueueButton } from '@/components/playlists/AddToQueueButton';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
 import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
+import { useArtistMetadata, useAddArtistToLibrary } from '@/lib/hooks/useArtistMetadata';
 import { PageLayout } from '@/components/ui/page-layout';
+import { toast } from '@/lib/toast';
 
 export const Route = createFileRoute('/library/search')({
   beforeLoad: async ({ context }) => {
@@ -118,12 +121,7 @@ function SearchPage() {
             </CardContent>
           </Card>
         ) : songs.length === 0 ? (
-          <Card>
-            <CardContent className="p-12 text-center">
-              <h3 className="font-semibold text-lg mb-2">No results found for "{query}"</h3>
-              <p className="text-sm text-muted-foreground">Try different keywords or check your spelling.</p>
-            </CardContent>
-          </Card>
+          <ArtistAddFallback query={query.trim()} />
         ) : (
           <div aria-live="polite" className="space-y-2">
             {songs.map((song) => (
@@ -246,5 +244,161 @@ function SearchPage() {
         )}
       </PageLayout>
     </NavidromeErrorBoundary>
+  );
+}
+
+// When Navidrome returns no results, try Aurral to resolve the query to a
+// MusicBrainz artist and offer a one-click "Add to Lidarr" fallback. If Aurral
+// can't resolve it either, fall back to a clear "not available" state.
+function ArtistAddFallback({ query }: { query: string }) {
+  const { data: metadata, isLoading, isError } = useArtistMetadata(query, {
+    enabled: query.length > 0,
+  });
+  const addArtist = useAddArtistToLibrary();
+
+  if (isLoading) {
+    return (
+      <Card>
+        <CardContent className="p-6 sm:p-8 space-y-4">
+          <div className="flex items-center gap-4">
+            <Skeleton className="h-20 w-20 rounded-full flex-shrink-0" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-5 w-1/2" />
+              <Skeleton className="h-4 w-1/3" />
+              <Skeleton className="h-4 w-2/3" />
+            </div>
+          </div>
+          <p className="text-xs text-muted-foreground text-center">
+            Searching MusicBrainz for "{query}"…
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const notFound = isError || !metadata || !metadata.mbid;
+
+  if (notFound) {
+    return (
+      <Card>
+        <CardContent className="p-8 sm:p-12 text-center space-y-3">
+          <AlertCircle className="h-10 w-10 mx-auto text-muted-foreground opacity-60" />
+          <h3 className="font-semibold text-lg">No results for "{query}"</h3>
+          <p className="text-sm text-muted-foreground">
+            Not in your library, and MusicBrainz couldn't match this artist either.
+          </p>
+          <p className="text-xs text-muted-foreground">
+            Try different keywords, check spelling, or search by the artist's official name.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const alreadyMonitored = metadata.lidarrMonitored;
+  const topGenres = metadata.genres.slice(0, 3);
+  const formedLabel = metadata.formedYear ? `formed ${metadata.formedYear}` : null;
+  const countryLabel = metadata.country ?? null;
+  const details = [countryLabel, formedLabel].filter(Boolean).join(' • ');
+
+  const handleAdd = () => {
+    if (!metadata.mbid) return;
+    addArtist.mutate(
+      { mbid: metadata.mbid, artistName: metadata.artistName },
+      {
+        onSuccess: () => {
+          toast.success(`${metadata.artistName} queued for download via Lidarr`);
+        },
+        onError: (err) => {
+          toast.error(`Failed to add artist: ${err.message}`);
+        },
+      },
+    );
+  };
+
+  return (
+    <Card className="border-primary/30">
+      <CardContent className="p-6 sm:p-8 space-y-5">
+        <div>
+          <p className="text-sm text-muted-foreground">
+            Not in your library. Found on MusicBrainz:
+          </p>
+        </div>
+
+        <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4">
+          {metadata.coverImageUrl ? (
+            <img
+              src={metadata.coverImageUrl}
+              alt={metadata.artistName}
+              className="h-24 w-24 sm:h-28 sm:w-28 rounded-full object-cover flex-shrink-0 border"
+              loading="lazy"
+            />
+          ) : (
+            <div className="h-24 w-24 sm:h-28 sm:w-28 rounded-full bg-muted flex items-center justify-center flex-shrink-0">
+              <SearchIcon className="h-10 w-10 text-muted-foreground opacity-50" />
+            </div>
+          )}
+
+          <div className="flex-1 min-w-0 text-center sm:text-left space-y-1.5">
+            <h3 className="font-semibold text-xl truncate">{metadata.artistName}</h3>
+            {metadata.disambiguation && (
+              <p className="text-sm text-muted-foreground truncate">{metadata.disambiguation}</p>
+            )}
+            {details && (
+              <p className="text-xs text-muted-foreground">{details}</p>
+            )}
+            {topGenres.length > 0 && (
+              <div className="flex flex-wrap gap-1.5 justify-center sm:justify-start pt-1">
+                {topGenres.map((genre) => (
+                  <span
+                    key={genre}
+                    className="text-xs bg-muted px-2 py-0.5 rounded-full text-muted-foreground"
+                  >
+                    {genre}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+        </div>
+
+        <div className="pt-1 border-t">
+          {alreadyMonitored ? (
+            <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground py-2">
+              <CheckCircle2 className="h-4 w-4 text-green-500" />
+              <span>Already monitored in Lidarr — songs will appear as they download.</span>
+            </div>
+          ) : addArtist.isSuccess ? (
+            <div className="flex items-center justify-center gap-2 text-sm text-green-600 dark:text-green-400 py-2">
+              <CheckCircle2 className="h-4 w-4" />
+              <span>Queued for download. Lidarr will notify when it finishes.</span>
+            </div>
+          ) : (
+            <div className="flex flex-col sm:flex-row items-center gap-3">
+              <p className="text-xs text-muted-foreground flex-1 text-center sm:text-left">
+                Add to Lidarr to monitor this artist and auto-download new releases.
+              </p>
+              <Button
+                onClick={handleAdd}
+                disabled={addArtist.isPending}
+                className="min-h-[44px] w-full sm:w-auto"
+              >
+                {addArtist.isPending ? (
+                  <>
+                    <Download className="h-4 w-4 mr-2 animate-pulse" />
+                    Adding…
+                  </>
+                ) : (
+                  <>
+                    <Plus className="h-4 w-4 mr-2" />
+                    Add to Lidarr
+                  </>
+                )}
+              </Button>
+            </div>
+          )}
+        </div>
+      </CardContent>
+    </Card>
   );
 }

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -13,6 +13,7 @@ import { AddToPlaylistButton } from '@/components/playlists/AddToPlaylistButton'
 import { AddToQueueButton } from '@/components/playlists/AddToQueueButton';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
 import { ArtistCard } from '@/components/library/ArtistsList';
+import { AlbumArt } from '@/components/ui/album-art';
 import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
 import { useArtistMetadata, useAddArtistToLibrary } from '@/lib/hooks/useArtistMetadata';
 import { PageLayout } from '@/components/ui/page-layout';
@@ -237,9 +238,12 @@ function SearchPage() {
                 <CardContent className="p-3 sm:p-4">
                   {/* Desktop layout: single row */}
                   <div className="hidden sm:flex items-center gap-3">
-                    <div className="w-8 text-right text-sm text-muted-foreground flex-shrink-0">
-                      {song.track}
-                    </div>
+                    <AlbumArt
+                      albumId={song.albumId}
+                      songId={song.id}
+                      artist={song.artist}
+                      size="sm"
+                    />
                     <div
                       className="flex-1 min-w-0 cursor-pointer"
                       onClick={() => handleSongClick(song.id)}
@@ -289,14 +293,17 @@ function SearchPage() {
 
                   {/* Mobile layout: two rows for better button visibility */}
                   <div className="sm:hidden space-y-1.5">
-                    {/* Row 1: Track number, song info (tappable) */}
+                    {/* Row 1: Album art, song info (tappable) */}
                     <div
-                      className="flex items-center gap-2 cursor-pointer"
+                      className="flex items-center gap-2.5 cursor-pointer"
                       onClick={() => handleSongClick(song.id)}
                     >
-                      <div className="w-6 text-right text-xs text-muted-foreground flex-shrink-0">
-                        {song.track}
-                      </div>
+                      <AlbumArt
+                        albumId={song.albumId}
+                        songId={song.id}
+                        artist={song.artist}
+                        size="sm"
+                      />
                       <div className="flex-1 min-w-0">
                         <div className="font-semibold text-sm truncate">{song.name || song.title || 'Unknown Song'}</div>
                         <div className="text-xs text-muted-foreground truncate">

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -276,9 +276,25 @@ function ArtistAddFallback({ query }: { query: string }) {
     );
   }
 
-  const notFound = isError || !metadata || !metadata.mbid;
+  // Distinguish "MusicBrainz has no match" from "Aurral service unreachable".
+  // The metadata endpoint returns null for both, but isError flags fetch/timeout failures.
+  if (isError) {
+    return (
+      <Card>
+        <CardContent className="p-8 sm:p-12 text-center space-y-3">
+          <AlertCircle className="h-10 w-10 mx-auto text-destructive opacity-70" />
+          <h3 className="font-semibold text-lg">MusicBrainz lookup unavailable</h3>
+          <p className="text-sm text-muted-foreground">
+            Couldn't reach the metadata service. "{query}" isn't in your library, and we
+            can't offer to add it right now.
+          </p>
+          <p className="text-xs text-muted-foreground">Try again in a moment.</p>
+        </CardContent>
+      </Card>
+    );
+  }
 
-  if (notFound) {
+  if (!metadata || !metadata.mbid) {
     return (
       <Card>
         <CardContent className="p-8 sm:p-12 text-center space-y-3">


### PR DESCRIPTION
## Summary
When the library search returns no results, we now try Aurral/MusicBrainz to resolve the query to an artist and offer a one-click **Add to Lidarr** action — closing the gap where users naturally searched for an artist we didn't have, and hit a dead-end "No results" screen.

Three possible states replace the old static empty message:

1. **Artist found on MusicBrainz, not yet in Lidarr** → card with cover, canonical name, disambiguation, country/formed year, top genres, and an **Add to Lidarr** button. Queues via existing \`POST /api/aurral/add-artist\`.
2. **Artist already monitored in Lidarr** → explicit "already monitored" status so users know it's downloading.
3. **Aurral can't match either** → clear "not available" state with guidance.

No new endpoints or hooks — \`useArtistMetadata\` and \`useAddArtistToLibrary\` already existed, they were just never wired into the search empty-state.

## Test plan
- [ ] Search for an artist not in your Navidrome library but known on MusicBrainz (e.g. a brand-new release) — verify card appears with Add button
- [ ] Click Add — verify toast, Lidarr queues the artist, card switches to "Queued for download"
- [ ] Search for an artist already monitored in Lidarr but not yet downloaded — verify "Already monitored" state
- [ ] Search for nonsense string ("xzyqqq") — verify "not available" fallback
- [ ] Mobile: verify card stacks properly, Add button is full-width, min 44px tap target
- [ ] Aurral disabled (strip config) — verify it gracefully falls back to the "not available" state

🤖 Generated with [Claude Code](https://claude.com/claude-code)