### PR TITLE
feat: Seeded radio + iOS audio fixes + cross-device gating + AI DJ affinity recompute

### DIFF
--- a/drizzle/0025_artist_cooccurrence.sql
+++ b/drizzle/0025_artist_cooccurrence.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "artist_cooccurrence" (
+	"id" text PRIMARY KEY NOT NULL,
+	"user_id" text NOT NULL,
+	"artist_a" text NOT NULL,
+	"artist_b" text NOT NULL,
+	"cooccurrence_score" real DEFAULT 0 NOT NULL,
+	"coplay_count" integer DEFAULT 0 NOT NULL,
+	"last_coplayed_at" timestamp,
+	"calculated_at" timestamp NOT NULL,
+	CONSTRAINT "artist_cooccurrence_unique" UNIQUE("user_id","artist_a","artist_b")
+);
+--> statement-breakpoint
+ALTER TABLE "artist_cooccurrence" ADD CONSTRAINT "artist_cooccurrence_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "artist_cooccurrence_user_artist_score_idx" ON "artist_cooccurrence" USING btree ("user_id","artist_a","cooccurrence_score");--> statement-breakpoint
+CREATE INDEX "artist_cooccurrence_user_id_idx" ON "artist_cooccurrence" USING btree ("user_id");

--- a/drizzle/meta/0025_snapshot.json
+++ b/drizzle/meta/0025_snapshot.json
@@ -1,0 +1,7658 @@
+{
+  "id": "56d300f3-b2b5-4806-92c2-43fc3c3915b6",
+  "prevId": "ddd1fb4e-0174-47cb-b93f-c5f033266720",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations_cache": {
+      "name": "recommendations_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_count": {
+          "name": "feedback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recommendations_cache_user_id_user_id_fk": {
+          "name": "recommendations_cache_user_id_user_id_fk",
+          "tableFrom": "recommendations_cache",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_settings": {
+          "name": "recommendation_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"aiEnabled\":true,\"frequency\":\"always\",\"styleBasedPlaylists\":true,\"useFeedbackForPersonalization\":true,\"enableSeasonalRecommendations\":true,\"syncFeedbackToNavidrome\":true,\"aiDJEnabled\":false,\"aiDJQueueThreshold\":2,\"aiDJBatchSize\":3,\"aiDJUseCurrentContext\":true,\"aiDJGenreExploration\":50,\"autoplayEnabled\":false,\"autoplayBlendMode\":\"crossfade\",\"autoplayTransitionDuration\":4,\"autoplaySmartTransitions\":true}'::jsonb"
+        },
+        "playback_settings": {
+          "name": "playback_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"volume\":0.5,\"autoplayNext\":true,\"crossfadeDuration\":0,\"defaultQuality\":\"high\"}'::jsonb"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"browserNotifications\":false,\"downloadCompletion\":true,\"recommendationUpdates\":true}'::jsonb"
+        },
+        "dashboard_layout": {
+          "name": "dashboard_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"showRecommendations\":true,\"showRecentlyPlayed\":true,\"widgetOrder\":[\"recommendations\",\"recentlyPlayed\"]}'::jsonb"
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_feedback": {
+      "name": "recommendation_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_cache_id": {
+          "name": "recommendation_cache_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommendation'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hour_of_day": {
+          "name": "hour_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_feedback_user_id_idx": {
+          "name": "recommendation_feedback_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_timestamp_idx": {
+          "name": "recommendation_feedback_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_cache_id_idx": {
+          "name": "recommendation_feedback_cache_id_idx",
+          "columns": [
+            {
+              "expression": "recommendation_cache_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_type_time_idx": {
+          "name": "recommendation_feedback_user_type_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedback_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_month_idx": {
+          "name": "recommendation_feedback_month_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_season_idx": {
+          "name": "recommendation_feedback_season_idx",
+          "columns": [
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_season_idx": {
+          "name": "recommendation_feedback_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_month_idx": {
+          "name": "recommendation_feedback_user_month_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_song_id_idx": {
+          "name": "recommendation_feedback_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_song_id_idx": {
+          "name": "recommendation_feedback_user_song_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_feedback_user_id_user_id_fk": {
+          "name": "recommendation_feedback_user_id_user_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk": {
+          "name": "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "recommendations_cache",
+          "columnsFrom": [
+            "recommendation_cache_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recommendation_feedback_user_song_unique": {
+          "name": "recommendation_feedback_user_song_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_songs": {
+      "name": "playlist_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_songs_playlist_id_idx": {
+          "name": "playlist_songs_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_song_id_idx": {
+          "name": "playlist_songs_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_position_idx": {
+          "name": "playlist_songs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_songs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_songs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_songs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_song": {
+          "name": "unique_playlist_song",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlists": {
+      "name": "user_playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navidrome_id": {
+          "name": "navidrome_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_playlist_criteria": {
+          "name": "smart_playlist_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_playlists_user_id_idx": {
+          "name": "user_playlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_created_at_idx": {
+          "name": "user_playlists_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_navidrome_id_idx": {
+          "name": "user_playlists_navidrome_id_idx",
+          "columns": [
+            {
+              "expression": "navidrome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlists_user_id_user_id_fk": {
+          "name": "user_playlists_user_id_user_id_fk",
+          "tableFrom": "user_playlists",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_playlist_name": {
+          "name": "unique_user_playlist_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaboration_activity": {
+      "name": "collaboration_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_playlist_id_idx": {
+          "name": "activity_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_id_idx": {
+          "name": "activity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_created_at_idx": {
+          "name": "activity_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collaboration_activity_playlist_id_user_playlists_id_fk": {
+          "name": "collaboration_activity_playlist_id_user_playlists_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaboration_activity_user_id_user_id_fk": {
+          "name": "collaboration_activity_user_id_user_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaboration_settings": {
+      "name": "playlist_collaboration_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "playlist_privacy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_approve_threshold": {
+          "name": "auto_approve_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "max_suggestions_per_user": {
+          "name": "max_suggestions_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "max_total_suggestions": {
+          "name": "max_total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notify_on_suggestion": {
+          "name": "notify_on_suggestion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_on_vote": {
+          "name": "notify_on_vote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_approval": {
+          "name": "notify_on_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_code": {
+          "name": "share_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collab_settings_playlist_id_idx": {
+          "name": "collab_settings_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_settings_share_code_idx": {
+          "name": "collab_settings_share_code_idx",
+          "columns": [
+            {
+              "expression": "share_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaboration_settings_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaboration_settings_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaboration_settings",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlist_collaboration_settings_playlist_id_unique": {
+          "name": "playlist_collaboration_settings_playlist_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id"
+          ]
+        },
+        "playlist_collaboration_settings_share_code_unique": {
+          "name": "playlist_collaboration_settings_share_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaborators": {
+      "name": "playlist_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "collaborator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "collaborators_playlist_id_idx": {
+          "name": "collaborators_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collaborators_user_id_idx": {
+          "name": "collaborators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaborators_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaborators_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_user_id_user_id_fk": {
+          "name": "playlist_collaborators_user_id_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_invited_by_user_id_fk": {
+          "name": "playlist_collaborators_invited_by_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_collaborator": {
+          "name": "unique_playlist_collaborator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_suggestions": {
+      "name": "playlist_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_title": {
+          "name": "song_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist": {
+          "name": "song_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_album": {
+          "name": "song_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_checked_at": {
+          "name": "availability_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suggestions_playlist_id_idx": {
+          "name": "suggestions_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_suggested_by_idx": {
+          "name": "suggestions_suggested_by_idx",
+          "columns": [
+            {
+              "expression": "suggested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_status_idx": {
+          "name": "suggestions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_score_idx": {
+          "name": "suggestions_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_suggestions_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_suggestions_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_suggested_by_user_id_fk": {
+          "name": "playlist_suggestions_suggested_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "suggested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_processed_by_user_id_fk": {
+          "name": "playlist_suggestions_processed_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_song_playlist": {
+          "name": "unique_suggestion_song_playlist",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestion_votes": {
+      "name": "suggestion_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_suggestion_id_idx": {
+          "name": "votes_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestion_votes_suggestion_id_playlist_suggestions_id_fk": {
+          "name": "suggestion_votes_suggestion_id_playlist_suggestions_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "playlist_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestion_votes_user_id_user_id_fk": {
+          "name": "suggestion_votes_user_id_user_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_vote": {
+          "name": "unique_suggestion_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suggestion_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_profiles": {
+      "name": "library_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_distribution": {
+          "name": "genre_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_keywords": {
+          "name": "top_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_needed": {
+          "name": "refresh_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "library_profiles_user_id_idx": {
+          "name": "library_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_last_analyzed_idx": {
+          "name": "library_profiles_last_analyzed_idx",
+          "columns": [
+            {
+              "expression": "last_analyzed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_refresh_needed_idx": {
+          "name": "library_profiles_refresh_needed_idx",
+          "columns": [
+            {
+              "expression": "refresh_needed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_profiles_user_id_user_id_fk": {
+          "name": "library_profiles_user_id_user_id_fk",
+          "tableFrom": "library_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_profiles_user_id_unique": {
+          "name": "library_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compound_scores": {
+      "name": "compound_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_count": {
+          "name": "source_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recency_weighted_score": {
+          "name": "recency_weighted_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "compound_scores_user_id_idx": {
+          "name": "compound_scores_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_user_score_idx": {
+          "name": "compound_scores_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_song_id_idx": {
+          "name": "compound_scores_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compound_scores_user_id_user_id_fk": {
+          "name": "compound_scores_user_id_user_id_fk",
+          "tableFrom": "compound_scores",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compound_scores_unique": {
+          "name": "compound_scores_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_history": {
+      "name": "listening_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_detected": {
+          "name": "skip_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "listening_history_user_id_idx": {
+          "name": "listening_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_played_at_idx": {
+          "name": "listening_history_played_at_idx",
+          "columns": [
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_user_played_at_idx": {
+          "name": "listening_history_user_played_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_song_id_idx": {
+          "name": "listening_history_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_artist_idx": {
+          "name": "listening_history_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_skip_idx": {
+          "name": "listening_history_skip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skip_detected",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_history_user_id_user_id_fk": {
+          "name": "listening_history_user_id_user_id_fk",
+          "tableFrom": "listening_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.track_similarities": {
+      "name": "track_similarities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_artist": {
+          "name": "source_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_title": {
+          "name": "source_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist": {
+          "name": "target_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_song_id": {
+          "name": "target_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "track_similarities_source_idx": {
+          "name": "track_similarities_source_idx",
+          "columns": [
+            {
+              "expression": "source_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_idx": {
+          "name": "track_similarities_target_idx",
+          "columns": [
+            {
+              "expression": "target_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_song_id_idx": {
+          "name": "track_similarities_target_song_id_idx",
+          "columns": [
+            {
+              "expression": "target_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_expires_at_idx": {
+          "name": "track_similarities_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "track_similarities_unique": {
+          "name": "track_similarities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_artist",
+            "source_title",
+            "target_artist",
+            "target_title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_artists": {
+      "name": "indexed_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_artist_id": {
+          "name": "navidrome_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_count": {
+          "name": "album_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_artists_user_id_idx": {
+          "name": "indexed_artists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_user_artist_idx": {
+          "name": "indexed_artists_user_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_name_idx": {
+          "name": "indexed_artists_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_songs": {
+      "name": "indexed_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_song_id": {
+          "name": "navidrome_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_key": {
+          "name": "song_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_songs_user_id_idx": {
+          "name": "indexed_songs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_user_song_idx": {
+          "name": "indexed_songs_user_song_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_song_key_idx": {
+          "name": "indexed_songs_song_key_idx",
+          "columns": [
+            {
+              "expression": "song_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_artist_idx": {
+          "name": "indexed_songs_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_synced_at_idx": {
+          "name": "indexed_songs_synced_at_idx",
+          "columns": [
+            {
+              "expression": "synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sync_state": {
+      "name": "library_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_sync_at": {
+          "name": "last_full_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_incremental_sync_at": {
+          "name": "last_incremental_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_items": {
+          "name": "processed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_frequency_minutes": {
+          "name": "sync_frequency_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "max_concurrent_requests": {
+          "name": "max_concurrent_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_sync_duration_ms": {
+          "name": "last_sync_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_songs_indexed": {
+          "name": "total_songs_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_artists_indexed": {
+          "name": "total_artists_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_albums_indexed": {
+          "name": "total_albums_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sync_state_user_id_idx": {
+          "name": "library_sync_state_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_error_log": {
+      "name": "sync_error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_session_id": {
+          "name": "sync_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_error_log_user_id_idx": {
+          "name": "sync_error_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_session_idx": {
+          "name": "sync_error_log_session_idx",
+          "columns": [
+            {
+              "expression": "sync_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_created_at_idx": {
+          "name": "sync_error_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mood_snapshots": {
+      "name": "mood_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_distribution": {
+          "name": "mood_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_listens": {
+          "name": "total_listens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_feedback": {
+          "name": "total_feedback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_up_count": {
+          "name": "thumbs_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_down_count": {
+          "name": "thumbs_down_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "acceptance_rate": {
+          "name": "acceptance_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diversity_score": {
+          "name": "diversity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mood_snapshots_user_id_idx": {
+          "name": "mood_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_start_idx": {
+          "name": "mood_snapshots_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_idx": {
+          "name": "mood_snapshots_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_type_idx": {
+          "name": "mood_snapshots_period_type_idx",
+          "columns": [
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_type_idx": {
+          "name": "mood_snapshots_user_period_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mood_snapshots_user_id_user_id_fk": {
+          "name": "mood_snapshots_user_id_user_id_fk",
+          "tableFrom": "mood_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_history": {
+      "name": "recommendation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_songs": {
+          "name": "recommended_songs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_context": {
+          "name": "mood_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_factors": {
+          "name": "reasoning_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taste_profile_snapshot": {
+          "name": "taste_profile_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_history_user_id_idx": {
+          "name": "recommendation_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_generated_at_idx": {
+          "name": "recommendation_history_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_user_generated_at_idx": {
+          "name": "recommendation_history_user_generated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_source_idx": {
+          "name": "recommendation_history_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_history_user_id_user_id_fk": {
+          "name": "recommendation_history_user_id_user_id_fk",
+          "tableFrom": "recommendation_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_snapshots": {
+      "name": "taste_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_data": {
+          "name": "profile_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_formats": {
+          "name": "export_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_generated": {
+          "name": "is_auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "taste_snapshots_user_id_idx": {
+          "name": "taste_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "taste_snapshots_captured_at_idx": {
+          "name": "taste_snapshots_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "taste_snapshots_user_id_user_id_fk": {
+          "name": "taste_snapshots_user_id_user_id_fk",
+          "tableFrom": "taste_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_analytics": {
+      "name": "discovery_feed_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_level": {
+          "name": "aggregation_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items_shown": {
+          "name": "total_items_shown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_clicks": {
+          "name": "total_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_plays": {
+          "name": "total_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_duration": {
+          "name": "total_play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_saves": {
+          "name": "total_saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_skips": {
+          "name": "total_skips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dismissals": {
+          "name": "total_dismissals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_likes": {
+          "name": "total_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dislikes": {
+          "name": "total_dislikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_not_interested": {
+          "name": "total_not_interested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_through_rate": {
+          "name": "click_through_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "play_rate": {
+          "name": "play_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "save_rate": {
+          "name": "save_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "dismissal_rate": {
+          "name": "dismissal_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "time_slot_breakdown": {
+          "name": "time_slot_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notifications_sent": {
+          "name": "notifications_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notifications_opened": {
+          "name": "notifications_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notification_open_rate": {
+          "name": "notification_open_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_analytics_period_idx": {
+          "name": "discovery_feed_analytics_period_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_analytics_user_id_idx": {
+          "name": "discovery_feed_analytics_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_analytics_user_id_user_id_fk": {
+          "name": "discovery_feed_analytics_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_analytics",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_feed_analytics_unique": {
+          "name": "discovery_feed_analytics_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "period_start",
+            "aggregation_level",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_items": {
+      "name": "discovery_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendation_source": {
+          "name": "recommendation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "target_time_slot": {
+          "name": "target_time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'any'"
+        },
+        "target_context": {
+          "name": "target_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "shown": {
+          "name": "shown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played": {
+          "name": "played",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_at": {
+          "name": "feedback_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_items_user_id_idx": {
+          "name": "discovery_feed_items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_time_slot_idx": {
+          "name": "discovery_feed_items_user_time_slot_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_shown_at_idx": {
+          "name": "discovery_feed_items_shown_at_idx",
+          "columns": [
+            {
+              "expression": "shown_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_expires_at_idx": {
+          "name": "discovery_feed_items_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_content_idx": {
+          "name": "discovery_feed_items_user_content_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_items_user_id_user_id_fk": {
+          "name": "discovery_feed_items_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_notification_preferences": {
+      "name": "discovery_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "preferred_times": {
+          "name": "preferred_times",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"09:00\",\"17:00\"]'::jsonb"
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'22:00'"
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "active_days": {
+          "name": "active_days",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[0,1,2,3,4,5,6]'::jsonb"
+        },
+        "include_new_releases": {
+          "name": "include_new_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_personalized": {
+          "name": "include_personalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_time_based_suggestions": {
+          "name": "include_time_based_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_trending": {
+          "name": "include_trending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_notifications_per_day": {
+          "name": "max_notifications_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "computed_optimal_time": {
+          "name": "computed_optimal_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ab_test_group": {
+          "name": "ab_test_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'control'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_notification_prefs_user_id_idx": {
+          "name": "discovery_notification_prefs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_notification_preferences_user_id_user_id_fk": {
+          "name": "discovery_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "discovery_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_notification_preferences_user_id_unique": {
+          "name": "discovery_notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_patterns": {
+      "name": "listening_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "top_moods": {
+          "name": "top_moods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avg_energy": {
+          "name": "avg_energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "avg_bpm": {
+          "name": "avg_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_context": {
+          "name": "primary_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "listening_patterns_user_id_idx": {
+          "name": "listening_patterns_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_time_slot_idx": {
+          "name": "listening_patterns_time_slot_idx",
+          "columns": [
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_user_time_day_idx": {
+          "name": "listening_patterns_user_time_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_patterns_user_id_user_id_fk": {
+          "name": "listening_patterns_user_id_user_id_fk",
+          "tableFrom": "listening_patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "listening_patterns_unique": {
+          "name": "listening_patterns_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "day_of_week"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_notifications": {
+      "name": "scheduled_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ab_test_variant": {
+          "name": "ab_test_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scheduled_notifications_status_scheduled_idx": {
+          "name": "scheduled_notifications_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_user_id_idx": {
+          "name": "scheduled_notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_type_status_idx": {
+          "name": "scheduled_notifications_type_status_idx",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_notifications_user_id_user_id_fk": {
+          "name": "scheduled_notifications_user_id_user_id_fk",
+          "tableFrom": "scheduled_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_credentials": {
+      "name": "platform_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expiry": {
+          "name": "token_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "platform_credentials_user_platform_idx": {
+          "name": "platform_credentials_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_credentials_user_id_user_id_fk": {
+          "name": "platform_credentials_user_id_user_id_fk",
+          "tableFrom": "platform_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_download_jobs": {
+      "name": "playlist_download_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_job_id": {
+          "name": "import_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "completed_items": {
+          "name": "completed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "download_queue": {
+          "name": "download_queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_organization": {
+          "name": "pending_organization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_download_jobs_user_id_idx": {
+          "name": "playlist_download_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_service_idx": {
+          "name": "playlist_download_jobs_service_idx",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_status_idx": {
+          "name": "playlist_download_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_created_at_idx": {
+          "name": "playlist_download_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_download_jobs_user_id_user_id_fk": {
+          "name": "playlist_download_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk": {
+          "name": "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "playlist_import_jobs",
+          "columnsFrom": [
+            "import_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_export_jobs": {
+      "name": "playlist_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exported_data": {
+          "name": "exported_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_export_jobs_user_id_idx": {
+          "name": "playlist_export_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_status_idx": {
+          "name": "playlist_export_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_created_at_idx": {
+          "name": "playlist_export_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_export_jobs_user_id_user_id_fk": {
+          "name": "playlist_export_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_export_jobs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_export_jobs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_import_jobs": {
+      "name": "playlist_import_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_platform": {
+          "name": "target_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_description": {
+          "name": "playlist_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_playlist_id": {
+          "name": "created_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "matched_songs": {
+          "name": "matched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unmatched_songs": {
+          "name": "unmatched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pending_review_songs": {
+          "name": "pending_review_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "match_results": {
+          "name": "match_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_import_jobs_user_id_idx": {
+          "name": "playlist_import_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_status_idx": {
+          "name": "playlist_import_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_created_at_idx": {
+          "name": "playlist_import_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_import_jobs_user_id_user_id_fk": {
+          "name": "playlist_import_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_import_jobs_created_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_import_jobs_created_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "created_playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_identity_summaries": {
+      "name": "music_identity_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_insights": {
+          "name": "ai_insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_profile": {
+          "name": "mood_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_affinities": {
+          "name": "artist_affinities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trend_analysis": {
+          "name": "trend_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_theme": {
+          "name": "card_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_identity_user_id_idx": {
+          "name": "music_identity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_user_period_idx": {
+          "name": "music_identity_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_share_token_idx": {
+          "name": "music_identity_share_token_idx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_identity_summaries_user_id_user_id_fk": {
+          "name": "music_identity_summaries_user_id_user_id_fk",
+          "tableFrom": "music_identity_summaries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lyrics_cache": {
+      "name": "lyrics_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics": {
+          "name": "lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_lyrics": {
+          "name": "synced_lyrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrumental": {
+          "name": "instrumental",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_job_state": {
+      "name": "discovery_job_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "max_suggestions_per_run": {
+          "name": "max_suggestions_per_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "seed_count": {
+          "name": "seed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_running": {
+          "name": "is_running",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_suggestions_generated": {
+          "name": "total_suggestions_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_approved": {
+          "name": "total_approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_rejected": {
+          "name": "total_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_job_state_next_run_at_idx": {
+          "name": "discovery_job_state_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_job_state_enabled_idx": {
+          "name": "discovery_job_state_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_job_state_user_id_user_id_fk": {
+          "name": "discovery_job_state_user_id_user_id_fk",
+          "tableFrom": "discovery_job_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_rejection_history": {
+      "name": "discovery_rejection_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_rejection_expires_at_idx": {
+          "name": "discovery_rejection_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_rejection_user_artist_track_idx": {
+          "name": "discovery_rejection_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_rejection_history_user_id_user_id_fk": {
+          "name": "discovery_rejection_history_user_id_user_id_fk",
+          "tableFrom": "discovery_rejection_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_rejection_unique": {
+          "name": "discovery_rejection_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist_name",
+            "track_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_suggestions": {
+      "name": "discovery_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_artist": {
+          "name": "seed_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_track": {
+          "name": "seed_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lastfm_url": {
+          "name": "lastfm_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discovery_suggestions_user_status_idx": {
+          "name": "discovery_suggestions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_user_artist_track_idx": {
+          "name": "discovery_suggestions_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_match_score_idx": {
+          "name": "discovery_suggestions_match_score_idx",
+          "columns": [
+            {
+              "expression": "match_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_seed_artist_idx": {
+          "name": "discovery_suggestions_seed_artist_idx",
+          "columns": [
+            {
+              "expression": "seed_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_suggestions_user_id_user_id_fk": {
+          "name": "discovery_suggestions_user_id_user_id_fk",
+          "tableFrom": "discovery_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_affinities": {
+      "name": "artist_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity_score": {
+          "name": "affinity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "liked_count": {
+          "name": "liked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_count": {
+          "name": "skip_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_time": {
+          "name": "total_play_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_affinities_user_id_idx": {
+          "name": "artist_affinities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_user_score_idx": {
+          "name": "artist_affinities_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_artist_idx": {
+          "name": "artist_affinities_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_affinities_user_id_user_id_fk": {
+          "name": "artist_affinities_user_id_user_id_fk",
+          "tableFrom": "artist_affinities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_affinities_unique": {
+          "name": "artist_affinities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liked_songs_sync": {
+      "name": "liked_songs_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "liked_songs_sync_user_id_idx": {
+          "name": "liked_songs_sync_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_song_id_idx": {
+          "name": "liked_songs_sync_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_user_active_idx": {
+          "name": "liked_songs_sync_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "liked_songs_sync_user_id_user_id_fk": {
+          "name": "liked_songs_sync_user_id_user_id_fk",
+          "tableFrom": "liked_songs_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "liked_songs_sync_unique": {
+          "name": "liked_songs_sync_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.temporal_preferences": {
+      "name": "temporal_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_score": {
+          "name": "preference_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "temporal_preferences_user_id_idx": {
+          "name": "temporal_preferences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_time_idx": {
+          "name": "temporal_preferences_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_season_idx": {
+          "name": "temporal_preferences_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_genre_idx": {
+          "name": "temporal_preferences_genre_idx",
+          "columns": [
+            {
+              "expression": "genre",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "temporal_preferences_user_id_user_id_fk": {
+          "name": "temporal_preferences_user_id_user_id_fk",
+          "tableFrom": "temporal_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "temporal_preferences_unique": {
+          "name": "temporal_preferences_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "season",
+            "genre"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_cover_art": {
+      "name": "saved_cover_art",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_cover_art_entity_id_unique": {
+          "name": "saved_cover_art_entity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cover_art_fetch_jobs": {
+      "name": "cover_art_fetch_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "found": {
+          "name": "found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "not_found": {
+          "name": "not_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_art_fetch_jobs_user_id_idx": {
+          "name": "cover_art_fetch_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cover_art_fetch_jobs_status_idx": {
+          "name": "cover_art_fetch_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_art_fetch_jobs_user_id_user_id_fk": {
+          "name": "cover_art_fetch_jobs_user_id_user_id_fk",
+          "tableFrom": "cover_art_fetch_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playback_sessions": {
+      "name": "playback_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_device_id": {
+          "name": "active_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_device_name": {
+          "name": "active_device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_device_type": {
+          "name": "active_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "original_queue": {
+          "name": "original_queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_index": {
+          "name": "current_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_position_ms": {
+          "name": "current_position_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_playing": {
+          "name": "is_playing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "is_shuffled": {
+          "name": "is_shuffled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "queue_updated_at": {
+          "name": "queue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "position_updated_at": {
+          "name": "position_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "play_state_updated_at": {
+          "name": "play_state_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "playback_sessions_user_id_idx": {
+          "name": "playback_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playback_sessions_user_id_user_id_fk": {
+          "name": "playback_sessions_user_id_user_id_fk",
+          "tableFrom": "playback_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playback_sessions_user_id_unique": {
+          "name": "playback_sessions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devices_user_id_idx": {
+          "name": "devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explicit_content_cache": {
+      "name": "explicit_content_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_explicit": {
+          "name": "is_explicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deezer'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "explicit_artist_title_idx": {
+          "name": "explicit_artist_title_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.navidrome_users": {
+      "name": "navidrome_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_username": {
+          "name": "navidrome_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_password": {
+          "name": "navidrome_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_salt": {
+          "name": "navidrome_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_token": {
+          "name": "navidrome_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "navidrome_users_user_id_user_id_fk": {
+          "name": "navidrome_users_user_id_user_id_fk",
+          "tableFrom": "navidrome_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "navidrome_users_user_id_unique": {
+          "name": "navidrome_users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "navidrome_users_navidrome_username_unique": {
+          "name": "navidrome_users_navidrome_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "navidrome_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_metadata_cache": {
+      "name": "artist_metadata_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name_normalized": {
+          "name": "artist_name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navidrome_id": {
+          "name": "navidrome_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disambiguation": {
+          "name": "disambiguation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_type": {
+          "name": "artist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formed_year": {
+          "name": "formed_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relations": {
+          "name": "relations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similar_artists": {
+          "name": "similar_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_groups": {
+          "name": "release_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_id": {
+          "name": "lidarr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_monitored": {
+          "name": "lidarr_monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_artist_metadata_name": {
+          "name": "idx_artist_metadata_name",
+          "columns": [
+            {
+              "expression": "artist_name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_metadata_mbid": {
+          "name": "idx_artist_metadata_mbid",
+          "columns": [
+            {
+              "expression": "mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_metadata_navidrome": {
+          "name": "idx_artist_metadata_navidrome",
+          "columns": [
+            {
+              "expression": "navidrome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_cooccurrence": {
+      "name": "artist_cooccurrence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_a": {
+          "name": "artist_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_b": {
+          "name": "artist_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooccurrence_score": {
+          "name": "cooccurrence_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "coplay_count": {
+          "name": "coplay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_coplayed_at": {
+          "name": "last_coplayed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_cooccurrence_user_artist_score_idx": {
+          "name": "artist_cooccurrence_user_artist_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cooccurrence_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_cooccurrence_user_id_idx": {
+          "name": "artist_cooccurrence_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_cooccurrence_user_id_user_id_fk": {
+          "name": "artist_cooccurrence_user_id_user_id_fk",
+          "tableFrom": "artist_cooccurrence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_cooccurrence_unique": {
+          "name": "artist_cooccurrence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist_a",
+            "artist_b"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collaborator_role": {
+      "name": "collaborator_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.playlist_privacy": {
+      "name": "playlist_privacy",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "invite_only"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -176,6 +176,13 @@
       "when": 1774138503717,
       "tag": "0024_glamorous_weapon_omega",
       "breakpoints": true
+    },
+    {
+      "idx": 25,
+      "version": "7",
+      "when": 1776803095399,
+      "tag": "0025_artist_cooccurrence",
+      "breakpoints": true
     }
   ]
 }

--- a/server.ts
+++ b/server.ts
@@ -16,6 +16,7 @@ import { toNodeHandler } from 'srvx/node';
 import sirv from 'sirv';
 import { setupPlaybackWebSocket } from './src/lib/services/playback-websocket';
 import { getUserIdFromRequest } from './src/lib/auth/ws-session';
+import { clearActiveDeviceIfMatches } from './src/lib/auth/ws-playback-ops';
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const HOST = process.env.HOST || '0.0.0.0';
@@ -55,7 +56,7 @@ async function start() {
   const wss = new WebSocketServer({ noServer: true });
 
   // Setup playback WebSocket handlers
-  setupPlaybackWebSocket(wss, getUserIdFromRequest);
+  setupPlaybackWebSocket(wss, getUserIdFromRequest, clearActiveDeviceIfMatches);
 
   // Handle upgrade requests
   server.on('upgrade', (request, socket, head) => {

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -285,19 +285,11 @@ export function PlayerBar() {
       nextSong();
 
       // Queue mutations during the crossfade (addToQueueNext, AI DJ insertions,
-      // removals) can shift the crossfaded song off of currentSongIndex+1.
-      // nextSong() only increments by 1, so after advancing, playlist[currentSongIndex]
-      // may not match the song that's actually playing on the new active deck.
-      // If we don't correct this, useSongLoader will later load the mismatched
-      // song onto the active deck and interrupt playback.
-      const postState = useAudioStore.getState();
-      if (postState.playlist[postState.currentSongIndex]?.id !== song.id) {
-        const actualIndex = postState.playlist.findIndex(s => s.id === song.id);
-        if (actualIndex >= 0) {
-          console.log(`[XFADE] Playlist shifted during crossfade — correcting currentSongIndex ${postState.currentSongIndex} → ${actualIndex}`);
-          useAudioStore.setState({ currentSongIndex: actualIndex });
-        }
-      }
+      // removals) and user-initiated skips mid-crossfade can both shift the
+      // playing song off of currentSongIndex+1. Reconcile against the deck's
+      // real song so the UI never shows the wrong "now playing" after a
+      // transition.
+      useAudioStore.getState().syncIndexToActiveSong(song.id);
     },
     onCrossfadeAbort: (song, isLoadFailure) => {
       if (song) {
@@ -684,6 +676,7 @@ export function PlayerBar() {
     lastProgressTimeRef,
     lastProgressValueRef,
     setActiveDeck,
+    currentSongIdRef,
   });
 
   // SAFETY: Periodic check that the inactive deck isn't playing unexpectedly.

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -174,7 +174,8 @@ export function PlayerBar() {
   }, [isRemotePlaying, remoteDevice?.currentPositionMs, remoteDevice?.updatedAt, remoteDevice?.durationMs]);
 
   // Derived values for display: use remote time when remote is playing and local isn't
-  const [showDevicePicker, setShowDevicePicker] = useState(false);
+  const showDevicePicker = useAudioStore((s) => s.isDevicePickerOpen);
+  const setDevicePickerOpen = useAudioStore((s) => s.setDevicePickerOpen);
   const devicePickerTriggerRef = useRef<HTMLButtonElement>(null);
   const showRemoteTime = isRemotePlaying && !isPlaying;
   const displayCurrentTime = showRemoteTime ? remoteEstimatedPositionMs / 1000 : currentTime;
@@ -867,7 +868,7 @@ export function PlayerBar() {
                   ref={devicePickerTriggerRef}
                   onClick={(e) => {
                     e.stopPropagation();
-                    setShowDevicePicker(prev => !prev);
+                    setDevicePickerOpen(!showDevicePicker);
                   }}
                   className="flex items-center gap-1 text-[10px] text-green-500/60 mt-0.5 hover:text-green-500 transition-colors"
                   aria-label="Switch playback device"
@@ -970,7 +971,7 @@ export function PlayerBar() {
             {showRemoteTime && (
               <button
                 ref={devicePickerTriggerRef}
-                onClick={(e) => { e.stopPropagation(); setShowDevicePicker(prev => !prev); }}
+                onClick={(e) => { e.stopPropagation(); setDevicePickerOpen(!showDevicePicker); }}
                 className="flex items-center gap-1 text-[10px] text-green-500/60 mt-0.5 hover:text-green-500 transition-colors"
                 aria-label="Switch playback device"
               >
@@ -1164,7 +1165,7 @@ export function PlayerBar() {
 
       {/* Device Picker — rendered via portal */}
       {showDevicePicker && (
-        <DevicePicker onClose={() => setShowDevicePicker(false)} triggerRef={devicePickerTriggerRef} />
+        <DevicePicker onClose={() => setDevicePickerOpen(false)} triggerRef={devicePickerTriggerRef} />
       )}
     </>
   );

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -217,6 +217,11 @@ export function PlayerBar() {
       }),
     }).then(() => {
       queryClient.invalidateQueries({ queryKey: ['listening-history'] });
+      // Auto-refresh the AI DJ affinity profile after a meaningful chunk of
+      // plays. Without this the profile is frozen at onboarding and the
+      // "profile-based recommendations (zero API calls)" path keeps picking
+      // the same handful of songs forever.
+      useAudioStore.getState().recordPlayForProfileTrigger();
     }).catch(err => console.warn('Failed to record listening history:', err));
   }, [queryClient]);
 

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -191,6 +191,16 @@ export function PlayerBar() {
     userInitiatedSkip?: boolean,
   ) => {
     if (!songId || !song) return;
+    // Tag where this play originated so we can tell AI-DJ recommendations
+    // apart from manual clicks / radio sessions / autoplay in the logs.
+    // Precedence: ai_dj > autoplay > radio > manual. AI DJ insertions can
+    // happen during a radio session; the more specific tag wins.
+    const audioState = useAudioStore.getState();
+    const source: 'ai_dj' | 'autoplay' | 'radio' | 'manual' =
+      audioState.aiQueuedSongIds.has(songId) ? 'ai_dj'
+      : audioState.autoplayQueuedSongIds.has(songId) ? 'autoplay'
+      : audioState.isRadioSession ? 'radio'
+      : 'manual';
     fetch('/api/listening-history/record', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -203,6 +213,7 @@ export function PlayerBar() {
         duration: songDuration,
         playDuration,
         userInitiatedSkip,
+        source,
       }),
     }).then(() => {
       queryClient.invalidateQueries({ queryKey: ['listening-history'] });

--- a/src/components/playlists/CreatePlaylistDialog.tsx
+++ b/src/components/playlists/CreatePlaylistDialog.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/lib/toast';
 import {
@@ -21,16 +21,37 @@ interface CreatePlaylistDialogProps {
   open?: boolean;
   onOpenChange?: (open: boolean) => void;
   onSubmit?: (data: { name: string; description?: string }) => void | Promise<void>;
+  /** Prefilled name when the dialog opens. Useful for snapshotting queues (e.g. "Radio — 4/22/2026"). */
+  defaultName?: string;
+  title?: string;
+  description?: string;
+  submitLabel?: string;
 }
 
-export function CreatePlaylistDialog({ trigger, open: externalOpen, onOpenChange: externalOnOpenChange, onSubmit }: CreatePlaylistDialogProps) {
+export function CreatePlaylistDialog({
+  trigger,
+  open: externalOpen,
+  onOpenChange: externalOnOpenChange,
+  onSubmit,
+  defaultName,
+  title = 'Create Playlist',
+  description: dialogDescription = 'Create a new playlist to organize your favorite songs.',
+  submitLabel = 'Create',
+}: CreatePlaylistDialogProps) {
   const [internalOpen, setInternalOpen] = useState(false);
 
   // Use external control if provided, otherwise use internal state
   const open = externalOpen !== undefined ? externalOpen : internalOpen;
   const setOpen = externalOnOpenChange || setInternalOpen;
-  const [name, setName] = useState('');
+  const [name, setName] = useState(defaultName ?? '');
   const [description, setDescription] = useState('');
+
+  // When the dialog opens with a new defaultName, seed the input.
+  useEffect(() => {
+    if (open && defaultName !== undefined) {
+      setName(defaultName);
+    }
+  }, [open, defaultName]);
   const queryClient = useQueryClient();
 
   const createMutation = useMutation({
@@ -104,10 +125,8 @@ export function CreatePlaylistDialog({ trigger, open: externalOpen, onOpenChange
       <DialogContent className="sm:max-w-[425px]">
         <form onSubmit={handleSubmit}>
           <DialogHeader>
-            <DialogTitle>Create Playlist</DialogTitle>
-            <DialogDescription>
-              Create a new playlist to organize your favorite songs.
-            </DialogDescription>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>{dialogDescription}</DialogDescription>
           </DialogHeader>
           <div className="grid gap-4 py-4">
             <div className="grid gap-2">
@@ -149,7 +168,7 @@ export function CreatePlaylistDialog({ trigger, open: externalOpen, onOpenChange
               disabled={createMutation.isPending}
               className="min-h-[44px]"
             >
-              {createMutation.isPending ? 'Creating...' : 'Create'}
+              {createMutation.isPending ? 'Creating...' : submitLabel}
             </Button>
           </DialogFooter>
         </form>

--- a/src/components/radio/StartRadioButton.tsx
+++ b/src/components/radio/StartRadioButton.tsx
@@ -27,11 +27,24 @@ interface StartRadioButtonProps {
   className?: string;
 }
 
+// `null` = "Auto" (no constraint, default ~40 tracks).
+type LengthChoice = 30 | 60 | 120 | 180 | null;
+
+const LENGTH_OPTIONS: Array<{ value: LengthChoice; label: string; tag: string }> = [
+  { value: null, label: 'Auto', tag: 'auto' },
+  { value: 30, label: '30 minutes', tag: '30' },
+  { value: 60, label: '1 hour', tag: '60' },
+  { value: 120, label: '2 hours', tag: '120' },
+  { value: 180, label: 'Journey (3+ hours)', tag: '180' },
+];
+
 /**
  * Start Radio — a separate, additive entry point that never replaces
- * existing Play / Add-to-Queue controls. For artist seeds, opens a menu
- * letting the user pick Artist Variety (Low/Med/High). Other seed kinds
- * start immediately at Medium variety (the knob is artist-specific).
+ * existing Play / Add-to-Queue controls.
+ *
+ * Labelled variant opens a dropdown with Length (all seeds) and Variety
+ * (artist seeds only). Icon-only variant is one-tap with defaults so the
+ * dense context-menu callsites stay frictionless.
  */
 export function StartRadioButton({
   seed,
@@ -42,92 +55,93 @@ export function StartRadioButton({
 }: StartRadioButtonProps) {
   const startRadio = useAudioStore((s) => s.startRadio);
   const [variety, setVariety] = useState<ArtistVariety>('medium');
+  const [length, setLength] = useState<LengthChoice>(null);
   const [busy, setBusy] = useState(false);
 
-  const run = async (v: ArtistVariety = variety) => {
+  const run = async (
+    v: ArtistVariety = variety,
+    targetMinutes: LengthChoice = length,
+  ) => {
     if (busy) return;
     setBusy(true);
     try {
-      await startRadio(seed, v);
+      await startRadio(seed, {
+        variety: v,
+        ...(targetMinutes != null ? { targetMinutes } : {}),
+      });
     } finally {
       setBusy(false);
     }
   };
 
-  // For non-artist seeds, the variety knob doesn't apply — one-tap start.
-  if (seed.kind !== 'artist') {
-    if (size === 'icon') {
-      return (
-        <Button
-          size="icon"
-          variant={variant}
-          disabled={busy}
-          onClick={() => void run('medium')}
-          aria-label={label}
-          title={label}
-          className={className}
-        >
-          <Radio className="size-4" />
-        </Button>
-      );
-    }
+  // Icon-only callsites (per-song context menus) stay one-tap with defaults.
+  if (size === 'icon') {
     return (
       <Button
-        size={size}
+        size="icon"
         variant={variant}
         disabled={busy}
-        onClick={() => void run('medium')}
-        className={cn('gap-2', className)}
+        onClick={() => void run('medium', null)}
+        aria-label={label}
+        title={label}
+        className={className}
       >
         <Radio className="size-4" />
-        {label}
       </Button>
     );
   }
 
-  // Artist seed: dropdown offers variety selection
+  const showVariety = seed.kind === 'artist';
+  const lengthTag = LENGTH_OPTIONS.find((o) => o.value === length)?.tag ?? 'auto';
+
   return (
     <DropdownMenu>
       <DropdownMenuTrigger asChild>
-        {size === 'icon' ? (
-          <Button
-            size="icon"
-            variant={variant}
-            disabled={busy}
-            aria-label={label}
-            title={label}
-            className={className}
-          >
-            <Radio className="size-4" />
-          </Button>
-        ) : (
-          <Button
-            size={size}
-            variant={variant}
-            disabled={busy}
-            className={cn('gap-2', className)}
-          >
-            <Radio className="size-4" />
-            {label}
-          </Button>
-        )}
+        <Button
+          size={size}
+          variant={variant}
+          disabled={busy}
+          className={cn('gap-2', className)}
+        >
+          <Radio className="size-4" />
+          {label}
+        </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
-        <DropdownMenuLabel>Artist Variety</DropdownMenuLabel>
+        <DropdownMenuLabel>Length</DropdownMenuLabel>
         <DropdownMenuRadioGroup
-          value={variety}
-          onValueChange={(v) => setVariety(v as ArtistVariety)}
+          value={lengthTag}
+          onValueChange={(t) => {
+            const found = LENGTH_OPTIONS.find((o) => o.tag === t);
+            if (found) setLength(found.value);
+          }}
         >
-          <DropdownMenuRadioItem value="low">
-            Low — mostly this artist
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="medium">
-            Medium — balanced mix
-          </DropdownMenuRadioItem>
-          <DropdownMenuRadioItem value="high">
-            High — adventurous
-          </DropdownMenuRadioItem>
+          {LENGTH_OPTIONS.map((o) => (
+            <DropdownMenuRadioItem key={o.tag} value={o.tag}>
+              {o.label}
+            </DropdownMenuRadioItem>
+          ))}
         </DropdownMenuRadioGroup>
+        {showVariety ? (
+          <>
+            <DropdownMenuSeparator />
+            <DropdownMenuLabel>Artist Variety</DropdownMenuLabel>
+            <DropdownMenuRadioGroup
+              value={variety}
+              onValueChange={(v) => setVariety(v as ArtistVariety)}
+            >
+              <DropdownMenuRadioItem value="low">
+                Low — mostly this artist
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="medium">
+                Medium — balanced mix
+              </DropdownMenuRadioItem>
+              <DropdownMenuRadioItem value="high">
+                High — adventurous
+              </DropdownMenuRadioItem>
+            </DropdownMenuRadioGroup>
+          </>
+        ) : null}
         <DropdownMenuSeparator />
         <DropdownMenuItem onSelect={() => void run()} disabled={busy}>
           <Radio className="size-4" />

--- a/src/components/radio/StartRadioButton.tsx
+++ b/src/components/radio/StartRadioButton.tsx
@@ -1,0 +1,139 @@
+import { Radio } from 'lucide-react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useAudioStore } from '@/lib/stores/audio';
+import type { SeededRadioSeed, ArtistVariety } from '@/lib/services/seeded-radio';
+import { cn } from '@/lib/utils';
+
+type Variant = React.ComponentProps<typeof Button>['variant'];
+type Size = React.ComponentProps<typeof Button>['size'];
+
+interface StartRadioButtonProps {
+  seed: SeededRadioSeed;
+  label?: string;
+  /** If "icon", renders a square icon-only button; otherwise a labelled button. */
+  size?: Size;
+  variant?: Variant;
+  className?: string;
+}
+
+/**
+ * Start Radio — a separate, additive entry point that never replaces
+ * existing Play / Add-to-Queue controls. For artist seeds, opens a menu
+ * letting the user pick Artist Variety (Low/Med/High). Other seed kinds
+ * start immediately at Medium variety (the knob is artist-specific).
+ */
+export function StartRadioButton({
+  seed,
+  label = 'Start Radio',
+  size = 'sm',
+  variant = 'outline',
+  className,
+}: StartRadioButtonProps) {
+  const startRadio = useAudioStore((s) => s.startRadio);
+  const [variety, setVariety] = useState<ArtistVariety>('medium');
+  const [busy, setBusy] = useState(false);
+
+  const run = async (v: ArtistVariety = variety) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      await startRadio(seed, v);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  // For non-artist seeds, the variety knob doesn't apply — one-tap start.
+  if (seed.kind !== 'artist') {
+    if (size === 'icon') {
+      return (
+        <Button
+          size="icon"
+          variant={variant}
+          disabled={busy}
+          onClick={() => void run('medium')}
+          aria-label={label}
+          title={label}
+          className={className}
+        >
+          <Radio className="size-4" />
+        </Button>
+      );
+    }
+    return (
+      <Button
+        size={size}
+        variant={variant}
+        disabled={busy}
+        onClick={() => void run('medium')}
+        className={cn('gap-2', className)}
+      >
+        <Radio className="size-4" />
+        {label}
+      </Button>
+    );
+  }
+
+  // Artist seed: dropdown offers variety selection
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        {size === 'icon' ? (
+          <Button
+            size="icon"
+            variant={variant}
+            disabled={busy}
+            aria-label={label}
+            title={label}
+            className={className}
+          >
+            <Radio className="size-4" />
+          </Button>
+        ) : (
+          <Button
+            size={size}
+            variant={variant}
+            disabled={busy}
+            className={cn('gap-2', className)}
+          >
+            <Radio className="size-4" />
+            {label}
+          </Button>
+        )}
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="w-56">
+        <DropdownMenuLabel>Artist Variety</DropdownMenuLabel>
+        <DropdownMenuRadioGroup
+          value={variety}
+          onValueChange={(v) => setVariety(v as ArtistVariety)}
+        >
+          <DropdownMenuRadioItem value="low">
+            Low — mostly this artist
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="medium">
+            Medium — balanced mix
+          </DropdownMenuRadioItem>
+          <DropdownMenuRadioItem value="high">
+            High — adventurous
+          </DropdownMenuRadioItem>
+        </DropdownMenuRadioGroup>
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => void run()} disabled={busy}>
+          <Radio className="size-4" />
+          {busy ? 'Starting…' : 'Start Radio'}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
+++ b/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
@@ -362,7 +362,7 @@ const SummaryCards = memo(function SummaryCards({
         <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
           <div className="text-lg sm:text-2xl font-bold">{summary.totalFeedback}</div>
           <p className="text-[10px] sm:text-xs text-muted-foreground">
-            Songs rated
+            Feedback events
           </p>
         </CardContent>
       </Card>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -243,7 +243,7 @@ function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
       <Card className="md:col-span-2">
         <CardHeader>
           <CardTitle>Top Liked Artists</CardTitle>
-          <CardDescription>Your most favorited artists</CardDescription>
+          <CardDescription>Artists you've thumbed up most on AI DJ recommendations</CardDescription>
         </CardHeader>
         <CardContent>
           <TopArtistsChart artists={analytics.profile.likedArtists.slice(0, 10)} />
@@ -342,7 +342,7 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         <MetricCard
           title="Total Ratings"
           value={analytics.quality.totalRecommendations.toString()}
-          description="Songs rated"
+          description="Feedback events (a song may be rated more than once)"
         />
       </div>
     </div>
@@ -388,8 +388,8 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
     <div className="grid gap-4">
       <Card>
         <CardHeader>
-          <CardTitle>Listening Patterns</CardTitle>
-          <CardDescription>When you're most active</CardDescription>
+          <CardTitle>Feedback Patterns</CardTitle>
+          <CardDescription>When you most often rate AI DJ recommendations</CardDescription>
         </CardHeader>
         <CardContent>
           <div className="space-y-2">
@@ -405,7 +405,8 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
       <div className="grid gap-4 md:grid-cols-2">
         <Card>
           <CardHeader>
-            <CardTitle>Activity by Day of Week</CardTitle>
+            <CardTitle>Feedback Events by Day of Week</CardTitle>
+            <CardDescription>Summed across every day in the selected period</CardDescription>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
@@ -422,7 +423,8 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
 
         <Card>
           <CardHeader>
-            <CardTitle>Activity by Hour</CardTitle>
+            <CardTitle>Feedback Events by Hour</CardTitle>
+            <CardDescription>Summed across every hour in the selected period</CardDescription>
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -347,6 +347,11 @@ export function QueuePanel() {
   }, [queuePanelOpen, toggleQueuePanel]);
   const [timeSinceLastQueue, setTimeSinceLastQueue] = useState(0);
   const [createPlaylistOpen, setCreatePlaylistOpen] = useState(false);
+  const [saveRadioDialogOpen, setSaveRadioDialogOpen] = useState(false);
+  const radioDefaultName = useMemo(
+    () => `Radio — ${new Date().toLocaleDateString()}`,
+    [saveRadioDialogOpen],
+  );
   const [undoTimeRemaining, setUndoTimeRemaining] = useState<number | null>(null);
   const queryClient = useQueryClient();
 
@@ -814,15 +819,7 @@ export function QueuePanel() {
                   <Button
                     variant="outline"
                     size="sm"
-                    onClick={() => {
-                      const defaultName = `Radio — ${new Date().toLocaleDateString()}`;
-                      const name = typeof window !== 'undefined'
-                        ? window.prompt('Save radio as playlist named:', defaultName)
-                        : defaultName;
-                      if (name && name.trim()) {
-                        void saveRadioAsPlaylist(name.trim());
-                      }
-                    }}
+                    onClick={() => setSaveRadioDialogOpen(true)}
                     className="w-full h-8 md:h-9 text-xs md:text-sm bg-gradient-to-r from-orange-500/5 to-amber-500/5 hover:from-orange-500/10 hover:to-amber-500/10 border-orange-500/20 hover:border-orange-500/30 text-orange-600/80 dark:text-orange-400/80 hover:text-orange-600 dark:hover:text-orange-400 transition-all duration-200 group"
                   >
                     <Radio className="mr-1 md:mr-2 h-3.5 w-3.5 md:h-4 md:w-4 group-hover:scale-110 transition-transform" />
@@ -883,6 +880,19 @@ export function QueuePanel() {
         open={createPlaylistOpen}
         onOpenChange={setCreatePlaylistOpen}
         onSubmit={handleCreatePlaylistFromQueue}
+      />
+
+      {/* Save Radio as Playlist Dialog */}
+      <CreatePlaylistDialog
+        open={saveRadioDialogOpen}
+        onOpenChange={setSaveRadioDialogOpen}
+        defaultName={radioDefaultName}
+        title="Save Radio as Playlist"
+        description="Snapshot the current radio queue as a new playlist in your library."
+        submitLabel="Save"
+        onSubmit={(data) => {
+          void saveRadioAsPlaylist(data.name.trim());
+        }}
       />
     </div>
   );

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -1,7 +1,7 @@
 import { useAudioStore } from '@/lib/stores/audio';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
-import { X, Music, Trash2, GripVertical, Plus, RotateCcw, ThumbsUp, ThumbsDown, Shuffle, SkipForward, Sparkles } from 'lucide-react';
+import { X, Music, Trash2, GripVertical, Plus, RotateCcw, ThumbsUp, ThumbsDown, Shuffle, SkipForward, Sparkles, Radio } from 'lucide-react';
 import { useState, useEffect, useCallback, useMemo, memo, useRef } from 'react';
 import { CreatePlaylistDialog } from '@/components/playlists/CreatePlaylistDialog';
 import { useQueryClient } from '@tanstack/react-query';
@@ -339,6 +339,8 @@ export function QueuePanel() {
   } = useAudioStore();
   const queuePanelOpen = useAudioStore(s => s.queuePanelOpen);
   const toggleQueuePanel = useAudioStore(s => s.toggleQueuePanel);
+  const isRadioSession = useAudioStore(s => s.isRadioSession);
+  const saveRadioAsPlaylist = useAudioStore(s => s.saveRadioAsPlaylist);
   const isOpen = queuePanelOpen;
   const setIsOpen = useCallback((open: boolean) => {
     if (open !== queuePanelOpen) toggleQueuePanel();
@@ -806,6 +808,27 @@ export function QueuePanel() {
                     </Button>
                   )}
                 </div>
+
+                {/* Save Radio as Playlist — only visible during a radio session */}
+                {isRadioSession && (currentSong || upcomingQueue.length > 0) && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => {
+                      const defaultName = `Radio — ${new Date().toLocaleDateString()}`;
+                      const name = typeof window !== 'undefined'
+                        ? window.prompt('Save radio as playlist named:', defaultName)
+                        : defaultName;
+                      if (name && name.trim()) {
+                        void saveRadioAsPlaylist(name.trim());
+                      }
+                    }}
+                    className="w-full h-8 md:h-9 text-xs md:text-sm bg-gradient-to-r from-orange-500/5 to-amber-500/5 hover:from-orange-500/10 hover:to-amber-500/10 border-orange-500/20 hover:border-orange-500/30 text-orange-600/80 dark:text-orange-400/80 hover:text-orange-600 dark:hover:text-orange-400 transition-all duration-200 group"
+                  >
+                    <Radio className="mr-1 md:mr-2 h-3.5 w-3.5 md:h-4 md:w-4 group-hover:scale-110 transition-transform" />
+                    Save Radio as Playlist
+                  </Button>
+                )}
 
                 {/* More Like This Button */}
                 {currentSong && (

--- a/src/lib/auth/ws-playback-ops.ts
+++ b/src/lib/auth/ws-playback-ops.ts
@@ -1,0 +1,59 @@
+/**
+ * WebSocket Playback DB Operations
+ *
+ * Server-side helpers used by the WebSocket handler for playback session
+ * mutations that need direct DB access (not a fetch to the API route).
+ */
+
+import { db } from '@/lib/db';
+import { playbackSessions } from '@/lib/db/schema/playback-session.schema';
+import { eq } from 'drizzle-orm';
+
+export interface ClearActiveDeviceResult {
+  cleared: boolean;
+  playStateUpdatedAt: string | null;
+}
+
+/**
+ * If the given device is the currently-active player, clear the active-device
+ * fields and set isPlaying=false. Queue, currentIndex, position are not touched.
+ *
+ * Called from the WebSocket close handler so a device that disappears
+ * (browser tab closed, network drop) doesn't leave the server advertising it
+ * as the active player — which would trap other devices in remote-control
+ * mode with a dead target.
+ */
+export async function clearActiveDeviceIfMatches(
+  userId: string,
+  deviceId: string,
+): Promise<ClearActiveDeviceResult> {
+  try {
+    const [existing] = await db
+      .select()
+      .from(playbackSessions)
+      .where(eq(playbackSessions.userId, userId))
+      .limit(1);
+
+    if (!existing || existing.activeDeviceId !== deviceId) {
+      return { cleared: false, playStateUpdatedAt: null };
+    }
+
+    const now = new Date();
+    await db
+      .update(playbackSessions)
+      .set({
+        isPlaying: false,
+        activeDeviceId: null,
+        activeDeviceName: null,
+        activeDeviceType: null,
+        playStateUpdatedAt: now,
+        updatedAt: now,
+      })
+      .where(eq(playbackSessions.userId, userId));
+
+    return { cleared: true, playStateUpdatedAt: now.toISOString() };
+  } catch (err) {
+    console.error('[WS] clearActiveDeviceIfMatches failed:', err);
+    return { cleared: false, playStateUpdatedAt: null };
+  }
+}

--- a/src/lib/db/schema/artist-cooccurrence.schema.ts
+++ b/src/lib/db/schema/artist-cooccurrence.schema.ts
@@ -1,0 +1,53 @@
+import { pgTable, text, timestamp, integer, real, index, unique } from "drizzle-orm/pg-core";
+import { user } from "./auth.schema";
+
+/**
+ * Artist Co-Occurrence Table
+ *
+ * Per-user graph of which artists the user plays together in the same
+ * listening session. A session is a contiguous run of plays with no gap
+ * > 30 minutes. Pairs are stored bidirectionally ((A,B) and (B,A)) so
+ * lookups can use a single indexed `artistA` filter.
+ *
+ * Score formula:
+ *   raw_weight   = Σ exp(-0.05 * days_ago)  over co-occurrences
+ *   cooccurrence = raw_weight / sqrt(plays(A) * plays(B))   // cosine-like
+ *
+ * Used by seeded-radio's artist seed to surface "adjacent" artists the
+ * user actually plays together, independent of Last.fm similarity.
+ */
+export const artistCoOccurrence = pgTable("artist_cooccurrence", {
+  id: text("id").primaryKey().$defaultFn(() => crypto.randomUUID()),
+
+  userId: text("user_id")
+    .notNull()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  artistA: text("artist_a").notNull(),
+  artistB: text("artist_b").notNull(),
+
+  cooccurrenceScore: real("cooccurrence_score").notNull().default(0),
+  coplayCount: integer("coplay_count").notNull().default(0),
+
+  lastCoplayedAt: timestamp("last_coplayed_at"),
+  calculatedAt: timestamp("calculated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+}, (table) => ({
+  uniqueUserPair: unique("artist_cooccurrence_unique").on(
+    table.userId,
+    table.artistA,
+    table.artistB,
+  ),
+
+  userArtistScoreIdx: index("artist_cooccurrence_user_artist_score_idx").on(
+    table.userId,
+    table.artistA,
+    table.cooccurrenceScore,
+  ),
+
+  userIdIdx: index("artist_cooccurrence_user_id_idx").on(table.userId),
+}));
+
+export type ArtistCoOccurrence = typeof artistCoOccurrence.$inferSelect;
+export type ArtistCoOccurrenceInsert = typeof artistCoOccurrence.$inferInsert;

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -20,3 +20,4 @@ export * from "./devices.schema";
 export * from "./explicit-content.schema";
 export * from "./navidrome-users.schema";
 export * from "./artist-metadata.schema";
+export * from "./artist-cooccurrence.schema";

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -171,66 +171,85 @@ export function useCrossfade({
       // Start playing the next song - CRITICAL: handle failure on mobile
       inactiveDeck.play()
         .then(() => {
-          console.log(`[XFADE] Inactive deck play() succeeded, scheduling GainNode ramps`);
+          // Pre-warm window. The inactive deck's HTMLAudioElement decoder
+          // advances currentTime ~10% slower than wall clock for the first
+          // several seconds after a fresh src load (decode-buffer warm-up
+          // observed at -0.5s drift consistently across 7/7 crossfades on
+          // iOS PWA + Bluetooth). If ramps start immediately, that slow
+          // window sits underneath the audible crossfade and produces
+          // chorusing / perceived pitch shift against the outgoing deck.
+          // Letting the deck play inaudibly at gain=0 for WARMUP_MS hands
+          // off to a fully-warmed decoder for the audible portion of the
+          // fade. The crossfade overlap duration is unchanged — only the
+          // start is delayed.
+          const WARMUP_MS = 500;
+          console.log(`[XFADE] Inactive deck play() succeeded — pre-warming decoder for ${WARMUP_MS}ms before ramps`);
 
-          // Schedule gain ramps on the audio thread (immune to JS throttling)
-          scheduleGainRamp(activeDeckLabel, 0, xfadeDuration, 'equalpower');
-          scheduleGainRamp(inactiveDeckLabel, 1.0, xfadeDuration, 'equalpower');
-
-          // Diagnostic — capture both decks' state at the start, midpoint, and
-          // end of the crossfade. Under iOS LPM + Bluetooth, the two decks can
-          // drift against each other during the overlap (decode loop starvation
-          // on the throttled main thread), producing audible comb-filter /
-          // pitch-shift artifacts. The midpoint drift check is the smoking gun.
-          const xfadeStartWall = Date.now();
-          const xfadeStartInactiveT = inactiveDeck.currentTime;
-          const snapshotDecks = (label: string, drift?: number) => {
-            const a = activeDeck, i = inactiveDeck;
-            const driftStr = drift !== undefined ? ` drift=${drift.toFixed(3)}s` : '';
-            console.log(
-              `[XFADE] decks @ ${label} — ` +
-              `${activeDeckLabel}{t=${a.currentTime.toFixed(2)} rate=${a.playbackRate} paused=${a.paused} ready=${a.readyState} net=${a.networkState}} ` +
-              `${inactiveDeckLabel}{t=${i.currentTime.toFixed(2)} rate=${i.playbackRate} paused=${i.paused} ready=${i.readyState} net=${i.networkState}}` +
-              driftStr,
-            );
-            if (a.playbackRate !== 1 || i.playbackRate !== 1) {
-              console.warn(`[XFADE] ⚠️ playbackRate drift @ ${label}: ${activeDeckLabel}=${a.playbackRate} ${inactiveDeckLabel}=${i.playbackRate}`);
-            }
-          };
-          snapshotDecks('start');
           setTimeout(() => {
-            if (!crossfadeInProgressRef.current) return;
-            const wallElapsed = (Date.now() - xfadeStartWall) / 1000;
-            const inactiveElapsed = inactiveDeck.currentTime - xfadeStartInactiveT;
-            const drift = inactiveElapsed - wallElapsed;
-            snapshotDecks('midpoint', drift);
-            if (Math.abs(drift) > 0.1) {
-              console.warn(`[XFADE] ⚠️ inactive deck drift exceeds 100ms at midpoint: ${drift.toFixed(3)}s (likely pitch-shift root cause)`);
+            if (!crossfadeInProgressRef.current) {
+              console.log('[XFADE] Crossfade aborted during warmup, skipping ramps');
+              return;
             }
-          }, (xfadeDuration * 1000) / 2);
 
-          // Subscribe to store for pause detection during crossfade
-          pauseUnsubscribeRef.current = useAudioStore.subscribe((state, prevState) => {
-            if (prevState.isPlaying && !state.isPlaying && crossfadeInProgressRef.current) {
-              console.log('[XFADE] User paused during crossfade - aborting');
-              activeDeck.pause();
-              inactiveDeck.pause();
-              abortCrossfade('user paused');
-            }
-          });
+            console.log(`[XFADE] Warmup complete (inactive at t=${inactiveDeck.currentTime.toFixed(2)}), scheduling GainNode ramps`);
 
-          // Completion via setTimeout matching ramp duration (+150ms buffer)
-          crossfadeCompletionTimeoutRef.current = setTimeout(() => {
-            // Verify inactive deck is still playing before completing
-            if (!crossfadeInProgressRef.current) return;
+            // Schedule gain ramps on the audio thread (immune to JS throttling)
+            scheduleGainRamp(activeDeckLabel, 0, xfadeDuration, 'equalpower');
+            scheduleGainRamp(inactiveDeckLabel, 1.0, xfadeDuration, 'equalpower');
 
-            if (!inactiveDeck.paused && inactiveDeck.currentTime > 0) {
-              completeCrossfade(activeDeck, inactiveDeck, activeDeckLabel, inactiveDeckLabel, nextSongData);
-            } else {
-              console.warn(`⚠️ [XFADE] Completion timeout: inactive deck not playing - aborting`);
-              abortCrossfade('inactive deck stopped during ramp');
-            }
-          }, xfadeDuration * 1000 + 150);
+            // Diagnostic — capture both decks' state at the start, midpoint, and
+            // end of the crossfade. The drift baseline is captured AFTER warmup
+            // so the midpoint drift value reflects the audible portion only.
+            const xfadeStartWall = Date.now();
+            const xfadeStartInactiveT = inactiveDeck.currentTime;
+            const snapshotDecks = (label: string, drift?: number) => {
+              const a = activeDeck, i = inactiveDeck;
+              const driftStr = drift !== undefined ? ` drift=${drift.toFixed(3)}s` : '';
+              console.log(
+                `[XFADE] decks @ ${label} — ` +
+                `${activeDeckLabel}{t=${a.currentTime.toFixed(2)} rate=${a.playbackRate} paused=${a.paused} ready=${a.readyState} net=${a.networkState}} ` +
+                `${inactiveDeckLabel}{t=${i.currentTime.toFixed(2)} rate=${i.playbackRate} paused=${i.paused} ready=${i.readyState} net=${i.networkState}}` +
+                driftStr,
+              );
+              if (a.playbackRate !== 1 || i.playbackRate !== 1) {
+                console.warn(`[XFADE] ⚠️ playbackRate drift @ ${label}: ${activeDeckLabel}=${a.playbackRate} ${inactiveDeckLabel}=${i.playbackRate}`);
+              }
+            };
+            snapshotDecks('start');
+            setTimeout(() => {
+              if (!crossfadeInProgressRef.current) return;
+              const wallElapsed = (Date.now() - xfadeStartWall) / 1000;
+              const inactiveElapsed = inactiveDeck.currentTime - xfadeStartInactiveT;
+              const drift = inactiveElapsed - wallElapsed;
+              snapshotDecks('midpoint', drift);
+              if (Math.abs(drift) > 0.1) {
+                console.warn(`[XFADE] ⚠️ inactive deck drift exceeds 100ms at midpoint: ${drift.toFixed(3)}s (likely pitch-shift root cause)`);
+              }
+            }, (xfadeDuration * 1000) / 2);
+
+            // Subscribe to store for pause detection during crossfade
+            pauseUnsubscribeRef.current = useAudioStore.subscribe((state, prevState) => {
+              if (prevState.isPlaying && !state.isPlaying && crossfadeInProgressRef.current) {
+                console.log('[XFADE] User paused during crossfade - aborting');
+                activeDeck.pause();
+                inactiveDeck.pause();
+                abortCrossfade('user paused');
+              }
+            });
+
+            // Completion via setTimeout matching ramp duration (+150ms buffer)
+            crossfadeCompletionTimeoutRef.current = setTimeout(() => {
+              // Verify inactive deck is still playing before completing
+              if (!crossfadeInProgressRef.current) return;
+
+              if (!inactiveDeck.paused && inactiveDeck.currentTime > 0) {
+                completeCrossfade(activeDeck, inactiveDeck, activeDeckLabel, inactiveDeckLabel, nextSongData);
+              } else {
+                console.warn(`⚠️ [XFADE] Completion timeout: inactive deck not playing - aborting`);
+                abortCrossfade('inactive deck stopped during ramp');
+              }
+            }, xfadeDuration * 1000 + 150);
+          }, WARMUP_MS);
         })
         .catch((err) => {
           console.error(`❌ [XFADE] Inactive deck play() FAILED: ${err.name} - ${err.message}`);

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -182,7 +182,11 @@ export function useCrossfade({
           // off to a fully-warmed decoder for the audible portion of the
           // fade. The crossfade overlap duration is unchanged — only the
           // start is delayed.
-          const WARMUP_MS = 500;
+          // Bumped from 500 → 1000ms after first iteration: 500ms reduced
+          // observed drift from −0.5s to −0.36s on iOS PWA + car BT (48k
+          // codec), still above the 100ms threshold. Doubling the warmup
+          // gives the decoder more headroom before the audible ramps begin.
+          const WARMUP_MS = 1000;
           console.log(`[XFADE] Inactive deck play() succeeded — pre-warming decoder for ${WARMUP_MS}ms before ramps`);
 
           setTimeout(() => {

--- a/src/lib/hooks/useCrossfade.ts
+++ b/src/lib/hooks/useCrossfade.ts
@@ -177,6 +177,38 @@ export function useCrossfade({
           scheduleGainRamp(activeDeckLabel, 0, xfadeDuration, 'equalpower');
           scheduleGainRamp(inactiveDeckLabel, 1.0, xfadeDuration, 'equalpower');
 
+          // Diagnostic — capture both decks' state at the start, midpoint, and
+          // end of the crossfade. Under iOS LPM + Bluetooth, the two decks can
+          // drift against each other during the overlap (decode loop starvation
+          // on the throttled main thread), producing audible comb-filter /
+          // pitch-shift artifacts. The midpoint drift check is the smoking gun.
+          const xfadeStartWall = Date.now();
+          const xfadeStartInactiveT = inactiveDeck.currentTime;
+          const snapshotDecks = (label: string, drift?: number) => {
+            const a = activeDeck, i = inactiveDeck;
+            const driftStr = drift !== undefined ? ` drift=${drift.toFixed(3)}s` : '';
+            console.log(
+              `[XFADE] decks @ ${label} — ` +
+              `${activeDeckLabel}{t=${a.currentTime.toFixed(2)} rate=${a.playbackRate} paused=${a.paused} ready=${a.readyState} net=${a.networkState}} ` +
+              `${inactiveDeckLabel}{t=${i.currentTime.toFixed(2)} rate=${i.playbackRate} paused=${i.paused} ready=${i.readyState} net=${i.networkState}}` +
+              driftStr,
+            );
+            if (a.playbackRate !== 1 || i.playbackRate !== 1) {
+              console.warn(`[XFADE] ⚠️ playbackRate drift @ ${label}: ${activeDeckLabel}=${a.playbackRate} ${inactiveDeckLabel}=${i.playbackRate}`);
+            }
+          };
+          snapshotDecks('start');
+          setTimeout(() => {
+            if (!crossfadeInProgressRef.current) return;
+            const wallElapsed = (Date.now() - xfadeStartWall) / 1000;
+            const inactiveElapsed = inactiveDeck.currentTime - xfadeStartInactiveT;
+            const drift = inactiveElapsed - wallElapsed;
+            snapshotDecks('midpoint', drift);
+            if (Math.abs(drift) > 0.1) {
+              console.warn(`[XFADE] ⚠️ inactive deck drift exceeds 100ms at midpoint: ${drift.toFixed(3)}s (likely pitch-shift root cause)`);
+            }
+          }, (xfadeDuration * 1000) / 2);
+
           // Subscribe to store for pause detection during crossfade
           pauseUnsubscribeRef.current = useAudioStore.subscribe((state, prevState) => {
             if (prevState.isPlaying && !state.isPlaying && crossfadeInProgressRef.current) {
@@ -225,6 +257,15 @@ export function useCrossfade({
       // Stop the old deck completely
       oldDeck.pause();
       oldDeck.currentTime = 0;
+
+      // Diagnostic — final snapshot before swap. Compare to start/midpoint
+      // to see whether the new (now-active) deck's currentTime advanced
+      // smoothly through the crossfade window, or stalled at any point.
+      console.log(
+        `[XFADE] decks @ complete — ` +
+        `${oldDeckLabel}{t=${oldDeck.currentTime.toFixed(2)} rate=${oldDeck.playbackRate} paused=${oldDeck.paused} ready=${oldDeck.readyState} net=${oldDeck.networkState}} ` +
+        `${newDeckLabel}{t=${newDeck.currentTime.toFixed(2)} rate=${newDeck.playbackRate} paused=${newDeck.paused} ready=${newDeck.readyState} net=${newDeck.networkState}}`,
+      );
 
       // Swap active deck
       setActiveDeck(newDeckLabel, 'crossfade-complete', { bypassCooldown: true });

--- a/src/lib/hooks/useDeckEventHandlers.ts
+++ b/src/lib/hooks/useDeckEventHandlers.ts
@@ -1,7 +1,7 @@
 import { useEffect } from 'react';
 import { useAudioStore } from '@/lib/stores/audio';
 import { scrobbleSong } from '@/lib/services/navidrome';
-import { hasRealSong, Song, type SetActiveDeckOptions } from './useDualDeckAudio';
+import { hasRealSong, Song, SILENT_AUDIO_DATA_URL, type SetActiveDeckOptions } from './useDualDeckAudio';
 import type { QueryClient } from '@tanstack/react-query';
 
 export interface UseDeckEventHandlersOptions {
@@ -290,6 +290,28 @@ export function useDeckEventHandlers({
         // Microtask delay lets the browser finish processing the 'ended' event
         setTimeout(restartDeck, 0);
         return;
+      }
+
+      // Prime the opposite deck while we're still inside the ended event's
+      // user-activation context. iOS Safari revokes autoplay grants on idle
+      // <audio> elements; without a fresh gesture-derived play() on the
+      // inactive deck, the next song's crossfade will be rejected with
+      // NotAllowedError. The `ended` handler inherits activation from the
+      // original play() chain, so a silent play() here succeeds where a
+      // timeupdate-initiated one does not.
+      const inactiveDeck = deckName === 'A' ? deckBRef.current : deckARef.current;
+      if (inactiveDeck && !inactiveDeck.src) {
+        inactiveDeck.src = SILENT_AUDIO_DATA_URL;
+        inactiveDeck.play()
+          .then(() => {
+            inactiveDeck.pause();
+            inactiveDeck.removeAttribute('src');
+            inactiveDeck.load();
+            console.log(`[PRIME] Deck ${deckName === 'A' ? 'B' : 'A'} primed via ended-event gesture`);
+          })
+          .catch((err) => {
+            console.warn(`[PRIME] Ended-event prime failed: ${err?.name || 'unknown'}`);
+          });
       }
 
       // Let the useEffect watching currentSongIndex handle loading the next song.

--- a/src/lib/hooks/useDeckEventHandlers.ts
+++ b/src/lib/hooks/useDeckEventHandlers.ts
@@ -1,7 +1,7 @@
-import { useEffect } from 'react';
+import { useEffect, useRef } from 'react';
 import { useAudioStore } from '@/lib/stores/audio';
 import { scrobbleSong } from '@/lib/services/navidrome';
-import { hasRealSong, Song, type SetActiveDeckOptions } from './useDualDeckAudio';
+import { hasRealSong, SILENT_AUDIO_DATA_URL, Song, type SetActiveDeckOptions } from './useDualDeckAudio';
 import type { QueryClient } from '@tanstack/react-query';
 
 export interface UseDeckEventHandlersOptions {
@@ -79,6 +79,11 @@ export function useDeckEventHandlers({
   queryClient,
   recordListeningHistory,
 }: UseDeckEventHandlersOptions): void {
+  // Tracks which song we've already primed the inactive deck for. iOS revokes
+  // the autoplay gesture on idle elements, so we re-prime once per song as
+  // the active deck approaches crossfade range.
+  const lastPrimedForSongRef = useRef<string | null>(null);
+
   useEffect(() => {
     const deckA = deckARef.current;
     const deckB = deckBRef.current;
@@ -170,6 +175,43 @@ export function useDeckEventHandlers({
                 startCrossfade(nextSongData, xfadeDuration);
               }
             }
+          }
+        }
+
+        // PRIME INACTIVE DECK: iOS revokes the autoplay gesture on audio
+        // elements that haven't been used recently. Without priming, every
+        // crossfade's inactive.play() gets rejected with NotAllowedError and
+        // we fall back to a ~10s silence between songs via the ended-event
+        // path. Pre-poke the inactive deck with a silent data URL while the
+        // active deck is still playing — page is producing sound, so this
+        // succeeds without needing a user gesture.
+        //
+        // Triggered once per song when we're within the final 30s but still
+        // comfortably outside the crossfade window, so the gesture stamp is
+        // fresh when startCrossfade runs.
+        const songId = currentSongIdRef.current;
+        if (
+          songId &&
+          xfadeDuration > 0 &&
+          timeRemaining > xfadeDuration + 2 &&
+          timeRemaining <= 30 &&
+          !crossfadeInProgressRef.current &&
+          lastPrimedForSongRef.current !== songId
+        ) {
+          const inactive = activeDeckRef.current === 'A' ? deckBRef.current : deckARef.current;
+          if (inactive && !inactive.src) {
+            lastPrimedForSongRef.current = songId;
+            inactive.src = SILENT_AUDIO_DATA_URL;
+            inactive.play()
+              .then(() => {
+                inactive.pause();
+                inactive.removeAttribute('src');
+                inactive.load();
+                console.log(`[PRIME] Inactive deck re-primed for upcoming crossfade`);
+              })
+              .catch((err) => {
+                console.warn(`[PRIME] Inactive deck prime failed: ${err?.name || 'unknown'}`);
+              });
           }
         }
 

--- a/src/lib/hooks/useDeckEventHandlers.ts
+++ b/src/lib/hooks/useDeckEventHandlers.ts
@@ -1,7 +1,7 @@
-import { useEffect, useRef } from 'react';
+import { useEffect } from 'react';
 import { useAudioStore } from '@/lib/stores/audio';
 import { scrobbleSong } from '@/lib/services/navidrome';
-import { hasRealSong, SILENT_AUDIO_DATA_URL, Song, type SetActiveDeckOptions } from './useDualDeckAudio';
+import { hasRealSong, Song, type SetActiveDeckOptions } from './useDualDeckAudio';
 import type { QueryClient } from '@tanstack/react-query';
 
 export interface UseDeckEventHandlersOptions {
@@ -79,11 +79,6 @@ export function useDeckEventHandlers({
   queryClient,
   recordListeningHistory,
 }: UseDeckEventHandlersOptions): void {
-  // Tracks which song we've already primed the inactive deck for. iOS revokes
-  // the autoplay gesture on idle elements, so we re-prime once per song as
-  // the active deck approaches crossfade range.
-  const lastPrimedForSongRef = useRef<string | null>(null);
-
   useEffect(() => {
     const deckA = deckARef.current;
     const deckB = deckBRef.current;
@@ -175,43 +170,6 @@ export function useDeckEventHandlers({
                 startCrossfade(nextSongData, xfadeDuration);
               }
             }
-          }
-        }
-
-        // PRIME INACTIVE DECK: iOS revokes the autoplay gesture on audio
-        // elements that haven't been used recently. Without priming, every
-        // crossfade's inactive.play() gets rejected with NotAllowedError and
-        // we fall back to a ~10s silence between songs via the ended-event
-        // path. Pre-poke the inactive deck with a silent data URL while the
-        // active deck is still playing — page is producing sound, so this
-        // succeeds without needing a user gesture.
-        //
-        // Triggered once per song when we're within the final 30s but still
-        // comfortably outside the crossfade window, so the gesture stamp is
-        // fresh when startCrossfade runs.
-        const songId = currentSongIdRef.current;
-        if (
-          songId &&
-          xfadeDuration > 0 &&
-          timeRemaining > xfadeDuration + 2 &&
-          timeRemaining <= 30 &&
-          !crossfadeInProgressRef.current &&
-          lastPrimedForSongRef.current !== songId
-        ) {
-          const inactive = activeDeckRef.current === 'A' ? deckBRef.current : deckARef.current;
-          if (inactive && !inactive.src) {
-            lastPrimedForSongRef.current = songId;
-            inactive.src = SILENT_AUDIO_DATA_URL;
-            inactive.play()
-              .then(() => {
-                inactive.pause();
-                inactive.removeAttribute('src');
-                inactive.load();
-                console.log(`[PRIME] Inactive deck re-primed for upcoming crossfade`);
-              })
-              .catch((err) => {
-                console.warn(`[PRIME] Inactive deck prime failed: ${err?.name || 'unknown'}`);
-              });
           }
         }
 

--- a/src/lib/hooks/usePlaybackStateSync.ts
+++ b/src/lib/hooks/usePlaybackStateSync.ts
@@ -13,6 +13,8 @@ export interface UsePlaybackStateSyncOptions {
   lastProgressTimeRef: React.RefObject<number>;
   lastProgressValueRef: React.RefObject<number>;
   setActiveDeck: (deck: 'A' | 'B', reason: string, opts?: SetActiveDeckOptions) => boolean;
+  /** Source of truth for what song the active deck actually has loaded. */
+  currentSongIdRef: React.RefObject<string | null>;
 }
 
 /**
@@ -36,6 +38,7 @@ export function usePlaybackStateSync({
   lastProgressTimeRef,
   lastProgressValueRef,
   setActiveDeck,
+  currentSongIdRef,
 }: UsePlaybackStateSyncOptions): void {
   const { setIsPlaying } = useAudioStore();
 
@@ -206,6 +209,27 @@ export function usePlaybackStateSync({
         const audioIsActuallyPlaying = !activeDeck.paused;
         const audioHadProgress = activeDeck.currentTime > 0 && hasRealSong(activeDeck);
 
+        // OPTION A: reconcile currentSongIndex with the deck's actual song.
+        // Covers skip-during-crossfade and any path where the index drifted
+        // while we weren't looking.
+        useAudioStore.getState().syncIndexToActiveSong(currentSongIdRef.current);
+
+        // OPTION B: the song ended while the screen was locked — iOS throttles
+        // timeupdate + ended so nextSong() never fired. If the active deck
+        // has reached its natural end, force-advance now.
+        const deckDuration = activeDeck.duration;
+        const deckReachedEnd = activeDeck.ended ||
+          (isFinite(deckDuration) && deckDuration > 0 &&
+            activeDeck.currentTime >= deckDuration - 0.5);
+        if ((storeIsPlaying || useAudioStore.getState().wasPlayingBeforeUnload) && deckReachedEnd) {
+          const state = useAudioStore.getState();
+          if (state.playlist.length > 1 && state.currentSongIndex + 1 < state.playlist.length) {
+            console.log('👁️ [VISIBILITY] Song ended while backgrounded — advancing');
+            state.nextSong();
+            return;
+          }
+        }
+
         // Check for buffer stall
         const getBufferedEnd = (deck: HTMLAudioElement) => {
           if (deck.buffered.length > 0) {
@@ -222,6 +246,21 @@ export function usePlaybackStateSync({
         if (isStalled && storeIsPlaying) {
           console.log('👁️ [VISIBILITY] Audio stalled - delegating to recovery system');
           attemptStallRecovery(activeDeck, 'visibility-stall');
+          return;
+        }
+
+        // OPTION B: next song stuck loading. If the active deck has a real
+        // song set but readyState is still low (iOS throttled the fetch while
+        // the screen was locked), kick the browser with a fresh load() so we
+        // don't sit here silent waiting for the user to wake the screen again.
+        const wantsToPlay = storeIsPlaying || useAudioStore.getState().wasPlayingBeforeUnload;
+        if (wantsToPlay && hasRealSong(activeDeck) && activeDeck.readyState < 2 && !audioHadProgress) {
+          console.log(`👁️ [VISIBILITY] Active deck stuck loading (readyState=${activeDeck.readyState}) — forcing reload`);
+          checkAndResumeAudioContext().then(() => {
+            activeDeck.load();
+            // Best-effort play() once it can — no-op if still not ready.
+            activeDeck.play().catch(() => { /* waiting for canplay */ });
+          });
           return;
         }
 
@@ -283,7 +322,7 @@ export function usePlaybackStateSync({
 
     document.addEventListener('visibilitychange', handleVisibilityChange);
     return () => document.removeEventListener('visibilitychange', handleVisibilityChange);
-  }, [setIsPlaying, attemptStallRecovery, checkAndResumeAudioContext, deckARef, deckBRef, activeDeckRef, lastProgressTimeRef, lastProgressValueRef, setActiveDeck]);
+  }, [setIsPlaying, attemptStallRecovery, checkAndResumeAudioContext, deckARef, deckBRef, activeDeckRef, lastProgressTimeRef, lastProgressValueRef, setActiveDeck, currentSongIdRef]);
 
   // Playback state preservation (beforeunload, pagehide, visibility hidden)
   // Uses a flag to prevent triple-save on iOS (visibilitychange + pagehide + beforeunload

--- a/src/lib/hooks/usePlaybackSync.ts
+++ b/src/lib/hooks/usePlaybackSync.ts
@@ -238,10 +238,17 @@ function handleIncomingMessage(
         const currentIndex = payload.currentIndex as number | undefined;
         const currentSong = queue && typeof currentIndex === 'number' ? queue[currentIndex] : null;
         const remoteIsPlaying = (payload.isPlaying as boolean) ?? false;
+        const remoteDeviceId = (payload.deviceId as string | undefined) ?? null;
+
+        // During a WS reconnect the old and new sockets briefly coexist; the
+        // server broadcasts a fresh state_update from the new socket to the
+        // old (still-registered) socket, and the client sees its own deviceId
+        // echoed back. Treat that as a no-op instead of a remote takeover.
+        const isOwnEcho = remoteDeviceId !== null && remoteDeviceId === deviceId;
 
         // TAKEOVER: If remote device started playing and local is also playing,
         // the device with the newer playStateUpdatedAt wins. Pause the loser.
-        if (remoteIsPlaying && store.isPlaying) {
+        if (!isOwnEcho && remoteIsPlaying && store.isPlaying) {
           const remotePlayTs = (payload.playStateUpdatedAt as string) ?? '';
           const localPlayTs = store.playStateUpdatedAt ?? '';
           if (remotePlayTs > localPlayTs) {
@@ -256,6 +263,14 @@ function handleIncomingMessage(
               });
             }
           }
+        }
+
+        // If this is our own echo, skip the remote-device indicator and
+        // applyServerState too — the local state is already authoritative,
+        // and applying it back to ourselves risks overwriting fresh changes
+        // with the stale snapshot the echo contains.
+        if (isOwnEcho) {
+          break;
         }
 
         // Update the remote device indicator (green bubble)

--- a/src/lib/hooks/usePlaybackSync.ts
+++ b/src/lib/hooks/usePlaybackSync.ts
@@ -362,8 +362,20 @@ function handleIncomingMessage(
       if (!payload) break;
 
       if (payload.targetDeviceId === deviceId) {
-        // Transfer TO this device — fetch full state from server and apply
-        fetchAndReconcileState();
+        // Transfer TO this device — fetch full state from server and apply,
+        // then honor payload.play. applyServerState deliberately never sets
+        // isPlaying=true (browser autoplay policy on the remote-state path),
+        // so transfer-to-self has to flip it explicitly. The user clicked
+        // the picker in DevicePicker → fresh gesture activation, so play()
+        // will work even after the WS round-trip.
+        void (async () => {
+          await fetchAndReconcileState();
+          if (payload.play) {
+            const s = useAudioStore.getState();
+            console.log('[PlaybackSync] Transfer to this device — starting playback');
+            s.setIsPlaying(true);
+          }
+        })();
       } else if (store.isPlaying) {
         // Transfer AWAY from this device — pause and show indicator
         store.markUserPause();

--- a/src/lib/hooks/useWebAudioGraph.ts
+++ b/src/lib/hooks/useWebAudioGraph.ts
@@ -140,7 +140,7 @@ export function useWebAudioGraph(): WebAudioGraph {
       deckBElementRef.current = deckB;
 
       setIsInitialized(true);
-      console.log(`[WEB AUDIO] Graph initialized successfully sampleRate=${ctx.sampleRate}`);
+      console.log(`[WEB AUDIO] Graph initialized successfully sampleRate=${ctx.sampleRate} pbA=${deckA.playbackRate} pbB=${deckB.playbackRate}`);
       return true;
     } catch (err) {
       console.error('[WEB AUDIO] Failed to initialize graph:', err);
@@ -375,7 +375,7 @@ export function useWebAudioGraph(): WebAudioGraph {
           }
         }
 
-        console.log(`[WEB AUDIO] Context ${state} — wasPlaying=${wasPlayingBeforeInterruptRef.current}, sampleRate=${ctx.sampleRate}, masterGain disconnected (elements untouched)`);
+        console.log(`[WEB AUDIO] Context ${state} — wasPlaying=${wasPlayingBeforeInterruptRef.current}, sampleRate=${ctx.sampleRate}, pbA=${deckA?.playbackRate ?? '?'} pbB=${deckB?.playbackRate ?? '?'}, masterGain disconnected (elements untouched)`);
 
         // Persistent resume retry — iOS may not allow resume immediately after
         // interrupt. Instead of a fixed set of timeouts that can all expire while
@@ -416,7 +416,14 @@ export function useWebAudioGraph(): WebAudioGraph {
           console.warn(`[WEB AUDIO] ⚠️ sampleRate changed across interrupt: ${prevRate} → ${currentRate} (likely pitch-shift root cause)`);
         }
         lastSampleRateRef.current = currentRate;
-        console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}, sampleRate=${currentRate}${rateChanged ? ' (CHANGED)' : ''}`);
+        const dA = deckAElementRef.current;
+        const dB = deckBElementRef.current;
+        const pbA = dA?.playbackRate ?? 1;
+        const pbB = dB?.playbackRate ?? 1;
+        if (pbA !== 1 || pbB !== 1) {
+          console.warn(`[WEB AUDIO] ⚠️ playbackRate drift on resume: pbA=${pbA} pbB=${pbB} (likely pitch-shift root cause)`);
+        }
+        console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}, sampleRate=${currentRate}${rateChanged ? ' (CHANGED)' : ''}, pbA=${pbA} pbB=${pbB}`);
 
         // Recovery sequence (order matters):
         // 1. Briefly mute elements — prevents pitch artifact during graph reconnect.
@@ -502,7 +509,9 @@ export function useWebAudioGraph(): WebAudioGraph {
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       const state = ctx.state as string;
-      console.log(`[WEB AUDIO] Visibility returned, context ${state} sampleRate=${ctx.sampleRate}`);
+      const visDA = deckAElementRef.current;
+      const visDB = deckBElementRef.current;
+      console.log(`[WEB AUDIO] Visibility returned, context ${state} sampleRate=${ctx.sampleRate} pbA=${visDA?.playbackRate ?? '?'} pbB=${visDB?.playbackRate ?? '?'}`);
 
       if (state === 'suspended' || state === 'interrupted') {
         console.log(`[WEB AUDIO] Context ${state} — attempting resume`);

--- a/src/lib/hooks/useWebAudioGraph.ts
+++ b/src/lib/hooks/useWebAudioGraph.ts
@@ -64,6 +64,11 @@ export function useWebAudioGraph(): WebAudioGraph {
   const interruptedAtRef = useRef<number>(0);
   const clearWasPlayingTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const resumeIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Last observed AudioContext.sampleRate. iOS LPM can renegotiate the rate
+  // (48k↔44.1k) across an interrupt/resume cycle, which produces a pitch-shift
+  // artifact even after a hard resync. We log the rate at every state
+  // transition and explicitly warn if it changes.
+  const lastSampleRateRef = useRef<number | null>(null);
 
   const getGainNode = useCallback((deck: 'A' | 'B'): GainNode | null => {
     return deck === 'A' ? gainARef.current : gainBRef.current;
@@ -84,6 +89,7 @@ export function useWebAudioGraph(): WebAudioGraph {
 
       const ctx = new AudioContextClass();
       audioContextRef.current = ctx;
+      lastSampleRateRef.current = ctx.sampleRate;
 
       const gainA = ctx.createGain();
       const gainB = ctx.createGain();
@@ -134,7 +140,7 @@ export function useWebAudioGraph(): WebAudioGraph {
       deckBElementRef.current = deckB;
 
       setIsInitialized(true);
-      console.log('[WEB AUDIO] Graph initialized successfully');
+      console.log(`[WEB AUDIO] Graph initialized successfully sampleRate=${ctx.sampleRate}`);
       return true;
     } catch (err) {
       console.error('[WEB AUDIO] Failed to initialize graph:', err);
@@ -369,7 +375,7 @@ export function useWebAudioGraph(): WebAudioGraph {
           }
         }
 
-        console.log(`[WEB AUDIO] Context ${state} — wasPlaying=${wasPlayingBeforeInterruptRef.current}, masterGain disconnected (elements untouched)`);
+        console.log(`[WEB AUDIO] Context ${state} — wasPlaying=${wasPlayingBeforeInterruptRef.current}, sampleRate=${ctx.sampleRate}, masterGain disconnected (elements untouched)`);
 
         // Persistent resume retry — iOS may not allow resume immediately after
         // interrupt. Instead of a fixed set of timeouts that can all expire while
@@ -403,7 +409,14 @@ export function useWebAudioGraph(): WebAudioGraph {
         interruptedAtRef.current = 0;
         const needsResync = interruptDuration > 500;
 
-        console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}`);
+        const prevRate = lastSampleRateRef.current;
+        const currentRate = ctx.sampleRate;
+        const rateChanged = prevRate != null && prevRate !== currentRate;
+        if (rateChanged) {
+          console.warn(`[WEB AUDIO] ⚠️ sampleRate changed across interrupt: ${prevRate} → ${currentRate} (likely pitch-shift root cause)`);
+        }
+        lastSampleRateRef.current = currentRate;
+        console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}, sampleRate=${currentRate}${rateChanged ? ' (CHANGED)' : ''}`);
 
         // Recovery sequence (order matters):
         // 1. Briefly mute elements — prevents pitch artifact during graph reconnect.
@@ -489,7 +502,7 @@ export function useWebAudioGraph(): WebAudioGraph {
     const handleVisibilityChange = () => {
       if (document.visibilityState !== 'visible') return;
       const state = ctx.state as string;
-      console.log(`[WEB AUDIO] Visibility returned, context ${state}`);
+      console.log(`[WEB AUDIO] Visibility returned, context ${state} sampleRate=${ctx.sampleRate}`);
 
       if (state === 'suspended' || state === 'interrupted') {
         console.log(`[WEB AUDIO] Context ${state} — attempting resume`);

--- a/src/lib/hooks/useWebAudioGraph.ts
+++ b/src/lib/hooks/useWebAudioGraph.ts
@@ -425,6 +425,39 @@ export function useWebAudioGraph(): WebAudioGraph {
         }
         console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}, sampleRate=${currentRate}${rateChanged ? ' (CHANGED)' : ''}, pbA=${pbA} pbB=${pbB}`);
 
+        // Fast path for sub-100ms iOS state bounces (screen lock / brief
+        // visibility blur). The full recovery sequence below — element-volume
+        // toggle + masterGain disconnect + 250ms fade-in — was designed for
+        // real suspensions. On a 30–80ms iOS bounce it's the recovery itself
+        // that becomes the audible event: the 250ms fade forces the Bluetooth
+        // A2DP codec to re-establish its time base, and the first ~200ms
+        // after resume plays at a perceptibly altered tempo (= "pitch shift"
+        // reported on screen-lock). For these short bounces we just reconnect
+        // masterGain at user volume directly. No fade, no element toggle.
+        if (interruptDuration > 0 && interruptDuration < 100) {
+          console.log(`[WEB AUDIO] Short interrupt (${interruptDuration}ms) — instant restore, skipping fade/element-toggle`);
+          const masterFast = masterGainRef.current;
+          if (masterFast) {
+            try { masterFast.gain.cancelScheduledValues(0); } catch { /* no scheduled values */ }
+            try { masterFast.connect(ctx.destination); } catch { /* already connected */ }
+            const userVolume = useAudioStore.getState().volume ?? 1.0;
+            masterFast.gain.setValueAtTime(userVolume, ctx.currentTime);
+          }
+          if (shouldResume) {
+            if (!useAudioStore.getState().isPlaying) {
+              useAudioStore.getState().setIsPlaying(true);
+            }
+            if (clearWasPlayingTimerRef.current) clearTimeout(clearWasPlayingTimerRef.current);
+            clearWasPlayingTimerRef.current = setTimeout(() => {
+              wasPlayingBeforeInterruptRef.current = false;
+              clearWasPlayingTimerRef.current = null;
+            }, 3000);
+          } else {
+            wasPlayingBeforeInterruptRef.current = false;
+          }
+          return;
+        }
+
         // Recovery sequence (order matters):
         // 1. Briefly mute elements — prevents pitch artifact during graph reconnect.
         //    Elements were left at volume=1 during interrupted state (for background

--- a/src/lib/services/__tests__/artist-cooccurrence.test.ts
+++ b/src/lib/services/__tests__/artist-cooccurrence.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the Artist Co-Occurrence service.
+ *
+ * Covers the pure helpers (session splitting, pair accumulation,
+ * recency-decayed weighting) without touching the DB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { splitIntoSessions, accumulatePairs } from '../artist-cooccurrence';
+
+function d(isoMinutesAgo: number, base = new Date('2026-04-01T12:00:00Z')): Date {
+  return new Date(base.getTime() - isoMinutesAgo * 60 * 1000);
+}
+
+describe('splitIntoSessions', () => {
+  it('returns empty array when there are no plays', () => {
+    expect(splitIntoSessions([])).toEqual([]);
+  });
+
+  it('keeps plays in one session when gaps are under the threshold', () => {
+    const plays = [
+      { artist: 'a', playedAt: d(20) },
+      { artist: 'b', playedAt: d(15) },
+      { artist: 'c', playedAt: d(10) },
+    ];
+    const sessions = splitIntoSessions(plays);
+    expect(sessions).toHaveLength(1);
+    expect(sessions[0]).toHaveLength(3);
+  });
+
+  it('splits when gap exceeds the threshold (default 30min)', () => {
+    const plays = [
+      { artist: 'a', playedAt: d(100) },
+      { artist: 'b', playedAt: d(95) },
+      { artist: 'c', playedAt: d(40) },
+      { artist: 'd', playedAt: d(35) },
+    ];
+    const sessions = splitIntoSessions(plays);
+    expect(sessions).toHaveLength(2);
+    expect(sessions[0].map((p) => p.artist)).toEqual(['a', 'b']);
+    expect(sessions[1].map((p) => p.artist)).toEqual(['c', 'd']);
+  });
+
+  it('uses custom gap threshold when provided', () => {
+    const plays = [
+      { artist: 'a', playedAt: d(20) },
+      { artist: 'b', playedAt: d(10) },
+    ];
+    const tight = splitIntoSessions(plays, 5 * 60 * 1000);
+    expect(tight).toHaveLength(2);
+  });
+});
+
+describe('accumulatePairs', () => {
+  it('emits no pairs for a one-artist session', () => {
+    const sessions = [
+      [
+        { artist: 'a', playedAt: d(5) },
+        { artist: 'a', playedAt: d(3) },
+      ],
+    ];
+    const pairs = accumulatePairs(sessions);
+    expect(pairs.size).toBe(0);
+  });
+
+  it('emits one pair per distinct artist pair per session (not per song)', () => {
+    const sessions = [
+      [
+        { artist: 'a', playedAt: d(10) },
+        { artist: 'b', playedAt: d(9) },
+        { artist: 'a', playedAt: d(8) }, // replay of a — should not inflate
+        { artist: 'b', playedAt: d(7) },
+      ],
+    ];
+    const pairs = accumulatePairs(sessions);
+    expect(pairs.size).toBe(1);
+    const [, acc] = [...pairs.entries()][0];
+    expect(acc.coplayCount).toBe(1);
+  });
+
+  it('keys pairs with lexicographic ordering (a|b, never b|a)', () => {
+    const sessions = [
+      [
+        { artist: 'zebra', playedAt: d(5) },
+        { artist: 'apple', playedAt: d(3) },
+      ],
+    ];
+    const pairs = accumulatePairs(sessions);
+    expect([...pairs.keys()]).toEqual(['apple|zebra']);
+  });
+
+  it('accumulates weight across sessions and counts coplays', () => {
+    const now = new Date('2026-04-01T12:00:00Z');
+    const sessions = [
+      [
+        { artist: 'a', playedAt: d(20) },
+        { artist: 'b', playedAt: d(15) },
+      ],
+      [
+        { artist: 'a', playedAt: d(10) },
+        { artist: 'b', playedAt: d(5) },
+      ],
+    ];
+    const pairs = accumulatePairs(sessions, now);
+    expect(pairs.size).toBe(1);
+    const acc = pairs.get('a|b')!;
+    expect(acc.coplayCount).toBe(2);
+    expect(acc.weight).toBeGreaterThan(1.5); // two near-instant plays → weight close to 2
+    expect(acc.weight).toBeLessThanOrEqual(2);
+  });
+
+  it('applies recency decay — older co-plays contribute less than fresh ones', () => {
+    const now = new Date('2026-04-01T12:00:00Z');
+    const staleSession = [
+      [
+        { artist: 'a', playedAt: new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000) },
+        { artist: 'b', playedAt: new Date(now.getTime() - 60 * 24 * 60 * 60 * 1000) },
+      ],
+    ];
+    const freshSession = [
+      [
+        { artist: 'a', playedAt: new Date(now.getTime() - 60 * 1000) },
+        { artist: 'b', playedAt: new Date(now.getTime() - 60 * 1000) },
+      ],
+    ];
+    const stale = accumulatePairs(staleSession, now).get('a|b')!;
+    const fresh = accumulatePairs(freshSession, now).get('a|b')!;
+    expect(fresh.weight).toBeGreaterThan(stale.weight);
+    expect(stale.weight).toBeLessThan(0.1); // exp(-0.05 * 60) ≈ 0.05
+    expect(fresh.weight).toBeGreaterThan(0.99);
+  });
+
+  it('emits all pairs for a 3-artist session', () => {
+    const sessions = [
+      [
+        { artist: 'a', playedAt: d(10) },
+        { artist: 'b', playedAt: d(8) },
+        { artist: 'c', playedAt: d(6) },
+      ],
+    ];
+    const pairs = accumulatePairs(sessions);
+    expect(new Set(pairs.keys())).toEqual(new Set(['a|b', 'a|c', 'b|c']));
+  });
+
+  it('tracks lastCoplayedAt as the most recent artist appearance in a pair', () => {
+    const t0 = new Date('2026-04-01T12:00:00Z');
+    const tLate = new Date('2026-04-01T12:20:00Z');
+    const sessions = [
+      [
+        { artist: 'a', playedAt: t0 },
+        { artist: 'b', playedAt: tLate },
+      ],
+    ];
+    const acc = accumulatePairs(sessions, tLate).get('a|b')!;
+    expect(acc.lastCoplayedAt.getTime()).toBe(tLate.getTime());
+  });
+});

--- a/src/lib/services/__tests__/seeded-radio.test.ts
+++ b/src/lib/services/__tests__/seeded-radio.test.ts
@@ -1,0 +1,295 @@
+/**
+ * Tests for the Seeded Radio service.
+ *
+ * Covers the pure helpers directly (dedupe, artist-diversity, recency cap,
+ * variety blend math) and each seed kind via mocked Navidrome + scorer.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Song } from '@/lib/types/song';
+
+// ---------------------------------------------------------------------------
+// Mocks — must be declared before importing the module under test.
+// ---------------------------------------------------------------------------
+
+// Chainable + thenable mock: `.where()` returns a thenable with `.groupBy()`
+// so both `await db.select().from().where()` and
+// `await db.select().from().where().groupBy()` resolve to [].
+function thenableChain(): Promise<never[]> & { groupBy: () => Promise<never[]> } {
+  const p = Promise.resolve([] as never[]);
+  return Object.assign(p, { groupBy: () => Promise.resolve([] as never[]) });
+}
+
+vi.mock('@/lib/db', () => ({
+  db: {
+    select: vi.fn().mockReturnThis(),
+    from: vi.fn().mockReturnThis(),
+    where: vi.fn(() => thenableChain()),
+  },
+}));
+
+vi.mock('@/lib/services/navidrome', () => ({
+  getPlaylist: vi.fn(),
+  getSongs: vi.fn(),
+  getSongsByArtist: vi.fn(),
+  getSongsByIds: vi.fn(),
+}));
+
+vi.mock('@/lib/services/blended-recommendation-scorer', () => ({
+  getBlendedRecommendations: vi.fn().mockResolvedValue({ songs: [], metadata: {} }),
+}));
+
+import { generateSeededRadio, __internal } from '../seeded-radio';
+import {
+  getPlaylist,
+  getSongs,
+  getSongsByArtist,
+  getSongsByIds,
+} from '@/lib/services/navidrome';
+import { getBlendedRecommendations } from '@/lib/services/blended-recommendation-scorer';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeSong(overrides: Partial<Song> & { id: string; artist: string; title: string }): Song {
+  return {
+    id: overrides.id,
+    name: overrides.title,
+    title: overrides.title,
+    artist: overrides.artist,
+    albumId: overrides.albumId ?? 'album-1',
+    duration: overrides.duration ?? 180,
+    track: overrides.track ?? 1,
+    url: `/api/navidrome/stream/${overrides.id}`,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('seeded-radio helpers', () => {
+  describe('dedupe', () => {
+    it('drops duplicates by id', () => {
+      const songs = [
+        makeSong({ id: 'a', artist: 'X', title: 'T1' }),
+        makeSong({ id: 'a', artist: 'X', title: 'T1' }),
+        makeSong({ id: 'b', artist: 'Y', title: 'T2' }),
+      ];
+      expect(__internal.dedupe(songs)).toHaveLength(2);
+    });
+
+    it('drops duplicates by (artist|title) even when ids differ', () => {
+      const songs = [
+        makeSong({ id: 'a', artist: 'X', title: 'Same' }),
+        makeSong({ id: 'b', artist: 'x', title: 'same' }), // case-insensitive match
+      ];
+      expect(__internal.dedupe(songs)).toHaveLength(1);
+    });
+  });
+
+  describe('enforceArtistDiversity', () => {
+    it('keeps at most one song per artist', () => {
+      const songs = [
+        makeSong({ id: '1', artist: 'A', title: 'a1' }),
+        makeSong({ id: '2', artist: 'A', title: 'a2' }),
+        makeSong({ id: '3', artist: 'B', title: 'b1' }),
+        makeSong({ id: '4', artist: 'B', title: 'b2' }),
+      ];
+      const out = __internal.enforceArtistDiversity(songs);
+      expect(out).toHaveLength(2);
+      expect(out.map((s) => s.artist)).toEqual(['A', 'B']);
+    });
+
+    it('allows multiple songs from the `allowArtist` but caps others', () => {
+      const songs = [
+        makeSong({ id: '1', artist: 'Seed', title: 's1' }),
+        makeSong({ id: '2', artist: 'Seed', title: 's2' }),
+        makeSong({ id: '3', artist: 'Seed', title: 's3' }),
+        makeSong({ id: '4', artist: 'Other', title: 'o1' }),
+        makeSong({ id: '5', artist: 'Other', title: 'o2' }),
+      ];
+      const out = __internal.enforceArtistDiversity(songs, 'Seed');
+      // 3 seed + 1 other
+      expect(out).toHaveLength(4);
+      expect(out.filter((s) => s.artist === 'Seed')).toHaveLength(3);
+      expect(out.filter((s) => s.artist === 'Other')).toHaveLength(1);
+    });
+  });
+
+  describe('applyRecencyCap', () => {
+    it('caps recent-heard songs at 40% of target when fresh tracks are available', () => {
+      const recentIds = new Set(['r1', 'r2', 'r3', 'r4', 'r5', 'r6']);
+      const recent = { ids: recentIds, titleKeys: new Set<string>() };
+      // 6 recent + 10 fresh → target 10 → cap should kick in (max 4 recent).
+      const candidates: Song[] = [
+        ...Array.from({ length: 6 }, (_, i) =>
+          makeSong({ id: `r${i + 1}`, artist: `R${i}`, title: `rt${i}` }),
+        ),
+        ...Array.from({ length: 10 }, (_, i) =>
+          makeSong({ id: `f${i}`, artist: `F${i}`, title: `ft${i}` }),
+        ),
+      ];
+      const out = __internal.applyRecencyCap(candidates, recent, 10);
+      // 10 * 0.4 = 4 recent allowed
+      const recentTaken = out.filter((s) => recentIds.has(s.id)).length;
+      expect(recentTaken).toBeLessThanOrEqual(4);
+      expect(out).toHaveLength(10);
+    });
+
+    it('falls back to recent overflow when not enough fresh tracks exist', () => {
+      // Soft cap: if fresh tracks < (target - cap), we refill from deferred recents
+      // rather than returning a short list.
+      const recentIds = new Set(['r1', 'r2', 'r3', 'r4', 'r5', 'r6']);
+      const recent = { ids: recentIds, titleKeys: new Set<string>() };
+      const candidates: Song[] = [
+        ...Array.from({ length: 6 }, (_, i) =>
+          makeSong({ id: `r${i + 1}`, artist: `R${i}`, title: `rt${i}` }),
+        ),
+        makeSong({ id: 'f1', artist: 'F', title: 'ft' }),
+      ];
+      const out = __internal.applyRecencyCap(candidates, recent, 10);
+      // 6 recent + 1 fresh = 7 max available; expect all 7 returned.
+      expect(out).toHaveLength(7);
+    });
+
+    it('counts pinned songs toward the target but not the recent cap', () => {
+      const recent = { ids: new Set(['pinned']), titleKeys: new Set<string>() };
+      const pinned = [makeSong({ id: 'pinned', artist: 'P', title: 'P' })];
+      const candidates = [
+        makeSong({ id: 'c1', artist: 'A', title: '1' }),
+        makeSong({ id: 'c2', artist: 'B', title: '2' }),
+      ];
+      const out = __internal.applyRecencyCap(candidates, recent, 3, pinned);
+      expect(out[0]).toEqual(pinned[0]);
+      expect(out).toHaveLength(3);
+    });
+  });
+
+  describe('ARTIST_CATALOG_FRACTION', () => {
+    it('translates low/med/high to the expected percentages', () => {
+      expect(__internal.ARTIST_CATALOG_FRACTION.low).toBe(0.6);
+      expect(__internal.ARTIST_CATALOG_FRACTION.medium).toBe(0.35);
+      expect(__internal.ARTIST_CATALOG_FRACTION.high).toBe(0.15);
+    });
+
+    it('produces sensible artist-slice targets for size=40', () => {
+      const size = 40;
+      expect(Math.round(size * __internal.ARTIST_CATALOG_FRACTION.low)).toBe(24);
+      expect(Math.round(size * __internal.ARTIST_CATALOG_FRACTION.medium)).toBe(14);
+      expect(Math.round(size * __internal.ARTIST_CATALOG_FRACTION.high)).toBe(6);
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Per-seed integration (mocked)
+// ---------------------------------------------------------------------------
+
+describe('generateSeededRadio', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('song seed: places seed at track 1 and excludes it from scorer output', async () => {
+    const seed = makeSong({ id: 'seed-1', artist: 'Seed', title: 'Seed Song' });
+    const others = Array.from({ length: 10 }, (_, i) =>
+      makeSong({ id: `o${i}`, artist: `A${i}`, title: `t${i}` }),
+    );
+    vi.mocked(getSongsByIds).mockResolvedValue([seed]);
+    vi.mocked(getBlendedRecommendations).mockResolvedValue({ songs: others, metadata: {} });
+
+    const result = await generateSeededRadio('user-1', { kind: 'song', songId: 'seed-1' });
+
+    expect(result.songs[0].id).toBe('seed-1');
+    expect(result.seedInfo.seedSongIds).toEqual(['seed-1']);
+    expect(result.seedInfo.seedArtists).toEqual(['Seed']);
+
+    const scorerCall = vi.mocked(getBlendedRecommendations).mock.calls[0];
+    expect(scorerCall[1]?.excludeSongIds).toContain('seed-1');
+  });
+
+  it('album seed: excludes album tracks from output', async () => {
+    const album = Array.from({ length: 6 }, (_, i) =>
+      makeSong({ id: `alb-${i}`, artist: 'AlbumArtist', title: `T${i}`, album: 'The Album' }),
+    );
+    const rec = Array.from({ length: 10 }, (_, i) =>
+      makeSong({ id: `rec-${i}`, artist: `R${i}`, title: `rt${i}` }),
+    );
+    // Also sneak an album track into the scorer output to verify we strip it.
+    rec.push(album[0]);
+    vi.mocked(getSongs).mockResolvedValue(album);
+    vi.mocked(getBlendedRecommendations).mockResolvedValue({ songs: rec, metadata: {} });
+
+    const result = await generateSeededRadio('user-1', { kind: 'album', albumId: 'album-1' });
+
+    const albumIds = new Set(album.map((s) => s.id));
+    for (const s of result.songs) {
+      expect(albumIds.has(s.id)).toBe(false);
+    }
+    expect(result.seedInfo.label).toContain('Album Radio');
+  });
+
+  it('playlist seed: excludes playlist tracks from output', async () => {
+    const entry = Array.from({ length: 5 }, (_, i) => ({
+      id: `pl-${i}`,
+      title: `PT${i}`,
+      artist: `PA${i}`,
+      albumId: 'pa',
+      duration: '180',
+      track: '1',
+    }));
+    vi.mocked(getPlaylist).mockResolvedValue({
+      id: 'pl-1',
+      name: 'My List',
+      songCount: 5,
+      duration: 900,
+      owner: 'me',
+      public: false,
+      created: '',
+      changed: '',
+      entry: entry as never,
+    } as never);
+    vi.mocked(getBlendedRecommendations).mockResolvedValue({
+      songs: Array.from({ length: 10 }, (_, i) =>
+        makeSong({ id: `r-${i}`, artist: `RA${i}`, title: `rt${i}` }),
+      ),
+      metadata: {},
+    });
+
+    const result = await generateSeededRadio('user-1', {
+      kind: 'playlist',
+      playlistId: 'pl-1',
+    });
+
+    const playlistIds = new Set(entry.map((e) => e.id));
+    for (const s of result.songs) {
+      expect(playlistIds.has(s.id)).toBe(false);
+    }
+    expect(result.seedInfo.label).toContain('My List');
+  });
+
+  it('artist seed: mix of seed-artist tracks + adjacent, honours variety knob', async () => {
+    const catalog = Array.from({ length: 20 }, (_, i) =>
+      makeSong({ id: `cat-${i}`, artist: 'TheArtist', title: `song${i}` }),
+    );
+    const adjacent = Array.from({ length: 20 }, (_, i) =>
+      makeSong({ id: `adj-${i}`, artist: `Other${i}`, title: `adj${i}` }),
+    );
+    vi.mocked(getSongsByArtist).mockResolvedValue(catalog);
+    vi.mocked(getBlendedRecommendations).mockResolvedValue({ songs: adjacent, metadata: {} });
+
+    const result = await generateSeededRadio(
+      'user-1',
+      { kind: 'artist', artistId: 'artist-1' },
+      { variety: 'low', size: 40 },
+    );
+
+    // Low variety = ~60% catalog → at least 18 of 40 should be TheArtist.
+    const seedArtistCount = result.songs.filter((s) => s.artist === 'TheArtist').length;
+    expect(seedArtistCount).toBeGreaterThanOrEqual(18);
+    expect(result.seedInfo.seedArtists).toEqual(['TheArtist']);
+  });
+});

--- a/src/lib/services/__tests__/seeded-radio.test.ts
+++ b/src/lib/services/__tests__/seeded-radio.test.ts
@@ -12,12 +12,26 @@ import type { Song } from '@/lib/types/song';
 // Mocks — must be declared before importing the module under test.
 // ---------------------------------------------------------------------------
 
-// Chainable + thenable mock: `.where()` returns a thenable with `.groupBy()`
-// so both `await db.select().from().where()` and
-// `await db.select().from().where().groupBy()` resolve to [].
-function thenableChain(): Promise<never[]> & { groupBy: () => Promise<never[]> } {
+// Chainable + thenable mock. `.where()` returns a thenable that also exposes
+// `.groupBy()`, `.orderBy()`, and `.limit()` so any of these chains resolve
+// to `[]`:
+//   await db.select().from().where()
+//   await db.select().from().where().groupBy()
+//   await db.select().from().where().orderBy().limit()
+type QueryChain = Promise<never[]> & {
+  groupBy: () => QueryChain;
+  orderBy: () => QueryChain;
+  limit: () => QueryChain;
+};
+
+function thenableChain(): QueryChain {
   const p = Promise.resolve([] as never[]);
-  return Object.assign(p, { groupBy: () => Promise.resolve([] as never[]) });
+  const chain = Object.assign(p, {
+    groupBy: () => thenableChain(),
+    orderBy: () => thenableChain(),
+    limit: () => thenableChain(),
+  }) as QueryChain;
+  return chain;
 }
 
 vi.mock('@/lib/db', () => ({
@@ -33,6 +47,12 @@ vi.mock('@/lib/services/navidrome', () => ({
   getSongs: vi.fn(),
   getSongsByArtist: vi.fn(),
   getSongsByIds: vi.fn(),
+  getStarredSongs: vi.fn().mockResolvedValue([]),
+  searchArtistsByName: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('@/lib/services/navidrome-users', () => ({
+  getNavidromeUserCreds: vi.fn().mockResolvedValue(null),
 }));
 
 vi.mock('@/lib/services/blended-recommendation-scorer', () => ({

--- a/src/lib/services/__tests__/seeded-radio.test.ts
+++ b/src/lib/services/__tests__/seeded-radio.test.ts
@@ -208,6 +208,87 @@ describe('seeded-radio helpers', () => {
       expect(Math.round(size * __internal.ARTIST_CATALOG_FRACTION.high)).toBe(6);
     });
   });
+
+  describe('applyDurationTarget', () => {
+    const mk = (id: string, duration: number): Song =>
+      ({
+        id,
+        name: id,
+        title: id,
+        artist: 'A',
+        album: '',
+        albumId: '',
+        track: 0,
+        duration,
+        url: '',
+      }) as unknown as Song;
+
+    it('returns input unchanged when target is 0 or negative', () => {
+      const songs = [mk('a', 200), mk('b', 200)];
+      expect(__internal.applyDurationTarget(songs, 0)).toBe(songs);
+      expect(__internal.applyDurationTarget(songs, -10)).toBe(songs);
+    });
+
+    it('returns empty when input is empty', () => {
+      expect(__internal.applyDurationTarget([], 600)).toEqual([]);
+    });
+
+    it('stops at exact boundary (include the track that hits target)', () => {
+      // 3x 200s = 600s exactly. Including the third hits target with 0 overshoot.
+      const songs = [mk('a', 200), mk('b', 200), mk('c', 200), mk('d', 200)];
+      expect(__internal.applyDurationTarget(songs, 600)).toHaveLength(3);
+    });
+
+    it('snaps to closer boundary on overshoot — undershoot wins', () => {
+      // After 2 tracks: 400s (undershoot 200). Adding 3rd: 700s (overshoot 100).
+      // Overshoot is closer → include the third track.
+      const songs = [mk('a', 200), mk('b', 200), mk('c', 300), mk('d', 200)];
+      expect(__internal.applyDurationTarget(songs, 600)).toHaveLength(3);
+    });
+
+    it('snaps to closer boundary on overshoot — overshoot wins', () => {
+      // After 2 tracks: 500s (undershoot 100). Adding 3rd: 800s (overshoot 200).
+      // Undershoot is closer → stop at two.
+      const songs = [mk('a', 250), mk('b', 250), mk('c', 300), mk('d', 200)];
+      expect(__internal.applyDurationTarget(songs, 600)).toHaveLength(2);
+    });
+
+    it('always returns at least one track when input is non-empty, even if first overshoots', () => {
+      // First track is 1200s, target 600s. Overshoot beats returning empty.
+      const songs = [mk('a', 1200), mk('b', 200)];
+      const out = __internal.applyDurationTarget(songs, 600);
+      expect(out).toHaveLength(1);
+      expect(out[0].id).toBe('a');
+    });
+
+    it('returns full list when total duration is below target', () => {
+      const songs = [mk('a', 100), mk('b', 100)];
+      expect(__internal.applyDurationTarget(songs, 600)).toHaveLength(2);
+    });
+
+    it('treats missing duration as 0 (does not advance accumulator)', () => {
+      const noDur = { id: 'a', name: 'a', title: 'a', artist: 'A', url: '' } as unknown as Song;
+      const songs = [noDur, mk('b', 600)];
+      // 'a' contributes 0, 'b' hits target exactly.
+      expect(__internal.applyDurationTarget(songs, 600)).toHaveLength(2);
+    });
+  });
+
+  describe('estimateSizeFromMinutes', () => {
+    it('floors at MIN_ESTIMATED_SIZE for very short targets', () => {
+      // 30 min / 3.75 * 1.3 = ~10.4 → 11, but min is 15.
+      expect(__internal.estimateSizeFromMinutes(30)).toBe(15);
+    });
+
+    it('scales linearly above the floor', () => {
+      // 60 / 3.75 * 1.3 = 20.8 → 21
+      expect(__internal.estimateSizeFromMinutes(60)).toBe(21);
+      // 120 / 3.75 * 1.3 = 41.6 → 42
+      expect(__internal.estimateSizeFromMinutes(120)).toBe(42);
+      // 180 / 3.75 * 1.3 = 62.4 → 63
+      expect(__internal.estimateSizeFromMinutes(180)).toBe(63);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/services/__tests__/seeded-radio.test.ts
+++ b/src/lib/services/__tests__/seeded-radio.test.ts
@@ -59,14 +59,20 @@ vi.mock('@/lib/services/blended-recommendation-scorer', () => ({
   getBlendedRecommendations: vi.fn().mockResolvedValue({ songs: [], metadata: {} }),
 }));
 
+vi.mock('@/lib/services/artist-cooccurrence', () => ({
+  getRelatedArtists: vi.fn().mockResolvedValue([]),
+}));
+
 import { generateSeededRadio, __internal } from '../seeded-radio';
 import {
   getPlaylist,
   getSongs,
   getSongsByArtist,
   getSongsByIds,
+  searchArtistsByName,
 } from '@/lib/services/navidrome';
 import { getBlendedRecommendations } from '@/lib/services/blended-recommendation-scorer';
+import { getRelatedArtists } from '@/lib/services/artist-cooccurrence';
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -311,5 +317,109 @@ describe('generateSeededRadio', () => {
     const seedArtistCount = result.songs.filter((s) => s.artist === 'TheArtist').length;
     expect(seedArtistCount).toBeGreaterThanOrEqual(18);
     expect(result.seedInfo.seedArtists).toEqual(['TheArtist']);
+  });
+
+  it('artist seed: surfaces co-occurrence artists in the adjacent pool', async () => {
+    const catalog = Array.from({ length: 10 }, (_, i) =>
+      makeSong({ id: `cat-${i}`, artist: 'TheArtist', title: `song${i}` }),
+    );
+    // Make the scorer return NOTHING so any non-seed tracks in the output
+    // can only come from the co-occurrence branch.
+    vi.mocked(getSongsByArtist).mockImplementation(async (artistId: string) => {
+      if (artistId === 'artist-1') return catalog;
+      // Second call — co-occurrence lookup for 'cooc-artist'
+      return [
+        makeSong({ id: 'cooc-1', artist: 'CoocArtist', title: 'c1' }),
+        makeSong({ id: 'cooc-2', artist: 'CoocArtist', title: 'c2' }),
+      ];
+    });
+    vi.mocked(getBlendedRecommendations).mockResolvedValue({ songs: [], metadata: {} });
+    vi.mocked(getRelatedArtists).mockResolvedValue([
+      { artist: 'coocartist', score: 0.8, coplayCount: 5 },
+    ]);
+    vi.mocked(searchArtistsByName).mockResolvedValue([
+      { id: 'cooc-id', name: 'CoocArtist' } as never,
+    ]);
+
+    const result = await generateSeededRadio(
+      'user-1',
+      { kind: 'artist', artistId: 'artist-1' },
+      { variety: 'medium', size: 20 },
+    );
+
+    const coocCount = result.songs.filter((s) => s.artist === 'CoocArtist').length;
+    expect(coocCount).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// interleaveByFraction — direct unit tests with deterministic rng
+// ---------------------------------------------------------------------------
+
+describe('interleaveByFraction', () => {
+  function makeRng(values: number[]): () => number {
+    let i = 0;
+    return () => values[i++ % values.length];
+  }
+
+  const seed = 'Seed';
+  const catalog = (n: number) =>
+    Array.from({ length: n }, (_, i) =>
+      makeSong({ id: `c${i}`, artist: seed, title: `c${i}` }),
+    );
+  const scorer = (n: number) =>
+    Array.from({ length: n }, (_, i) =>
+      makeSong({ id: `s${i}`, artist: `Other${i}`, title: `s${i}` }),
+    );
+
+  it('respects catalogTarget even when rng always picks catalog', () => {
+    const out = __internal.interleaveByFraction(catalog(20), scorer(20), {
+      size: 20,
+      catalogTarget: 8,
+      scorerTarget: 12,
+      catalogFraction: 0.9,
+      seedArtist: seed,
+      rng: () => 0, // always "take catalog"
+    });
+    const fromSeed = out.filter((s) => s.artist === seed).length;
+    expect(fromSeed).toBe(8);
+    expect(out).toHaveLength(20);
+  });
+
+  it('falls back to the other pool when one is empty', () => {
+    const out = __internal.interleaveByFraction(catalog(5), scorer(20), {
+      size: 20,
+      catalogTarget: 12,
+      scorerTarget: 8,
+      catalogFraction: 0.5,
+      seedArtist: seed,
+      rng: makeRng([0]), // prefer catalog, but it runs out after 5
+    });
+    expect(out).toHaveLength(20);
+    expect(out.filter((s) => s.artist === seed)).toHaveLength(5);
+    expect(out.filter((s) => s.artist !== seed)).toHaveLength(15);
+  });
+
+  it('stops at size even when both pools have more', () => {
+    const out = __internal.interleaveByFraction(catalog(30), scorer(30), {
+      size: 10,
+      catalogTarget: 4,
+      scorerTarget: 6,
+      catalogFraction: 0.5,
+      seedArtist: seed,
+      rng: makeRng([0.1, 0.9, 0.1, 0.9, 0.1, 0.9, 0.1, 0.9, 0.1, 0.9]),
+    });
+    expect(out).toHaveLength(10);
+  });
+
+  it('returns empty list when both pools are empty', () => {
+    const out = __internal.interleaveByFraction([], [], {
+      size: 10,
+      catalogTarget: 6,
+      scorerTarget: 4,
+      catalogFraction: 0.6,
+      seedArtist: seed,
+    });
+    expect(out).toEqual([]);
   });
 });

--- a/src/lib/services/artist-cooccurrence.ts
+++ b/src/lib/services/artist-cooccurrence.ts
@@ -29,6 +29,7 @@ const LOOKBACK_DAYS = 90;
 const SESSION_GAP_MS = 30 * 60 * 1000;
 const RECENCY_DECAY_RATE = 0.05;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
+const INSERT_BATCH_SIZE = 500;
 
 export interface RelatedArtist {
   artist: string;
@@ -175,18 +176,14 @@ export async function computeForUser(
     return 0;
   }
 
-  await db
-    .delete(artistCoOccurrence)
-    .where(eq(artistCoOccurrence.userId, userId));
-
-  let stored = 0;
+  const insertRows: ArtistCoOccurrenceInsert[] = [];
   for (const [key, acc] of pairs) {
     const [a, b] = key.split('|');
     const playsA = playsPerArtist.get(a) ?? 1;
     const playsB = playsPerArtist.get(b) ?? 1;
     const normalized = acc.weight / Math.sqrt(playsA * playsB);
 
-    const rowsToInsert: ArtistCoOccurrenceInsert[] = [
+    insertRows.push(
       {
         userId,
         artistA: a,
@@ -203,28 +200,39 @@ export async function computeForUser(
         coplayCount: acc.coplayCount,
         lastCoplayedAt: acc.lastCoplayedAt,
       },
-    ];
-
-    await db
-      .insert(artistCoOccurrence)
-      .values(rowsToInsert)
-      .onConflictDoUpdate({
-        target: [
-          artistCoOccurrence.userId,
-          artistCoOccurrence.artistA,
-          artistCoOccurrence.artistB,
-        ],
-        set: {
-          cooccurrenceScore: sql`excluded.cooccurrence_score`,
-          coplayCount: sql`excluded.coplay_count`,
-          lastCoplayedAt: sql`excluded.last_coplayed_at`,
-          calculatedAt: new Date(),
-        },
-      });
-
-    stored += 2;
+    );
   }
 
+  // Atomic swap: wipe + rewrite in a single transaction. If any insert fails
+  // we roll back so the user keeps their existing graph rather than ending up
+  // with a partial one.
+  await db.transaction(async (tx) => {
+    await tx
+      .delete(artistCoOccurrence)
+      .where(eq(artistCoOccurrence.userId, userId));
+
+    for (let i = 0; i < insertRows.length; i += INSERT_BATCH_SIZE) {
+      const chunk = insertRows.slice(i, i + INSERT_BATCH_SIZE);
+      await tx
+        .insert(artistCoOccurrence)
+        .values(chunk)
+        .onConflictDoUpdate({
+          target: [
+            artistCoOccurrence.userId,
+            artistCoOccurrence.artistA,
+            artistCoOccurrence.artistB,
+          ],
+          set: {
+            cooccurrenceScore: sql`excluded.cooccurrence_score`,
+            coplayCount: sql`excluded.coplay_count`,
+            lastCoplayedAt: sql`excluded.last_coplayed_at`,
+            calculatedAt: new Date(),
+          },
+        });
+    }
+  });
+
+  const stored = insertRows.length;
   console.log(`🔗 [ArtistCoOccurrence] Stored ${stored} rows (${pairs.size} pairs) for user ${userId}`);
   return stored;
 }

--- a/src/lib/services/artist-cooccurrence.ts
+++ b/src/lib/services/artist-cooccurrence.ts
@@ -1,0 +1,273 @@
+/**
+ * Artist Co-Occurrence Service
+ *
+ * Builds a per-user graph of which artists are played together in the same
+ * listening session. Used by seeded-radio's artist seed to surface
+ * "adjacent" artists the user actually plays together — independent of
+ * Last.fm similarity. Captures the long tail Last.fm misses.
+ *
+ * Algorithm:
+ *   1. Read listening_history for user, last 90 days, sorted by playedAt.
+ *   2. Group into sessions — contiguous plays with no gap > 30 minutes.
+ *   3. For each session, enumerate all distinct artist pairs (A, B).
+ *   4. Accumulate raw weight with recency decay: exp(-0.05 * days_ago).
+ *   5. Normalize by cosine: score = raw / sqrt(plays(A) * plays(B)).
+ *   6. Upsert bidirectionally — both (A,B) and (B,A) rows.
+ *
+ * Lookup is a cheap indexed scan by (userId, artistA).
+ */
+
+import { db } from '../db';
+import {
+  artistCoOccurrence,
+  listeningHistory,
+  type ArtistCoOccurrenceInsert,
+} from '../db/schema';
+import { and, desc, eq, gte, sql } from 'drizzle-orm';
+
+const LOOKBACK_DAYS = 90;
+const SESSION_GAP_MS = 30 * 60 * 1000;
+const RECENCY_DECAY_RATE = 0.05;
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+export interface RelatedArtist {
+  artist: string;
+  score: number;
+  coplayCount: number;
+}
+
+interface PlayRow {
+  artist: string;
+  playedAt: Date;
+}
+
+/**
+ * Slice a timeline of plays into sessions by gap threshold.
+ * Exported for testing.
+ */
+export function splitIntoSessions(plays: PlayRow[], gapMs = SESSION_GAP_MS): PlayRow[][] {
+  if (plays.length === 0) return [];
+  const sessions: PlayRow[][] = [];
+  let current: PlayRow[] = [plays[0]];
+  for (let i = 1; i < plays.length; i++) {
+    const prev = plays[i - 1].playedAt.getTime();
+    const curr = plays[i].playedAt.getTime();
+    if (curr - prev > gapMs) {
+      sessions.push(current);
+      current = [plays[i]];
+    } else {
+      current.push(plays[i]);
+    }
+  }
+  sessions.push(current);
+  return sessions;
+}
+
+interface PairAccumulator {
+  weight: number;
+  coplayCount: number;
+  lastCoplayedAt: Date;
+}
+
+/**
+ * Build pair accumulator map from sessions. Exported for testing.
+ *
+ * For each session, emit every unordered distinct-artist pair once
+ * (sessions with many plays of the same artist don't inflate self-pairs).
+ * Pairs are keyed by `"A|B"` with A < B alphabetically for dedupe, then
+ * expanded bidirectionally at upsert time.
+ */
+export function accumulatePairs(
+  sessions: PlayRow[][],
+  now: Date = new Date(),
+): Map<string, PairAccumulator> {
+  const pairs = new Map<string, PairAccumulator>();
+
+  for (const session of sessions) {
+    const uniqueArtists = new Map<string, Date>();
+    for (const play of session) {
+      const existing = uniqueArtists.get(play.artist);
+      if (!existing || play.playedAt > existing) {
+        uniqueArtists.set(play.artist, play.playedAt);
+      }
+    }
+    const artistList = Array.from(uniqueArtists.entries());
+    if (artistList.length < 2) continue;
+
+    for (let i = 0; i < artistList.length; i++) {
+      for (let j = i + 1; j < artistList.length; j++) {
+        const [artistI, timeI] = artistList[i];
+        const [artistJ, timeJ] = artistList[j];
+        const [a, b] = artistI < artistJ ? [artistI, artistJ] : [artistJ, artistI];
+        const mostRecent = timeI > timeJ ? timeI : timeJ;
+        const daysAgo = Math.max(0, (now.getTime() - mostRecent.getTime()) / MS_PER_DAY);
+        const weight = Math.exp(-RECENCY_DECAY_RATE * daysAgo);
+
+        const key = `${a}|${b}`;
+        const acc = pairs.get(key);
+        if (acc) {
+          acc.weight += weight;
+          acc.coplayCount += 1;
+          if (mostRecent > acc.lastCoplayedAt) acc.lastCoplayedAt = mostRecent;
+        } else {
+          pairs.set(key, {
+            weight,
+            coplayCount: 1,
+            lastCoplayedAt: mostRecent,
+          });
+        }
+      }
+    }
+  }
+
+  return pairs;
+}
+
+/**
+ * Recompute the co-occurrence graph for a user from scratch.
+ * Returns the number of directional rows written (each pair = 2 rows).
+ */
+export async function computeForUser(
+  userId: string,
+  daysBack: number = LOOKBACK_DAYS,
+): Promise<number> {
+  console.log(`🔗 [ArtistCoOccurrence] Computing for user ${userId} (${daysBack} days)`);
+
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - daysBack);
+
+  const rows = await db
+    .select({
+      artist: listeningHistory.artist,
+      playedAt: listeningHistory.playedAt,
+    })
+    .from(listeningHistory)
+    .where(
+      and(
+        eq(listeningHistory.userId, userId),
+        gte(listeningHistory.playedAt, cutoff),
+      ),
+    )
+    .orderBy(listeningHistory.playedAt);
+
+  if (rows.length === 0) {
+    console.log(`🔗 [ArtistCoOccurrence] No listening history for user ${userId}`);
+    return 0;
+  }
+
+  const plays: PlayRow[] = rows
+    .filter((r) => r.artist && r.artist.trim().length > 0)
+    .map((r) => ({
+      artist: r.artist.toLowerCase().trim(),
+      playedAt: r.playedAt,
+    }));
+
+  const playsPerArtist = new Map<string, number>();
+  for (const play of plays) {
+    playsPerArtist.set(play.artist, (playsPerArtist.get(play.artist) ?? 0) + 1);
+  }
+
+  const sessions = splitIntoSessions(plays);
+  const pairs = accumulatePairs(sessions);
+
+  if (pairs.size === 0) {
+    console.log(`🔗 [ArtistCoOccurrence] No co-occurring pairs for user ${userId}`);
+    return 0;
+  }
+
+  await db
+    .delete(artistCoOccurrence)
+    .where(eq(artistCoOccurrence.userId, userId));
+
+  let stored = 0;
+  for (const [key, acc] of pairs) {
+    const [a, b] = key.split('|');
+    const playsA = playsPerArtist.get(a) ?? 1;
+    const playsB = playsPerArtist.get(b) ?? 1;
+    const normalized = acc.weight / Math.sqrt(playsA * playsB);
+
+    const rowsToInsert: ArtistCoOccurrenceInsert[] = [
+      {
+        userId,
+        artistA: a,
+        artistB: b,
+        cooccurrenceScore: normalized,
+        coplayCount: acc.coplayCount,
+        lastCoplayedAt: acc.lastCoplayedAt,
+      },
+      {
+        userId,
+        artistA: b,
+        artistB: a,
+        cooccurrenceScore: normalized,
+        coplayCount: acc.coplayCount,
+        lastCoplayedAt: acc.lastCoplayedAt,
+      },
+    ];
+
+    await db
+      .insert(artistCoOccurrence)
+      .values(rowsToInsert)
+      .onConflictDoUpdate({
+        target: [
+          artistCoOccurrence.userId,
+          artistCoOccurrence.artistA,
+          artistCoOccurrence.artistB,
+        ],
+        set: {
+          cooccurrenceScore: sql`excluded.cooccurrence_score`,
+          coplayCount: sql`excluded.coplay_count`,
+          lastCoplayedAt: sql`excluded.last_coplayed_at`,
+          calculatedAt: new Date(),
+        },
+      });
+
+    stored += 2;
+  }
+
+  console.log(`🔗 [ArtistCoOccurrence] Stored ${stored} rows (${pairs.size} pairs) for user ${userId}`);
+  return stored;
+}
+
+/**
+ * Look up the top N artists that co-occur with `artist` for this user,
+ * ranked by cooccurrenceScore.
+ */
+export async function getRelatedArtists(
+  userId: string,
+  artist: string,
+  limit: number = 10,
+): Promise<RelatedArtist[]> {
+  const normalized = artist.toLowerCase().trim();
+  if (normalized.length === 0) return [];
+
+  const rows = await db
+    .select({
+      artist: artistCoOccurrence.artistB,
+      score: artistCoOccurrence.cooccurrenceScore,
+      coplayCount: artistCoOccurrence.coplayCount,
+    })
+    .from(artistCoOccurrence)
+    .where(
+      and(
+        eq(artistCoOccurrence.userId, userId),
+        eq(artistCoOccurrence.artistA, normalized),
+      ),
+    )
+    .orderBy(desc(artistCoOccurrence.cooccurrenceScore))
+    .limit(limit);
+
+  return rows.map((r) => ({
+    artist: r.artist,
+    score: r.score,
+    coplayCount: r.coplayCount,
+  }));
+}
+
+export const __internal = {
+  splitIntoSessions,
+  accumulatePairs,
+  SESSION_GAP_MS,
+  RECENCY_DECAY_RATE,
+  LOOKBACK_DAYS,
+};

--- a/src/lib/services/compound-scoring.ts
+++ b/src/lib/services/compound-scoring.ts
@@ -436,6 +436,7 @@ export async function calculateFullUserProfile(
   compoundScores: number;
   artistAffinities: number;
   temporalPreferences: number;
+  artistCooccurrenceRows: number;
   likedSongsSync: { synced: number; unstarred: number };
 }> {
   console.log(`👤 [Profile] Starting full profile calculation for user ${userId}`);
@@ -478,13 +479,24 @@ export async function calculateFullUserProfile(
     console.error(`👤 [Profile] Failed to calculate temporal preferences:`, error);
   }
 
+  // Step 5: Rebuild artist co-occurrence graph
+  console.log(`👤 [Profile] Step 5/5: Computing artist co-occurrence graph...`);
+  let cooccurrenceRows = 0;
+  try {
+    const { computeForUser: computeCooccurrence } = await import('./artist-cooccurrence');
+    cooccurrenceRows = await computeCooccurrence(userId, daysBack * 6); // 90 days, same as artist affinity
+  } catch (error) {
+    console.error(`👤 [Profile] Failed to compute artist co-occurrence:`, error);
+  }
+
   const elapsed = Date.now() - startTime;
-  console.log(`👤 [Profile] Complete in ${elapsed}ms: ${compoundCount} compound scores, ${artistCount} artist affinities, ${temporalCount} temporal prefs, ${likedResult.synced} liked songs synced`);
+  console.log(`👤 [Profile] Complete in ${elapsed}ms: ${compoundCount} compound scores, ${artistCount} artist affinities, ${temporalCount} temporal prefs, ${cooccurrenceRows} co-occurrence rows, ${likedResult.synced} liked songs synced`);
 
   return {
     compoundScores: compoundCount,
     artistAffinities: artistCount,
     temporalPreferences: temporalCount,
+    artistCooccurrenceRows: cooccurrenceRows,
     likedSongsSync: likedResult,
   };
 }

--- a/src/lib/services/listening-history.ts
+++ b/src/lib/services/listening-history.ts
@@ -71,7 +71,11 @@ export async function recordSongPlay(
     duration?: number;
   },
   playDuration?: number,
-  userInitiatedSkip?: boolean
+  userInitiatedSkip?: boolean,
+  /** Origin of the play. Surfaced in logs so we can tell AI DJ
+   * recommendations apart from manual clicks / radio / autoplay. Not
+   * persisted to DB yet — log-only for first iteration. */
+  source?: string,
 ): Promise<void> {
   const completed = playDuration && song.duration
     ? (playDuration / song.duration >= COMPLETION_THRESHOLD ? 1 : 0)
@@ -115,7 +119,7 @@ export async function recordSongPlay(
 
   await db.insert(listeningHistory).values(record);
 
-  console.log(`📊 [ListeningHistory] Recorded play: ${song.artist} - ${song.title} (completed: ${completed === 1}, skipped: ${skipDetected === 1})`);
+  console.log(`📊 [ListeningHistory] Recorded play: ${song.artist} - ${song.title} (source=${source ?? 'unknown'}, completed: ${completed === 1}, skipped: ${skipDetected === 1})`);
 
   // Trigger async similarity fetch (don't await - fire and forget)
   fetchAndStoreSimilarTracks(song.artist, song.title).catch(err => {

--- a/src/lib/services/playback-websocket.ts
+++ b/src/lib/services/playback-websocket.ts
@@ -13,6 +13,9 @@ const connections = new Map<string, Set<WebSocket>>();
 // Track last heartbeat per connection
 const lastHeartbeat = new WeakMap<WebSocket, number>();
 
+// Track which deviceId each ws represents (captured from first message carrying one)
+const wsDeviceIds = new WeakMap<WebSocket, string>();
+
 // Message types
 interface PlaybackMessage {
   type: 'state_update' | 'transfer' | 'command' | 'sync_request' | 'heartbeat' | 'feedback_update';
@@ -28,12 +31,22 @@ interface PlaybackCommand {
 // Session lookup function (to be implemented with your auth)
 type GetUserIdFromRequest = (request: import('http').IncomingMessage) => Promise<string | null>;
 
+// Optional DB hook to clear the active-device fields when a device disconnects.
+// Returns `cleared: true` only if the disconnecting device was in fact the
+// active player. `playStateUpdatedAt` is the new server timestamp used by the
+// client-side conflict-resolution merge.
+export type ClearActiveDevice = (
+  userId: string,
+  deviceId: string,
+) => Promise<{ cleared: boolean; playStateUpdatedAt: string | null }>;
+
 /**
  * Setup WebSocket handlers for playback sync
  */
 export function setupPlaybackWebSocket(
   wss: WebSocketServer,
-  getUserId: GetUserIdFromRequest
+  getUserId: GetUserIdFromRequest,
+  clearActiveDevice?: ClearActiveDevice,
 ) {
   // Heartbeat check - terminate dead connections
   const HEARTBEAT_TIMEOUT = 60000; // 60 seconds
@@ -77,6 +90,12 @@ export function setupPlaybackWebSocket(
 
         // Update heartbeat on any message
         lastHeartbeat.set(ws, Date.now());
+
+        // Capture the deviceId this ws represents so we can detect a stale
+        // active-device entry when the connection closes.
+        if (message.deviceId && !wsDeviceIds.has(ws)) {
+          wsDeviceIds.set(ws, message.deviceId);
+        }
 
         switch (message.type) {
           case 'state_update':
@@ -133,10 +152,34 @@ export function setupPlaybackWebSocket(
       }
     });
 
-    ws.on('close', () => {
+    ws.on('close', async () => {
       connections.get(userId)?.delete(ws);
       const remaining = connections.get(userId)?.size || 0;
       console.log(`[WS] User ${userId} disconnected (${remaining} remaining)`);
+
+      // If the closing device was the active player, clear server-side state
+      // so other devices drop out of remote-control mode with a dead target.
+      const deviceId = wsDeviceIds.get(ws);
+      if (deviceId && clearActiveDevice) {
+        try {
+          const { cleared, playStateUpdatedAt } = await clearActiveDevice(userId, deviceId);
+          if (cleared && playStateUpdatedAt) {
+            console.log(`[WS] Cleared stale active device for user ${userId} (was ${deviceId})`);
+            // Notify remaining devices so their remoteDevice indicator flips off.
+            broadcastToAllDevices(userId, {
+              type: 'state',
+              payload: {
+                isPlaying: false,
+                deviceId: null,
+                deviceName: null,
+                playStateUpdatedAt,
+              },
+            });
+          }
+        } catch (err) {
+          console.error('[WS] Error clearing active device on disconnect:', err);
+        }
+      }
 
       if (remaining === 0) {
         connections.delete(userId);

--- a/src/lib/services/playback-websocket.ts
+++ b/src/lib/services/playback-websocket.ts
@@ -85,8 +85,9 @@ export function setupPlaybackWebSocket(
 
     // Handle messages
     ws.on('message', async (data: Buffer) => {
+      const raw = data.toString();
       try {
-        const message: PlaybackMessage = JSON.parse(data.toString());
+        const message: PlaybackMessage = JSON.parse(raw);
 
         // Update heartbeat on any message
         lastHeartbeat.set(ws, Date.now());
@@ -95,6 +96,25 @@ export function setupPlaybackWebSocket(
         // active-device entry when the connection closes.
         if (message.deviceId && !wsDeviceIds.has(ws)) {
           wsDeviceIds.set(ws, message.deviceId);
+          console.log(`[WS RX] user=${userId} device=${message.deviceId} bound to socket (first message)`);
+        }
+
+        // Compact RX summary so the transfer/command/state flow is traceable
+        // in the log. Pulls only the fields that matter for diagnosis.
+        const fromDevice = message.deviceId ?? '?';
+        let summary = `type=${message.type} from=${fromDevice}`;
+        if (message.type === 'transfer') {
+          const p = message.payload as { targetDeviceId?: string; targetDeviceName?: string; play?: boolean } | undefined;
+          summary += ` target=${p?.targetDeviceId ?? '?'} targetName=${JSON.stringify(p?.targetDeviceName ?? null)} play=${p?.play ?? '?'}`;
+        } else if (message.type === 'command') {
+          const p = message.payload as { action?: string; value?: unknown } | undefined;
+          summary += ` action=${p?.action ?? '?'}` + (p?.value !== undefined ? ` value=${JSON.stringify(p.value)}` : '');
+        } else if (message.type === 'state_update') {
+          const p = message.payload as { isPlaying?: boolean; deviceId?: string; deviceName?: string; currentIndex?: number; playStateUpdatedAt?: string } | undefined;
+          summary += ` isPlaying=${p?.isPlaying ?? '?'} senderName=${JSON.stringify(p?.deviceName ?? null)} idx=${p?.currentIndex ?? '?'}`;
+        }
+        if (message.type !== 'heartbeat') {
+          console.log(`[WS RX] ${summary}`);
         }
 
         switch (message.type) {
@@ -103,7 +123,7 @@ export function setupPlaybackWebSocket(
             broadcastToUser(userId, ws, {
               type: 'state',
               payload: message.payload,
-            });
+            }, 'state');
             break;
 
           case 'command':
@@ -115,7 +135,7 @@ export function setupPlaybackWebSocket(
               type: 'remote_command',
               payload: message.payload as PlaybackCommand,
               fromDevice: message.deviceId,
-            });
+            }, 'remote_command');
             break;
 
           case 'transfer':
@@ -123,7 +143,7 @@ export function setupPlaybackWebSocket(
             broadcastToAllDevices(userId, {
               type: 'transfer',
               payload: message.payload,
-            });
+            }, 'transfer');
             break;
 
           case 'sync_request':
@@ -131,7 +151,7 @@ export function setupPlaybackWebSocket(
             broadcastToUser(userId, ws, {
               type: 'sync_request',
               requestingDevice: message.deviceId,
-            });
+            }, 'sync_request');
             break;
 
           case 'feedback_update':
@@ -139,16 +159,22 @@ export function setupPlaybackWebSocket(
             broadcastToUser(userId, ws, {
               type: 'feedback_update',
               payload: message.payload,
-            });
+            }, 'feedback_update');
             break;
 
           case 'heartbeat':
             // Already updated lastHeartbeat, just acknowledge
             ws.send(JSON.stringify({ type: 'heartbeat_ack' }));
             break;
+
+          default:
+            // Surface unknown message types — silently dropped messages are
+            // a common cause of "I sent X but the other device didn't react."
+            console.warn(`[WS RX] ⚠️ unknown message type — dropped: ${JSON.stringify(message).slice(0, 200)}`);
         }
       } catch (err) {
-        console.error('[WS] Message error:', err);
+        // Include the raw payload (truncated) so we can see what failed to parse.
+        console.error(`[WS] ⚠️ Message error: ${(err as Error).message} — raw=${raw.slice(0, 200)}`);
       }
     });
 
@@ -174,7 +200,7 @@ export function setupPlaybackWebSocket(
                 deviceName: null,
                 playStateUpdatedAt,
               },
-            });
+            }, 'state-cleared-on-disconnect');
           }
         } catch (err) {
           console.error('[WS] Error clearing active device on disconnect:', err);
@@ -193,45 +219,58 @@ export function setupPlaybackWebSocket(
 }
 
 /**
- * Broadcast to all devices of a user except the sender
+ * Broadcast to all devices of a user except the sender. `typeForLog` is the
+ * outgoing message's `type` field, used only for diagnostic logging.
  */
-function broadcastToUser(userId: string, sender: WebSocket, message: Record<string, unknown>) {
+function broadcastToUser(userId: string, sender: WebSocket, message: Record<string, unknown>, typeForLog: string) {
   const userConnections = connections.get(userId);
   if (!userConnections) return;
 
   const data = JSON.stringify(message);
   let sent = 0;
+  let skippedClosed = 0;
 
   for (const ws of userConnections) {
-    if (ws !== sender && ws.readyState === 1) { // WebSocket.OPEN = 1
-      ws.send(data);
-      sent++;
+    if (ws !== sender) {
+      if (ws.readyState === 1) {
+        ws.send(data);
+        sent++;
+      } else {
+        skippedClosed++;
+      }
     }
   }
 
-  if (sent > 0) {
-    console.log(`[WS] Broadcast to ${sent} device(s) for user ${userId}`);
-  }
+  const skipNote = skippedClosed > 0 ? ` (skipped ${skippedClosed} closed)` : '';
+  console.log(`[WS TX] type=${typeForLog} to=${sent} device(s) (excluding sender)${skipNote}`);
 }
 
 /**
- * Broadcast to all devices of a user including sender
+ * Broadcast to all devices of a user including sender. `typeForLog` is the
+ * outgoing message's `type` field, used only for diagnostic logging.
  */
-function broadcastToAllDevices(userId: string, message: Record<string, unknown>) {
+function broadcastToAllDevices(userId: string, message: Record<string, unknown>, typeForLog: string) {
   const userConnections = connections.get(userId);
-  if (!userConnections) return;
+  if (!userConnections) {
+    console.warn(`[WS TX] ⚠️ type=${typeForLog} dropped — no connections for user ${userId}`);
+    return;
+  }
 
   const data = JSON.stringify(message);
   let sent = 0;
+  let skippedClosed = 0;
 
   for (const ws of userConnections) {
-    if (ws.readyState === 1) { // WebSocket.OPEN = 1
+    if (ws.readyState === 1) {
       ws.send(data);
       sent++;
+    } else {
+      skippedClosed++;
     }
   }
 
-  console.log(`[WS] Broadcast to all ${sent} device(s) for user ${userId}`);
+  const skipNote = skippedClosed > 0 ? ` (skipped ${skippedClosed} closed)` : '';
+  console.log(`[WS TX] type=${typeForLog} to=ALL ${sent} device(s)${skipNote}`);
 }
 
 /**

--- a/src/lib/services/recommendation-analytics.ts
+++ b/src/lib/services/recommendation-analytics.ts
@@ -317,12 +317,12 @@ export async function getActivityTrends(userId: string): Promise<ActivityTrends>
   const insights: string[] = [];
 
   if (peakDayOfWeek !== null) {
-    insights.push(`Most active on ${DAY_NAMES[peakDayOfWeek]}`);
+    insights.push(`Most feedback on ${DAY_NAMES[peakDayOfWeek]}`);
   }
 
   if (peakHourOfDay !== null) {
     const timeOfDay = peakHourOfDay < 12 ? 'morning' : peakHourOfDay < 17 ? 'afternoon' : 'evening';
-    insights.push(`Peak listening in the ${timeOfDay} (around ${peakHourOfDay}:00)`);
+    insights.push(`Peak feedback in the ${timeOfDay} (around ${peakHourOfDay}:00)`);
   }
 
   // Weekend vs weekday pattern
@@ -330,9 +330,9 @@ export async function getActivityTrends(userId: string): Promise<ActivityTrends>
   const weekdayCount = allFeedback.length - weekendCount;
 
   if (weekendCount > weekdayCount * 0.5) {
-    insights.push('More active on weekends');
+    insights.push('More feedback on weekends');
   } else if (weekdayCount > weekendCount * 2) {
-    insights.push('More active on weekdays');
+    insights.push('More feedback on weekdays');
   }
 
   const trends: ActivityTrends = {

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -20,7 +20,7 @@
  *  - Artist seed → seed artist catalog IS part of output (that's the point).
  */
 
-import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
+import { and, eq, gte, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/db';
 import { listeningHistory } from '@/lib/db/schema/listening-history.schema';
 import {
@@ -414,6 +414,75 @@ async function generateFromCollection(
 }
 
 /**
+ * Interleave two pools (seed artist's own catalog vs. adjacent/scorer tracks)
+ * into a single list of length `size`, biasing the random choice toward the
+ * catalog pool by `catalogFraction`.
+ *
+ * Invariants:
+ *  - The catalog pool can contribute at most `catalogTarget` tracks (counted by
+ *    artist-name match against `seedArtist`).
+ *  - Likewise the scorer pool can contribute at most `scorerTarget` tracks.
+ *  - Once one pool is exhausted or over quota, the other drains to fill the
+ *    remaining slots.
+ *  - Ties are broken by `rng()` (defaults to Math.random). Passing a seeded
+ *    rng makes the result deterministic in tests.
+ */
+export function interleaveByFraction(
+  catalog: Song[],
+  scorer: Song[],
+  opts: {
+    size: number;
+    catalogTarget: number;
+    scorerTarget: number;
+    catalogFraction: number;
+    seedArtist: string;
+    rng?: () => number;
+  },
+): Song[] {
+  const { size, catalogTarget, scorerTarget, catalogFraction, seedArtist } = opts;
+  const rng = opts.rng ?? Math.random;
+  const seed = seedArtist.toLowerCase();
+  const isSeedArtist = (s: Song) => (s.artist ?? '').toLowerCase() === seed;
+
+  const out: Song[] = [];
+  const catalogQueue = [...catalog];
+  const scorerQueue = [...scorer];
+  let catalogUsed = 0;
+  let scorerUsed = 0;
+
+  while (out.length < size && (catalogQueue.length || scorerQueue.length)) {
+    const catalogRemaining = catalogTarget - catalogUsed;
+    const scorerRemaining = scorerTarget - scorerUsed;
+
+    const takeCatalog =
+      catalogRemaining > 0 &&
+      catalogQueue.length > 0 &&
+      (scorerRemaining <= 0 || scorerQueue.length === 0 || rng() < catalogFraction);
+
+    if (takeCatalog) {
+      const next = catalogQueue.shift()!;
+      out.push(next);
+      if (isSeedArtist(next)) catalogUsed++;
+      else scorerUsed++;
+    } else if (scorerQueue.length > 0) {
+      const next = scorerQueue.shift()!;
+      out.push(next);
+      if (isSeedArtist(next)) catalogUsed++;
+      else scorerUsed++;
+    } else if (catalogQueue.length > 0) {
+      const next = catalogQueue.shift()!;
+      out.push(next);
+      if (isSeedArtist(next)) catalogUsed++;
+      else scorerUsed++;
+    } else {
+      break;
+    }
+  }
+
+  return out;
+}
+
+/**
  * For the user's top co-occurring artists with the seed, look each up in
  * Navidrome and fetch a handful of tracks. Best-effort — silently skips
  * artists that aren't findable. Returns up to `maxTracks` songs total.
@@ -512,34 +581,19 @@ async function generateFromArtist(
   let scorerSlice = dedupe([...coocFiltered, ...scorerMerged]);
   scorerSlice = enforceArtistDiversity(scorerSlice);
 
-  // Interleave: start with an artist track, then alternate to avoid clustering.
-  const interleaved: Song[] = [];
-  const catalogQueue = [...artistSlice];
-  const scorerQueue = [...scorerSlice];
-  while (interleaved.length < size && (catalogQueue.length || scorerQueue.length)) {
-    const catalogRemaining = catalogTarget - interleaved.filter(
-      (s) => (s.artist ?? '').toLowerCase() === artistName.toLowerCase(),
-    ).length;
-    const scorerRemaining = scorerTarget - interleaved.filter(
-      (s) => (s.artist ?? '').toLowerCase() !== artistName.toLowerCase(),
-    ).length;
-    const takeCatalog =
-      catalogRemaining > 0 &&
-      catalogQueue.length > 0 &&
-      (scorerRemaining <= 0 || scorerQueue.length === 0 || Math.random() < catalogFraction);
-    if (takeCatalog) {
-      interleaved.push(catalogQueue.shift()!);
-    } else if (scorerQueue.length > 0) {
-      interleaved.push(scorerQueue.shift()!);
-    } else if (catalogQueue.length > 0) {
-      interleaved.push(catalogQueue.shift()!);
-    } else {
-      break;
-    }
-  }
+  const interleaved = interleaveByFraction(artistSlice, scorerSlice, {
+    size,
+    catalogTarget,
+    scorerTarget,
+    catalogFraction,
+    seedArtist: artistName,
+  });
 
   let final = dedupe(interleaved);
   final = enforceArtistDiversity(final, artistName);
+  // NOTE: recency cap runs after interleave, so in the pathological case where
+  // many tracks are "recent" the variety ratio may drift slightly from the
+  // catalogFraction target. Acceptable — the knob is approximate by design.
   final = applyRecencyCap(final, recent, size);
 
   return {
@@ -611,5 +665,6 @@ export const __internal = {
   enforceArtistDiversity,
   applyRecencyCap,
   pickSeedTracks,
+  interleaveByFraction,
   ARTIST_CATALOG_FRACTION,
 };

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -28,7 +28,9 @@ import {
   getSongs,
   getSongsByArtist,
   getSongsByIds,
+  getStarredSongs,
 } from '@/lib/services/navidrome';
+import { getNavidromeUserCreds } from '@/lib/services/navidrome-users';
 import type { SubsonicSong } from '@/lib/services/navidrome/types';
 import type { Song } from '@/lib/types/song';
 import { getBlendedRecommendations } from '@/lib/services/blended-recommendation-scorer';
@@ -521,9 +523,20 @@ export async function generateSeededRadio(
     }
 
     case 'playlist': {
-      const pl = await getPlaylist(seed.playlistId);
-      const songs = (pl.entry ?? []).map(subsonicToSong);
-      const label = `Playlist Radio — ${pl.name ?? 'Unknown'}`;
+      let songs: Song[];
+      let label: string;
+
+      if (seed.playlistId === 'liked-songs') {
+        const creds = await getNavidromeUserCreds(userId);
+        const starred = creds ? await getStarredSongs(creds) : await getStarredSongs();
+        songs = starred.map(subsonicToSong);
+        label = 'Liked Songs Radio';
+      } else {
+        const pl = await getPlaylist(seed.playlistId);
+        songs = (pl.entry ?? []).map(subsonicToSong);
+        label = `Playlist Radio — ${pl.name ?? 'Unknown'}`;
+      }
+
       return generateFromCollection(userId, songs, label, size, recent);
     }
 

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -52,6 +52,8 @@ export type ArtistVariety = 'low' | 'medium' | 'high';
 export interface SeededRadioOptions {
   variety?: ArtistVariety;
   size?: number;
+  /** Target queue length in minutes (10–300). Overrides `size` when set. */
+  targetMinutes?: number;
 }
 
 export interface SeededRadioResult {
@@ -82,6 +84,44 @@ const ARTIST_CATALOG_FRACTION: Record<ArtistVariety, number> = {
 
 // Per-seed scorer fetch size (we ask for more than we need so dedupe+cap leave headroom).
 const SCORER_LIMIT_PER_SEED = 20;
+
+// Conservative average track length used to estimate slot count from a duration target.
+// Generously over-shoots so the post-trim has room to land on the target.
+const AVG_TRACK_MINUTES = 3.75;
+const DURATION_BUFFER = 1.3;
+const MIN_ESTIMATED_SIZE = 15;
+
+function estimateSizeFromMinutes(minutes: number): number {
+  return Math.max(
+    MIN_ESTIMATED_SIZE,
+    Math.ceil((minutes / AVG_TRACK_MINUTES) * DURATION_BUFFER),
+  );
+}
+
+/**
+ * Trim a song list to land as close as possible to `targetSeconds` total
+ * duration. When the next track would push past target, choose the boundary
+ * (include or exclude that track) that lands closer to target. Always returns
+ * at least one track when input is non-empty, even if the first track alone
+ * overshoots — empty radio is worse than slightly-too-long radio.
+ */
+function applyDurationTarget(songs: Song[], targetSeconds: number): Song[] {
+  if (targetSeconds <= 0 || songs.length === 0) return songs;
+
+  let acc = 0;
+  for (let i = 0; i < songs.length; i++) {
+    const dur = songs[i].duration ?? 0;
+    const after = acc + dur;
+    if (after >= targetSeconds) {
+      const undershoot = targetSeconds - acc;
+      const overshoot = after - targetSeconds;
+      if (i === 0 || overshoot < undershoot) return songs.slice(0, i + 1);
+      return songs.slice(0, i);
+    }
+    acc = after;
+  }
+  return songs;
+}
 
 // ============================================================================
 // Utilities
@@ -615,20 +655,28 @@ export async function generateSeededRadio(
   seed: SeededRadioSeed,
   options: SeededRadioOptions = {},
 ): Promise<SeededRadioResult> {
-  const size = options.size ?? DEFAULT_SIZE;
   const variety = options.variety ?? 'medium';
+  const targetMinutes = options.targetMinutes;
+  // When a duration target is set we estimate (and over-shoot) the slot count
+  // so the post-trim has room to land near target. Otherwise honor `size`.
+  const size = targetMinutes != null
+    ? estimateSizeFromMinutes(targetMinutes)
+    : (options.size ?? DEFAULT_SIZE);
   const recent = await getRecentSongSet(userId);
 
+  let result: SeededRadioResult;
   switch (seed.kind) {
     case 'song':
-      return generateFromSong(userId, seed.songId, size, recent);
+      result = await generateFromSong(userId, seed.songId, size, recent);
+      break;
 
     case 'album': {
       const songs = await getSongs(seed.albumId, 0, 100);
       const label = songs[0]
         ? `Album Radio — ${songs[0].album ?? 'Unknown'}`
         : 'Album Radio';
-      return generateFromCollection(userId, songs, label, size, recent);
+      result = await generateFromCollection(userId, songs, label, size, recent);
+      break;
     }
 
     case 'playlist': {
@@ -646,17 +694,28 @@ export async function generateSeededRadio(
         label = `Playlist Radio — ${pl.name ?? 'Unknown'}`;
       }
 
-      return generateFromCollection(userId, songs, label, size, recent);
+      result = await generateFromCollection(userId, songs, label, size, recent);
+      break;
     }
 
     case 'artist':
-      return generateFromArtist(userId, seed.artistId, size, variety, recent);
+      result = await generateFromArtist(userId, seed.artistId, size, variety, recent);
+      break;
 
     default: {
       const exhaustive: never = seed;
       throw new Error(`Unknown seed kind: ${JSON.stringify(exhaustive)}`);
     }
   }
+
+  if (targetMinutes != null) {
+    result = {
+      ...result,
+      songs: applyDurationTarget(result.songs, targetMinutes * 60),
+    };
+  }
+
+  return result;
 }
 
 // Exports for testing
@@ -666,5 +725,7 @@ export const __internal = {
   applyRecencyCap,
   pickSeedTracks,
   interleaveByFraction,
+  applyDurationTarget,
+  estimateSizeFromMinutes,
   ARTIST_CATALOG_FRACTION,
 };

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -29,11 +29,13 @@ import {
   getSongsByArtist,
   getSongsByIds,
   getStarredSongs,
+  searchArtistsByName,
 } from '@/lib/services/navidrome';
 import { getNavidromeUserCreds } from '@/lib/services/navidrome-users';
 import type { SubsonicSong } from '@/lib/services/navidrome/types';
 import type { Song } from '@/lib/types/song';
 import { getBlendedRecommendations } from '@/lib/services/blended-recommendation-scorer';
+import { getRelatedArtists } from '@/lib/services/artist-cooccurrence';
 
 // ============================================================================
 // Types
@@ -411,6 +413,40 @@ async function generateFromCollection(
   };
 }
 
+/**
+ * For the user's top co-occurring artists with the seed, look each up in
+ * Navidrome and fetch a handful of tracks. Best-effort — silently skips
+ * artists that aren't findable. Returns up to `maxTracks` songs total.
+ */
+async function fetchCoOccurrenceTracks(
+  userId: string,
+  seedArtistName: string,
+  maxArtists: number,
+  tracksPerArtist: number,
+  maxTracks: number,
+): Promise<Song[]> {
+  const related = await getRelatedArtists(userId, seedArtistName, maxArtists);
+  if (related.length === 0) return [];
+
+  const perArtistTracks = await Promise.all(
+    related.map(async (r) => {
+      try {
+        const hits = await searchArtistsByName(r.artist, 1);
+        if (hits.length === 0) return [] as Song[];
+        const songs = await getSongsByArtist(hits[0].id, 0, tracksPerArtist);
+        return songs;
+      } catch (err) {
+        console.warn(`[seeded-radio] co-occurrence lookup failed for ${r.artist}:`, err);
+        return [] as Song[];
+      }
+    }),
+  );
+
+  const flat: Song[] = [];
+  for (const row of perArtistTracks) flat.push(...row);
+  return flat.slice(0, maxTracks);
+}
+
 async function generateFromArtist(
   userId: string,
   artistId: string,
@@ -431,6 +467,17 @@ async function generateFromArtist(
 
   // Artist catalog slice — sampled randomly (no weighting, keeps it fresh).
   const artistSlice = sample(catalog, Math.min(catalogTarget + 5, catalog.length));
+
+  // Kick off co-occurrence lookup in parallel with the scorer.
+  // Top 5 co-occurring artists × 3 tracks each, capped at scorerTarget so
+  // we never fully crowd out the scorer's broader discovery.
+  const coocPromise = fetchCoOccurrenceTracks(
+    userId,
+    artistName,
+    5,
+    3,
+    Math.max(0, Math.floor(scorerTarget / 2)),
+  );
 
   // Scorer input: 3 seeds from catalog, exclude seed artist from results
   // so we get "similar artists" rather than more catalog.
@@ -454,7 +501,15 @@ async function generateFromArtist(
       if (row[i]) scorerMerged.push(row[i]);
     }
   }
-  let scorerSlice = dedupe(scorerMerged);
+
+  // Prepend co-occurrence tracks so they get priority in the adjacent pool.
+  // The interleave + diversity + recency cap downstream keep the mix honest.
+  const coocTracks = await coocPromise;
+  const coocFiltered = coocTracks.filter(
+    (s) => (s.artist ?? '').toLowerCase() !== artistName.toLowerCase(),
+  );
+
+  let scorerSlice = dedupe([...coocFiltered, ...scorerMerged]);
   scorerSlice = enforceArtistDiversity(scorerSlice);
 
   // Interleave: start with an artist track, then alternate to avoid clustering.

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -1,0 +1,547 @@
+/**
+ * Seeded Radio Service
+ *
+ * Generates a ~40-track radio queue from a seed (song, album, playlist, artist).
+ * Blends local library tracks with Last.fm / compound / DJ-match scoring via the
+ * existing blended recommendation scorer, then applies:
+ *
+ *  - Recency cap: at most 40% of output may be "recently heard" (last 30 days).
+ *    Prevents the Spotify echo-chamber failure mode where radio becomes a
+ *    replay of the user's own recent history.
+ *  - Artist variety knob for artist-seeded radio: Low=60% / Medium=35% / High=15%
+ *    of output comes from the seed artist's own catalog. Rest is adjacent.
+ *  - One-song-per-artist diversity (except for the seed artist in artist radio).
+ *  - Dedupe by id and by (artist|title).
+ *
+ * Inclusion rules follow industry convention:
+ *  - Song seed   → seed song is track 1, then similar.
+ *  - Album seed  → seed tracks excluded from output (avoid "shuffled album" feel).
+ *  - Playlist seed → same as album.
+ *  - Artist seed → seed artist catalog IS part of output (that's the point).
+ */
+
+import { and, desc, eq, gte, inArray, sql } from 'drizzle-orm';
+import { db } from '@/lib/db';
+import { listeningHistory } from '@/lib/db/schema/listening-history.schema';
+import {
+  getPlaylist,
+  getSongs,
+  getSongsByArtist,
+  getSongsByIds,
+} from '@/lib/services/navidrome';
+import type { SubsonicSong } from '@/lib/services/navidrome/types';
+import type { Song } from '@/lib/types/song';
+import { getBlendedRecommendations } from '@/lib/services/blended-recommendation-scorer';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type SeededRadioSeed =
+  | { kind: 'song'; songId: string }
+  | { kind: 'album'; albumId: string }
+  | { kind: 'playlist'; playlistId: string }
+  | { kind: 'artist'; artistId: string };
+
+export type ArtistVariety = 'low' | 'medium' | 'high';
+
+export interface SeededRadioOptions {
+  variety?: ArtistVariety;
+  size?: number;
+}
+
+export interface SeededRadioResult {
+  songs: Song[];
+  seedInfo: {
+    label: string;
+    seedSongIds: string[];
+    seedArtists: string[];
+  };
+}
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+const DEFAULT_SIZE = 40;
+const RECENCY_FRACTION = 0.4;
+const RECENCY_DAYS = 30;
+const SEED_TRACKS_MIN = 3;
+const SEED_TRACKS_MAX = 5;
+
+// % of output that is the seed artist's OWN catalog, per variety level.
+const ARTIST_CATALOG_FRACTION: Record<ArtistVariety, number> = {
+  low: 0.6,
+  medium: 0.35,
+  high: 0.15,
+};
+
+// Per-seed scorer fetch size (we ask for more than we need so dedupe+cap leave headroom).
+const SCORER_LIMIT_PER_SEED = 20;
+
+// ============================================================================
+// Utilities
+// ============================================================================
+
+function shuffle<T>(arr: T[]): T[] {
+  const out = [...arr];
+  for (let i = out.length - 1; i > 0; i--) {
+    const j = Math.floor(Math.random() * (i + 1));
+    [out[i], out[j]] = [out[j], out[i]];
+  }
+  return out;
+}
+
+function sample<T>(arr: T[], n: number): T[] {
+  return shuffle(arr).slice(0, n);
+}
+
+function titleKey(song: { artist?: string; title?: string; name?: string }): string {
+  const artist = (song.artist ?? '').toLowerCase();
+  const title = ((song.title ?? song.name) ?? '').toLowerCase();
+  return `${artist}|${title}`;
+}
+
+function dedupe(songs: Song[]): Song[] {
+  const ids = new Set<string>();
+  const titles = new Set<string>();
+  const out: Song[] = [];
+  for (const s of songs) {
+    if (!s?.id) continue;
+    if (ids.has(s.id)) continue;
+    const tk = titleKey(s);
+    if (titles.has(tk)) continue;
+    ids.add(s.id);
+    titles.add(tk);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * Keep at most one song per artist. `allowArtist` is NOT capped (used for the
+ * seed artist in artist-radio to preserve the intentional catalog slice).
+ */
+function enforceArtistDiversity(songs: Song[], allowArtist?: string): Song[] {
+  const allow = allowArtist?.toLowerCase();
+  const seenArtists = new Set<string>();
+  const out: Song[] = [];
+  for (const s of songs) {
+    const artist = (s.artist ?? '').toLowerCase();
+    if (allow && artist === allow) {
+      out.push(s);
+      continue;
+    }
+    if (seenArtists.has(artist)) continue;
+    seenArtists.add(artist);
+    out.push(s);
+  }
+  return out;
+}
+
+/**
+ * Convert Subsonic playlist entries to Song shape.
+ */
+function subsonicToSong(entry: SubsonicSong): Song {
+  return {
+    id: entry.id,
+    name: entry.title,
+    title: entry.title,
+    artist: entry.artist,
+    album: entry.album,
+    albumId: entry.albumId,
+    artistId: entry.artistId,
+    duration: Math.floor(parseFloat(entry.duration) || 0),
+    track: parseInt(entry.track) || 0,
+    url: `/api/navidrome/stream/${entry.id}`,
+    genre: entry.genre,
+    bpm: entry.bpm,
+  };
+}
+
+// ============================================================================
+// Recency (listening history)
+// ============================================================================
+
+/**
+ * Return the set of song IDs AND artist|title keys a user has played in the last
+ * `RECENCY_DAYS` days. Either match counts as "recent".
+ */
+async function getRecentSongSet(userId: string): Promise<{
+  ids: Set<string>;
+  titleKeys: Set<string>;
+}> {
+  try {
+    const cutoff = new Date(Date.now() - RECENCY_DAYS * 24 * 60 * 60 * 1000);
+    const rows = await db
+      .select({
+        songId: listeningHistory.songId,
+        artist: listeningHistory.artist,
+        title: listeningHistory.title,
+      })
+      .from(listeningHistory)
+      .where(
+        and(
+          eq(listeningHistory.userId, userId),
+          gte(listeningHistory.playedAt, cutoff),
+        ),
+      );
+
+    const ids = new Set<string>();
+    const titleKeys = new Set<string>();
+    for (const r of rows) {
+      if (r.songId) ids.add(r.songId);
+      if (r.artist && r.title) {
+        titleKeys.add(`${r.artist.toLowerCase()}|${r.title.toLowerCase()}`);
+      }
+    }
+    return { ids, titleKeys };
+  } catch (err) {
+    console.warn('[SeededRadio] Failed to load recency set:', err);
+    return { ids: new Set(), titleKeys: new Set() };
+  }
+}
+
+function isRecent(
+  song: Song,
+  recent: { ids: Set<string>; titleKeys: Set<string> },
+): boolean {
+  if (recent.ids.has(song.id)) return true;
+  return recent.titleKeys.has(titleKey(song));
+}
+
+/**
+ * Walk candidates in order, accepting up to `target` total, but allowing at most
+ * `floor(target * RECENCY_FRACTION)` recent entries. Pinned songs (e.g. seed song)
+ * count against the target but NOT the recent cap.
+ */
+function applyRecencyCap(
+  candidates: Song[],
+  recent: { ids: Set<string>; titleKeys: Set<string> },
+  target: number,
+  pinned: Song[] = [],
+): Song[] {
+  const maxRecent = Math.floor(target * RECENCY_FRACTION);
+  const pinnedIds = new Set(pinned.map((s) => s.id));
+  const out: Song[] = [...pinned];
+  let recentCount = 0;
+  const overflow: Song[] = [];
+
+  for (const s of candidates) {
+    if (pinnedIds.has(s.id)) continue;
+    if (out.length >= target) break;
+    if (isRecent(s, recent)) {
+      if (recentCount >= maxRecent) {
+        overflow.push(s);
+        continue;
+      }
+      recentCount++;
+    }
+    out.push(s);
+  }
+
+  // Fill from overflow if cap was generous and we're still short
+  if (out.length < target) {
+    for (const s of overflow) {
+      if (out.length >= target) break;
+      out.push(s);
+    }
+  }
+  return out;
+}
+
+// ============================================================================
+// Seed track picking
+// ============================================================================
+
+/**
+ * Pick `n` "representative" seed tracks from a source collection, weighted by
+ * local play count (from listening history). Ties broken randomly.
+ */
+async function pickSeedTracks(userId: string, songs: Song[], n: number): Promise<Song[]> {
+  if (songs.length <= n) return shuffle(songs);
+  const ids = songs.map((s) => s.id).filter(Boolean);
+  const playCounts = new Map<string, number>();
+
+  try {
+    if (ids.length > 0) {
+      const rows = await db
+        .select({
+          songId: listeningHistory.songId,
+          plays: sql<number>`count(*)::int`,
+        })
+        .from(listeningHistory)
+        .where(
+          and(
+            eq(listeningHistory.userId, userId),
+            inArray(listeningHistory.songId, ids),
+          ),
+        )
+        .groupBy(listeningHistory.songId);
+      for (const r of rows) {
+        playCounts.set(r.songId, Number(r.plays) || 0);
+      }
+    }
+  } catch (err) {
+    console.warn('[SeededRadio] Failed to load play counts for seed picking:', err);
+  }
+
+  // Rank: played songs first (by count desc), random tail for ties + unplayed.
+  const ranked = [...songs].sort((a, b) => {
+    const ca = playCounts.get(a.id) ?? 0;
+    const cb = playCounts.get(b.id) ?? 0;
+    if (cb !== ca) return cb - ca;
+    return Math.random() - 0.5;
+  });
+  return ranked.slice(0, n);
+}
+
+// ============================================================================
+// Scorer wrapper
+// ============================================================================
+
+async function scoreFromSeed(
+  seed: Song,
+  userId: string,
+  limit: number,
+  excludeSongIds: string[] = [],
+  excludeArtists: string[] = [],
+): Promise<Song[]> {
+  if (!seed.artist || !(seed.title || seed.name)) return [];
+  try {
+    const { songs } = await getBlendedRecommendations(
+      {
+        artist: seed.artist,
+        title: seed.title ?? seed.name ?? '',
+        genre: seed.genre,
+        bpm: seed.bpm,
+        key: seed.key,
+        energy: seed.energy,
+      },
+      { userId, limit, excludeSongIds, excludeArtists },
+    );
+    return songs;
+  } catch (err) {
+    console.warn(`[SeededRadio] Scorer failed for "${seed.artist} - ${seed.title}":`, err);
+    return [];
+  }
+}
+
+// ============================================================================
+// Per-seed strategies
+// ============================================================================
+
+async function generateFromSong(
+  userId: string,
+  songId: string,
+  size: number,
+  recent: { ids: Set<string>; titleKeys: Set<string> },
+): Promise<SeededRadioResult> {
+  const [seed] = await getSongsByIds([songId]);
+  if (!seed) {
+    throw new Error(`Seed song not found: ${songId}`);
+  }
+  const scored = await scoreFromSeed(seed, userId, size + 10, [seed.id]);
+  let merged = dedupe([seed, ...scored]);
+  merged = enforceArtistDiversity(merged, seed.artist);
+  merged = applyRecencyCap(merged, recent, size, [seed]);
+
+  return {
+    songs: merged,
+    seedInfo: {
+      label: `${seed.artist ?? 'Unknown'} — ${seed.title ?? seed.name ?? 'Unknown'}`,
+      seedSongIds: [seed.id],
+      seedArtists: seed.artist ? [seed.artist] : [],
+    },
+  };
+}
+
+async function generateFromCollection(
+  userId: string,
+  collection: Song[],
+  label: string,
+  size: number,
+  recent: { ids: Set<string>; titleKeys: Set<string> },
+): Promise<SeededRadioResult> {
+  if (collection.length === 0) {
+    return {
+      songs: [],
+      seedInfo: { label, seedSongIds: [], seedArtists: [] },
+    };
+  }
+
+  const seedCount = collection.length < 20 ? SEED_TRACKS_MIN : SEED_TRACKS_MAX;
+  const seeds = await pickSeedTracks(userId, collection, seedCount);
+  const seedIds = new Set(collection.map((s) => s.id));
+
+  // Run scorer per seed, merge scored results with first-seen-wins priority.
+  const perSeedResults = await Promise.all(
+    seeds.map((s) =>
+      scoreFromSeed(s, userId, SCORER_LIMIT_PER_SEED, Array.from(seedIds)),
+    ),
+  );
+
+  // Interleave results from each seed so no single seed dominates.
+  const merged: Song[] = [];
+  const maxLen = Math.max(...perSeedResults.map((r) => r.length), 0);
+  for (let i = 0; i < maxLen; i++) {
+    for (const row of perSeedResults) {
+      if (row[i]) merged.push(row[i]);
+    }
+  }
+
+  let final = dedupe(merged);
+  // Explicitly remove any seed-track IDs that snuck in.
+  final = final.filter((s) => !seedIds.has(s.id));
+  final = enforceArtistDiversity(final);
+  final = applyRecencyCap(final, recent, size);
+
+  const seedArtists = Array.from(
+    new Set(seeds.map((s) => s.artist).filter((a): a is string => !!a)),
+  );
+  return {
+    songs: final,
+    seedInfo: {
+      label,
+      seedSongIds: seeds.map((s) => s.id),
+      seedArtists,
+    },
+  };
+}
+
+async function generateFromArtist(
+  userId: string,
+  artistId: string,
+  size: number,
+  variety: ArtistVariety,
+  recent: { ids: Set<string>; titleKeys: Set<string> },
+): Promise<SeededRadioResult> {
+  const catalog = await getSongsByArtist(artistId, 0, 100);
+  if (catalog.length === 0) {
+    throw new Error(`No songs found for artist: ${artistId}`);
+  }
+  const artistName = catalog[0].artist ?? 'Unknown Artist';
+
+  // Split: X% from the artist's own catalog, (1-X)% from scorer (adjacent).
+  const catalogFraction = ARTIST_CATALOG_FRACTION[variety];
+  const catalogTarget = Math.round(size * catalogFraction);
+  const scorerTarget = size - catalogTarget;
+
+  // Artist catalog slice — sampled randomly (no weighting, keeps it fresh).
+  const artistSlice = sample(catalog, Math.min(catalogTarget + 5, catalog.length));
+
+  // Scorer input: 3 seeds from catalog, exclude seed artist from results
+  // so we get "similar artists" rather than more catalog.
+  const scorerSeeds = await pickSeedTracks(userId, catalog, 3);
+  const perSeedResults = await Promise.all(
+    scorerSeeds.map((s) =>
+      scoreFromSeed(
+        s,
+        userId,
+        SCORER_LIMIT_PER_SEED,
+        catalog.map((c) => c.id),
+        [artistName],
+      ),
+    ),
+  );
+
+  const scorerMerged: Song[] = [];
+  const maxLen = Math.max(...perSeedResults.map((r) => r.length), 0);
+  for (let i = 0; i < maxLen; i++) {
+    for (const row of perSeedResults) {
+      if (row[i]) scorerMerged.push(row[i]);
+    }
+  }
+  let scorerSlice = dedupe(scorerMerged);
+  scorerSlice = enforceArtistDiversity(scorerSlice);
+
+  // Interleave: start with an artist track, then alternate to avoid clustering.
+  const interleaved: Song[] = [];
+  const catalogQueue = [...artistSlice];
+  const scorerQueue = [...scorerSlice];
+  while (interleaved.length < size && (catalogQueue.length || scorerQueue.length)) {
+    const catalogRemaining = catalogTarget - interleaved.filter(
+      (s) => (s.artist ?? '').toLowerCase() === artistName.toLowerCase(),
+    ).length;
+    const scorerRemaining = scorerTarget - interleaved.filter(
+      (s) => (s.artist ?? '').toLowerCase() !== artistName.toLowerCase(),
+    ).length;
+    const takeCatalog =
+      catalogRemaining > 0 &&
+      catalogQueue.length > 0 &&
+      (scorerRemaining <= 0 || scorerQueue.length === 0 || Math.random() < catalogFraction);
+    if (takeCatalog) {
+      interleaved.push(catalogQueue.shift()!);
+    } else if (scorerQueue.length > 0) {
+      interleaved.push(scorerQueue.shift()!);
+    } else if (catalogQueue.length > 0) {
+      interleaved.push(catalogQueue.shift()!);
+    } else {
+      break;
+    }
+  }
+
+  let final = dedupe(interleaved);
+  final = enforceArtistDiversity(final, artistName);
+  final = applyRecencyCap(final, recent, size);
+
+  return {
+    songs: final,
+    seedInfo: {
+      label: `Artist Radio — ${artistName}`,
+      seedSongIds: scorerSeeds.map((s) => s.id),
+      seedArtists: [artistName],
+    },
+  };
+}
+
+// ============================================================================
+// Public entry point
+// ============================================================================
+
+export async function generateSeededRadio(
+  userId: string,
+  seed: SeededRadioSeed,
+  options: SeededRadioOptions = {},
+): Promise<SeededRadioResult> {
+  const size = options.size ?? DEFAULT_SIZE;
+  const variety = options.variety ?? 'medium';
+  const recent = await getRecentSongSet(userId);
+
+  switch (seed.kind) {
+    case 'song':
+      return generateFromSong(userId, seed.songId, size, recent);
+
+    case 'album': {
+      const songs = await getSongs(seed.albumId, 0, 100);
+      const label = songs[0]
+        ? `Album Radio — ${songs[0].album ?? 'Unknown'}`
+        : 'Album Radio';
+      return generateFromCollection(userId, songs, label, size, recent);
+    }
+
+    case 'playlist': {
+      const pl = await getPlaylist(seed.playlistId);
+      const songs = (pl.entry ?? []).map(subsonicToSong);
+      const label = `Playlist Radio — ${pl.name ?? 'Unknown'}`;
+      return generateFromCollection(userId, songs, label, size, recent);
+    }
+
+    case 'artist':
+      return generateFromArtist(userId, seed.artistId, size, variety, recent);
+
+    default: {
+      const exhaustive: never = seed;
+      throw new Error(`Unknown seed kind: ${JSON.stringify(exhaustive)}`);
+    }
+  }
+}
+
+// Exports for testing
+export const __internal = {
+  dedupe,
+  enforceArtistDiversity,
+  applyRecencyCap,
+  pickSeedTracks,
+  ARTIST_CATALOG_FRACTION,
+};

--- a/src/lib/stores/__tests__/audio-radio.test.ts
+++ b/src/lib/stores/__tests__/audio-radio.test.ts
@@ -1,0 +1,157 @@
+/**
+ * Tests for the seeded-radio store actions on the audio store:
+ *   - startRadio
+ *   - saveRadioAsPlaylist
+ *
+ * Verifies request shape, state transitions on success/failure, and the
+ * edge case where the server returns an empty song list.
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import { useAudioStore } from '../audio';
+import type { SeededRadioSeed } from '@/lib/services/seeded-radio';
+
+vi.mock('@/lib/toast', () => ({
+  toast: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+function jsonResponse(body: unknown, init: { status?: number } = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status: init.status ?? 200,
+    headers: { 'content-type': 'application/json' },
+  });
+}
+
+describe('audio store — seeded radio actions', () => {
+  beforeEach(() => {
+    useAudioStore.setState({
+      playlist: [],
+      currentSongIndex: -1,
+      isPlaying: false,
+      isRadioSession: false,
+      radioSeed: null,
+      radioVariety: 'medium',
+      radioSessionPlayCount: 0,
+      aiDJUserActionInProgress: false,
+    });
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('startRadio', () => {
+    it('populates the queue and sets radio-session flags on success', async () => {
+      const seed: SeededRadioSeed = { kind: 'song', songId: 'abc' };
+      const songs = [
+        { id: 'abc', title: 'Seed', artist: 'X', duration: 100, url: '/s/abc' },
+        { id: 'def', title: 'Two', artist: 'Y', duration: 100, url: '/s/def' },
+      ];
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { songs, seedInfo: { label: 'Seed Radio' } } }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await useAudioStore.getState().startRadio(seed, 'medium');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/radio/seeded',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ seed, variety: 'medium' });
+
+      const state = useAudioStore.getState();
+      expect(state.playlist).toHaveLength(2);
+      expect(state.isPlaying).toBe(true);
+      expect(state.isRadioSession).toBe(true);
+      expect(state.radioSeed).toEqual(seed);
+      expect(state.radioVariety).toBe('medium');
+      expect(state.radioSessionPlayCount).toBe(0);
+    });
+
+    it('warns and does not mutate state when the server returns no songs', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ data: { songs: [], seedInfo: {} } })),
+      );
+
+      const before = useAudioStore.getState();
+      await useAudioStore.getState().startRadio({ kind: 'song', songId: 'x' });
+
+      const after = useAudioStore.getState();
+      expect(after.playlist).toEqual(before.playlist);
+      expect(after.isRadioSession).toBe(false);
+      expect(after.radioSeed).toBeNull();
+    });
+
+    it('surfaces an error and leaves state untouched on non-2xx', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ message: 'boom' }, { status: 500 })),
+      );
+
+      const before = useAudioStore.getState();
+      await useAudioStore.getState().startRadio({ kind: 'song', songId: 'x' });
+
+      const after = useAudioStore.getState();
+      expect(after.isRadioSession).toBe(false);
+      expect(after.playlist).toEqual(before.playlist);
+    });
+  });
+
+  describe('saveRadioAsPlaylist', () => {
+    it('returns null when the queue is empty', async () => {
+      const fetchMock = vi.fn();
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await useAudioStore.getState().saveRadioAsPlaylist('Test');
+
+      expect(result).toBeNull();
+      expect(fetchMock).not.toHaveBeenCalled();
+    });
+
+    it('POSTs to /api/playlists/create-from-ids and returns playlist info', async () => {
+      useAudioStore.setState({
+        playlist: [
+          { id: '1', title: 'a', artist: 'A', duration: 60, url: '/1' },
+          { id: '2', title: 'b', artist: 'B', duration: 60, url: '/2' },
+        ],
+      });
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { playlistId: 'pl-42', name: 'My Radio' } }, { status: 201 }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const result = await useAudioStore.getState().saveRadioAsPlaylist('My Radio');
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        '/api/playlists/create-from-ids',
+        expect.objectContaining({ method: 'POST' }),
+      );
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ name: 'My Radio', songIds: ['1', '2'] });
+      expect(result).toEqual({ playlistId: 'pl-42', name: 'My Radio' });
+    });
+
+    it('returns null on non-2xx without throwing', async () => {
+      useAudioStore.setState({
+        playlist: [{ id: '1', title: 'a', artist: 'A', duration: 60, url: '/1' }],
+      });
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(jsonResponse({ message: 'denied' }, { status: 403 })),
+      );
+
+      const result = await useAudioStore.getState().saveRadioAsPlaylist('x');
+      expect(result).toBeNull();
+    });
+  });
+});

--- a/src/lib/stores/__tests__/audio-radio.test.ts
+++ b/src/lib/stores/__tests__/audio-radio.test.ts
@@ -59,7 +59,7 @@ describe('audio store — seeded radio actions', () => {
       );
       vi.stubGlobal('fetch', fetchMock);
 
-      await useAudioStore.getState().startRadio(seed, 'medium');
+      await useAudioStore.getState().startRadio(seed, { variety: 'medium' });
 
       expect(fetchMock).toHaveBeenCalledWith(
         '/api/radio/seeded',
@@ -74,7 +74,25 @@ describe('audio store — seeded radio actions', () => {
       expect(state.isRadioSession).toBe(true);
       expect(state.radioSeed).toEqual(seed);
       expect(state.radioVariety).toBe('medium');
+      expect(state.radioTargetMinutes).toBeNull();
       expect(state.radioSessionPlayCount).toBe(0);
+    });
+
+    it('forwards targetMinutes in the request body and persists it in state', async () => {
+      const seed: SeededRadioSeed = { kind: 'song', songId: 'abc' };
+      const songs = [
+        { id: 'abc', title: 'Seed', artist: 'X', duration: 100, url: '/s/abc' },
+      ];
+      const fetchMock = vi.fn().mockResolvedValue(
+        jsonResponse({ data: { songs, seedInfo: { label: 'Seed Radio' } } }),
+      );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await useAudioStore.getState().startRadio(seed, { targetMinutes: 60 });
+
+      const body = JSON.parse((fetchMock.mock.calls[0][1] as RequestInit).body as string);
+      expect(body).toEqual({ seed, variety: 'medium', targetMinutes: 60 });
+      expect(useAudioStore.getState().radioTargetMinutes).toBe(60);
     });
 
     it('warns and does not mutate state when the server returns no songs', async () => {

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -234,6 +234,9 @@ export const useAudioStore = create<AudioState>()(
       playlist: songs,
       currentSongIndex: 0,
       isShuffled: false,
+      isRadioSession: false,
+      radioSeed: null,
+      radioVariety: 'medium' as ArtistVariety,
     }),
 
     playSong: (songId: string, newPlaylist?: Song[]) => {

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -15,7 +15,14 @@ const RADIO_RESET = {
   isRadioSession: false,
   radioSeed: null as SeededRadioSeed | null,
   radioVariety: 'medium' as ArtistVariety,
+  radioTargetMinutes: null as number | null,
 } as const;
+
+export interface StartRadioOptions {
+  variety?: ArtistVariety;
+  /** Target queue length in minutes (10–300). Omit for default ~40-track behavior. */
+  targetMinutes?: number;
+}
 
 // Client-side helper functions (moved from ai-dj.ts to avoid server imports)
 function checkQueueThreshold(
@@ -118,6 +125,8 @@ interface AudioState {
   // Seeded radio (non-persisted): the seed and variety used for the current session
   radioSeed: SeededRadioSeed | null;
   radioVariety: ArtistVariety;
+  // Optional duration constraint (minutes) used for the current session. null = unconstrained.
+  radioTargetMinutes: number | null;
 
   setPlaylist: (songs: Song[]) => void;
   playSong: (songId: string, newPlaylist?: Song[]) => void;
@@ -171,7 +180,7 @@ interface AudioState {
   incrementRadioPlayCount: () => void;
   setIsRadioSession: (isRadio: boolean) => void;
   // Seeded radio
-  startRadio: (seed: SeededRadioSeed, variety?: ArtistVariety) => Promise<void>;
+  startRadio: (seed: SeededRadioSeed, opts?: StartRadioOptions) => Promise<void>;
   saveRadioAsPlaylist: (name: string) => Promise<{ playlistId: string; name: string } | null>;
   /**
    * Reconcile currentSongIndex with the song actually loaded on the active
@@ -242,6 +251,7 @@ export const useAudioStore = create<AudioState>()(
     isRadioSession: false,
     radioSeed: null,
     radioVariety: 'medium',
+    radioTargetMinutes: null,
 
     setAIUserActionInProgress: (inProgress: boolean) => set({ aiDJUserActionInProgress: inProgress }),
 
@@ -1793,7 +1803,9 @@ export const useAudioStore = create<AudioState>()(
       set({ currentSongIndex: actualIndex });
     },
 
-    startRadio: async (seed: SeededRadioSeed, variety: ArtistVariety = 'medium') => {
+    startRadio: async (seed: SeededRadioSeed, opts: StartRadioOptions = {}) => {
+      const variety = opts.variety ?? 'medium';
+      const targetMinutes = opts.targetMinutes ?? null;
       // Gate AI DJ auto-refresh while the queue is being replaced. Released
       // 2s after we finish — same cadence as playNow / addToQueue actions —
       // so the monitor can't fire against a half-settled queue.
@@ -1803,7 +1815,11 @@ export const useAudioStore = create<AudioState>()(
           method: 'POST',
           credentials: 'include',
           headers: { 'content-type': 'application/json' },
-          body: JSON.stringify({ seed, variety }),
+          body: JSON.stringify({
+            seed,
+            variety,
+            ...(targetMinutes != null ? { targetMinutes } : {}),
+          }),
         });
         if (!res.ok) {
           const err = await res.json().catch(() => ({}));
@@ -1822,6 +1838,7 @@ export const useAudioStore = create<AudioState>()(
           isRadioSession: true,
           radioSeed: seed,
           radioVariety: variety,
+          radioTargetMinutes: targetMinutes,
           radioSessionPlayCount: 0,
         });
         toast.success(`Radio started — ${label}`);
@@ -1894,6 +1911,7 @@ export const useAudioStore = create<AudioState>()(
         state.isRadioSession = false;
         state.radioSeed = null;
         state.radioVariety = 'medium';
+        state.radioTargetMinutes = null;
         state.aiQueuedSongIds = new Set<string>();
         state.autoplayIsLoading = false;
         state.autoplayTransitionActive = false;

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -9,6 +9,14 @@ import { toast } from '@/lib/toast';
 import { shuffleSongs } from '@/lib/utils/shuffle-scoring';
 import type { SeededRadioSeed, ArtistVariety } from '@/lib/services/seeded-radio';
 
+// Any non-additive queue replacement clears radio-session state. Spread into
+// the `set(...)` call of every action that swaps out the playlist wholesale.
+const RADIO_RESET = {
+  isRadioSession: false,
+  radioSeed: null as SeededRadioSeed | null,
+  radioVariety: 'medium' as ArtistVariety,
+} as const;
+
 // Client-side helper functions (moved from ai-dj.ts to avoid server imports)
 function checkQueueThreshold(
   currentSongIndex: number,
@@ -234,9 +242,7 @@ export const useAudioStore = create<AudioState>()(
       playlist: songs,
       currentSongIndex: 0,
       isShuffled: false,
-      isRadioSession: false,
-      radioSeed: null,
-      radioVariety: 'medium' as ArtistVariety,
+      ...RADIO_RESET,
     }),
 
     playSong: (songId: string, newPlaylist?: Song[]) => {
@@ -265,10 +271,16 @@ export const useAudioStore = create<AudioState>()(
         }
       }
 
+      // playSong may be handed a fresh playlist (full replacement) or a
+      // single-song fallback — both cases wipe radio state. If the existing
+      // queue is kept, radio continues (handled implicitly: state.playlist is
+      // reused and RADIO_RESET is not applied).
+      const replacing = playlist !== state.playlist;
       set({
         playlist,
         currentSongIndex: index,
         isPlaying: true,
+        ...(replacing ? RADIO_RESET : {}),
       });
     },
 
@@ -284,6 +296,7 @@ export const useAudioStore = create<AudioState>()(
           currentSongIndex: 0,
           isPlaying: true,
           isShuffled: false,
+          ...RADIO_RESET,
         });
       } else {
         // Replace the currently playing song with the new song
@@ -482,7 +495,7 @@ export const useAudioStore = create<AudioState>()(
         currentSongIndex: 0,
         isPlaying: true,
         isShuffled: false,
-  
+        ...RADIO_RESET,
       });
     },
     addPlaylistToQueue: (songs: Song[], replaceQueue: boolean = false) => {
@@ -494,7 +507,7 @@ export const useAudioStore = create<AudioState>()(
           currentSongIndex: 0,
           isPlaying: true,
           isShuffled: false,
-    
+          ...RADIO_RESET,
         });
       } else {
         // Append to existing queue
@@ -1764,6 +1777,9 @@ export const useAudioStore = create<AudioState>()(
     setIsRadioSession: (isRadio: boolean) => set({ isRadioSession: isRadio }),
 
     startRadio: async (seed: SeededRadioSeed, variety: ArtistVariety = 'medium') => {
+      // Gate AI DJ auto-refresh while the queue is being replaced. Released
+      // 2s after we finish — same cadence as playNow / addToQueue actions —
+      // so the monitor can't fire against a half-settled queue.
       set({ aiDJUserActionInProgress: true });
       try {
         const res = await fetch('/api/radio/seeded', {
@@ -1808,7 +1824,7 @@ export const useAudioStore = create<AudioState>()(
         return null;
       }
       try {
-        const res = await fetch('/api/radio/save-as-playlist', {
+        const res = await fetch('/api/playlists/create-from-ids', {
           method: 'POST',
           credentials: 'include',
           headers: { 'content-type': 'application/json' },

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -173,6 +173,13 @@ interface AudioState {
   // Seeded radio
   startRadio: (seed: SeededRadioSeed, variety?: ArtistVariety) => Promise<void>;
   saveRadioAsPlaylist: (name: string) => Promise<{ playlistId: string; name: string } | null>;
+  /**
+   * Reconcile currentSongIndex with the song actually loaded on the active
+   * deck. Used to close the UI/audio drift window when a crossfade, visibility
+   * recovery, or other async event advances the deck before the store catches
+   * up. No-op when already in sync or the song isn't in the playlist.
+   */
+  syncIndexToActiveSong: (songId: string | null | undefined) => void;
 }
 
 export const useAudioStore = create<AudioState>()(
@@ -1775,6 +1782,16 @@ export const useAudioStore = create<AudioState>()(
     })),
 
     setIsRadioSession: (isRadio: boolean) => set({ isRadioSession: isRadio }),
+
+    syncIndexToActiveSong: (songId: string | null | undefined) => {
+      if (!songId) return;
+      const state = get();
+      if (state.playlist[state.currentSongIndex]?.id === songId) return;
+      const actualIndex = state.playlist.findIndex((s) => s.id === songId);
+      if (actualIndex < 0) return;
+      console.log(`[SYNC] Correcting currentSongIndex ${state.currentSongIndex} → ${actualIndex} (deck has ${songId})`);
+      set({ currentSongIndex: actualIndex });
+    },
 
     startRadio: async (seed: SeededRadioSeed, variety: ArtistVariety = 'medium') => {
       // Gate AI DJ auto-refresh while the queue is being replaced. Released

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -7,6 +7,7 @@ import { getDeviceInfo } from '@/lib/utils/device';
 import { usePreferencesStore } from './preferences';
 import { toast } from '@/lib/toast';
 import { shuffleSongs } from '@/lib/utils/shuffle-scoring';
+import type { SeededRadioSeed, ArtistVariety } from '@/lib/services/seeded-radio';
 
 // Client-side helper functions (moved from ai-dj.ts to avoid server imports)
 function checkQueueThreshold(
@@ -106,6 +107,9 @@ interface AudioState {
   // Transient: radio session play counter for profile refresh trigger (Story 9.3)
   radioSessionPlayCount: number;
   isRadioSession: boolean;
+  // Seeded radio (non-persisted): the seed and variety used for the current session
+  radioSeed: SeededRadioSeed | null;
+  radioVariety: ArtistVariety;
 
   setPlaylist: (songs: Song[]) => void;
   playSong: (songId: string, newPlaylist?: Song[]) => void;
@@ -158,6 +162,9 @@ interface AudioState {
   // Radio session actions (Story 9.3)
   incrementRadioPlayCount: () => void;
   setIsRadioSession: (isRadio: boolean) => void;
+  // Seeded radio
+  startRadio: (seed: SeededRadioSeed, variety?: ArtistVariety) => Promise<void>;
+  saveRadioAsPlaylist: (name: string) => Promise<{ playlistId: string; name: string } | null>;
 }
 
 export const useAudioStore = create<AudioState>()(
@@ -218,6 +225,8 @@ export const useAudioStore = create<AudioState>()(
     _rehydratedCurrentTime: 0,
     radioSessionPlayCount: 0,
     isRadioSession: false,
+    radioSeed: null,
+    radioVariety: 'medium',
 
     setAIUserActionInProgress: (inProgress: boolean) => set({ aiDJUserActionInProgress: inProgress }),
 
@@ -1750,6 +1759,73 @@ export const useAudioStore = create<AudioState>()(
     })),
 
     setIsRadioSession: (isRadio: boolean) => set({ isRadioSession: isRadio }),
+
+    startRadio: async (seed: SeededRadioSeed, variety: ArtistVariety = 'medium') => {
+      set({ aiDJUserActionInProgress: true });
+      try {
+        const res = await fetch('/api/radio/seeded', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ seed, variety }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err?.message || `Failed to start radio (${res.status})`);
+        }
+        const json = await res.json();
+        const songs: Song[] = json?.data?.songs ?? [];
+        const label: string = json?.data?.seedInfo?.label ?? 'Radio';
+        if (songs.length === 0) {
+          toast.warning('No songs found for this radio seed');
+          return;
+        }
+        get().setPlaylist(songs);
+        set({
+          isPlaying: true,
+          isRadioSession: true,
+          radioSeed: seed,
+          radioVariety: variety,
+          radioSessionPlayCount: 0,
+        });
+        toast.success(`Radio started — ${label}`);
+      } catch (err) {
+        console.error('[startRadio] failed:', err);
+        toast.error(err instanceof Error ? err.message : 'Failed to start radio');
+      } finally {
+        setTimeout(() => set({ aiDJUserActionInProgress: false }), 2000);
+      }
+    },
+
+    saveRadioAsPlaylist: async (name: string) => {
+      const state = get();
+      const songIds = state.playlist.map((s) => s.id).filter(Boolean);
+      if (songIds.length === 0) {
+        toast.warning('Queue is empty — nothing to save');
+        return null;
+      }
+      try {
+        const res = await fetch('/api/radio/save-as-playlist', {
+          method: 'POST',
+          credentials: 'include',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ name, songIds }),
+        });
+        if (!res.ok) {
+          const err = await res.json().catch(() => ({}));
+          throw new Error(err?.message || `Failed to save playlist (${res.status})`);
+        }
+        const json = await res.json();
+        const playlistId: string | undefined = json?.data?.playlistId;
+        const savedName: string = json?.data?.name ?? name;
+        toast.success(`Saved as "${savedName}"`);
+        return playlistId ? { playlistId, name: savedName } : null;
+      } catch (err) {
+        console.error('[saveRadioAsPlaylist] failed:', err);
+        toast.error(err instanceof Error ? err.message : 'Failed to save playlist');
+        return null;
+      }
+    },
   }),
   {
     name: 'audio-player-storage',
@@ -1780,6 +1856,8 @@ export const useAudioStore = create<AudioState>()(
         state.songsPlayedSinceLastRec = 0;
         state.radioSessionPlayCount = 0;
         state.isRadioSession = false;
+        state.radioSeed = null;
+        state.radioVariety = 'medium';
         state.aiQueuedSongIds = new Set<string>();
         state.autoplayIsLoading = false;
         state.autoplayTransitionActive = false;

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -97,6 +97,9 @@ interface AudioState {
   queueUpdatedAt: string;
   positionUpdatedAt: string;
   playStateUpdatedAt: string;
+  // UI: whether the device picker dropdown is open (lifted from PlayerBar so
+  // gating code in actions can open it via toast actions).
+  isDevicePickerOpen: boolean;
   // Remote device indicator (set when another device is active)
   remoteDevice: {
     deviceId: string | null;
@@ -176,6 +179,7 @@ interface AudioState {
   // Cross-device sync actions
   applyServerState: (server: PlaybackStateResponse) => void;
   setRemoteDevice: (device: AudioState['remoteDevice']) => void;
+  setDevicePickerOpen: (open: boolean) => void;
   // Radio session actions (Story 9.3)
   incrementRadioPlayCount: () => void;
   setIsRadioSession: (isRadio: boolean) => void;
@@ -242,6 +246,7 @@ export const useAudioStore = create<AudioState>()(
     positionUpdatedAt: '',
     playStateUpdatedAt: '',
     remoteDevice: null,
+    isDevicePickerOpen: false,
     lastKnownPosition: 0,
     lastKnownDuration: 0,
     _userPauseAt: 0,
@@ -264,6 +269,22 @@ export const useAudioStore = create<AudioState>()(
 
     playSong: (songId: string, newPlaylist?: Song[]) => {
       const state = get();
+      // Gate: if another device is the active player, refuse to start a
+      // competing local stream. Prompt the user to switch devices first
+      // via the existing DevicePicker. Skip / next / prev still route
+      // correctly via remote_command — only ad-hoc song-click is gated.
+      if (state.remoteDevice && state.remoteDevice.isPlaying) {
+        toast.warning('Another device is playing', {
+          description: state.remoteDevice.deviceName
+            ? `Active: ${state.remoteDevice.deviceName}. Switch device to play here.`
+            : 'Switch device to play here.',
+          action: {
+            label: 'Switch device',
+            onClick: () => get().setDevicePickerOpen(true),
+          },
+        });
+        return;
+      }
       let playlist: Song[] = newPlaylist || state.playlist;
       let index = playlist.findIndex((song: Song) => song.id === songId);
 
@@ -303,9 +324,23 @@ export const useAudioStore = create<AudioState>()(
 
     playNow: (songId: string, song: Song) => {
       const state = get();
+      // Gate: if another device is the active player, refuse to start a
+      // competing local stream. See playSong for rationale.
+      if (state.remoteDevice && state.remoteDevice.isPlaying) {
+        toast.warning('Another device is playing', {
+          description: state.remoteDevice.deviceName
+            ? `Active: ${state.remoteDevice.deviceName}. Switch device to play here.`
+            : 'Switch device to play here.',
+          action: {
+            label: 'Switch device',
+            onClick: () => get().setDevicePickerOpen(true),
+          },
+        });
+        return;
+      }
       // Set user action flag to prevent AI DJ auto-refresh
       set({ aiDJUserActionInProgress: true });
-      
+
       if (state.playlist.length === 0 || state.currentSongIndex === -1) {
         // No existing playlist, just play the song
         set({
@@ -1786,6 +1821,8 @@ export const useAudioStore = create<AudioState>()(
     },
 
     setRemoteDevice: (device) => set({ remoteDevice: device }),
+
+    setDevicePickerOpen: (open: boolean) => set({ isDevicePickerOpen: open }),
 
     incrementRadioPlayCount: () => set((state) => ({
       radioSessionPlayCount: state.radioSessionPlayCount + 1,

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -130,6 +130,14 @@ interface AudioState {
   radioVariety: ArtistVariety;
   // Optional duration constraint (minutes) used for the current session. null = unconstrained.
   radioTargetMinutes: number | null;
+  // Auto-recompute trigger for AI DJ affinity profile. The profile drives the
+  // "profile-based recommendations (zero API calls)" path — without periodic
+  // recompute it stays frozen at onboarding values and the AI DJ recommends
+  // the same handful of songs forever. We trigger a fresh
+  // /api/profile/update after N recorded plays AND M hours since the last
+  // update — both conditions must hold so we don't thrash.
+  playsSinceLastProfileUpdate: number;
+  lastProfileUpdateAt: number; // epoch ms; 0 = never
 
   setPlaylist: (songs: Song[]) => void;
   playSong: (songId: string, newPlaylist?: Song[]) => void;
@@ -180,6 +188,9 @@ interface AudioState {
   applyServerState: (server: PlaybackStateResponse) => void;
   setRemoteDevice: (device: AudioState['remoteDevice']) => void;
   setDevicePickerOpen: (open: boolean) => void;
+  /** Increment the post-onboarding play counter and, if thresholds are met,
+   * fire an async /api/profile/update to refresh AI DJ affinity weights. */
+  recordPlayForProfileTrigger: () => void;
   // Radio session actions (Story 9.3)
   incrementRadioPlayCount: () => void;
   setIsRadioSession: (isRadio: boolean) => void;
@@ -247,6 +258,8 @@ export const useAudioStore = create<AudioState>()(
     playStateUpdatedAt: '',
     remoteDevice: null,
     isDevicePickerOpen: false,
+    playsSinceLastProfileUpdate: 0,
+    lastProfileUpdateAt: 0,
     lastKnownPosition: 0,
     lastKnownDuration: 0,
     _userPauseAt: 0,
@@ -1824,6 +1837,38 @@ export const useAudioStore = create<AudioState>()(
 
     setDevicePickerOpen: (open: boolean) => set({ isDevicePickerOpen: open }),
 
+    recordPlayForProfileTrigger: () => {
+      const PROFILE_REFRESH_PLAY_THRESHOLD = 10;
+      const PROFILE_REFRESH_COOLDOWN_MS = 4 * 60 * 60 * 1000; // 4h
+      const state = get();
+      const nextCount = state.playsSinceLastProfileUpdate + 1;
+      const now = Date.now();
+      const cooledDown = now - state.lastProfileUpdateAt >= PROFILE_REFRESH_COOLDOWN_MS;
+      if (nextCount >= PROFILE_REFRESH_PLAY_THRESHOLD && cooledDown) {
+        // Optimistically reset both counters BEFORE the fetch so concurrent
+        // plays during the recompute don't queue a second update.
+        set({ playsSinceLastProfileUpdate: 0, lastProfileUpdateAt: now });
+        console.log(`👤 [ProfileTrigger] Threshold reached (${nextCount} plays since last update, ${Math.round((now - state.lastProfileUpdateAt) / 3_600_000)}h cooldown) — recomputing AI DJ profile`);
+        fetch('/api/profile/update', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ daysBack: 14 }),
+        })
+          .then((r) => r.ok ? r.json() : Promise.reject(new Error(`HTTP ${r.status}`)))
+          .then((data) => {
+            console.log('👤 [ProfileTrigger] Profile update succeeded:', data?.data ?? data);
+          })
+          .catch((err) => {
+            console.warn('👤 [ProfileTrigger] Profile update failed (will retry on next threshold):', err);
+            // Roll back the cooldown so the next play retries sooner.
+            set({ lastProfileUpdateAt: state.lastProfileUpdateAt });
+          });
+      } else {
+        set({ playsSinceLastProfileUpdate: nextCount });
+      }
+    },
+
     incrementRadioPlayCount: () => set((state) => ({
       radioSessionPlayCount: state.radioSessionPlayCount + 1,
     })),
@@ -1950,6 +1995,8 @@ export const useAudioStore = create<AudioState>()(
       autoplaySmartTransitions: state.autoplaySmartTransitions,
       recentlyPlayedIds: state.recentlyPlayedIds,
       skipCounts: state.skipCounts,
+      playsSinceLastProfileUpdate: state.playsSinceLastProfileUpdate,
+      lastProfileUpdateAt: state.lastProfileUpdateAt,
     }),
     // Only preferences are persisted — queue/position come from server on mount
     onRehydrateStorage: () => (state) => {

--- a/src/lib/stores/audio.ts
+++ b/src/lib/stores/audio.ts
@@ -1841,6 +1841,22 @@ export const useAudioStore = create<AudioState>()(
     },
 
     startRadio: async (seed: SeededRadioSeed, opts: StartRadioOptions = {}) => {
+      // Gate: same as playSong/playNow — refuse to start a competing local
+      // stream when another device is the active player. Surface the
+      // existing DevicePicker so the user can transfer explicitly.
+      const initialState = get();
+      if (initialState.remoteDevice && initialState.remoteDevice.isPlaying) {
+        toast.warning('Another device is playing', {
+          description: initialState.remoteDevice.deviceName
+            ? `Active: ${initialState.remoteDevice.deviceName}. Switch device to start radio here.`
+            : 'Switch device to start radio here.',
+          action: {
+            label: 'Switch device',
+            onClick: () => get().setDevicePickerOpen(true),
+          },
+        });
+        return;
+      }
       const variety = opts.variety ?? 'medium';
       const targetMinutes = opts.targetMinutes ?? null;
       // Gate AI DJ auto-refresh while the queue is being replaced. Released

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -68,6 +68,8 @@ import { Route as ApiRecommendationsDiscoveryAnalyticsRouteImport } from './rout
 import { Route as ApiRecommendationsClearRouteImport } from './routes/api/recommendations/clear'
 import { Route as ApiRecommendationsAnalyticsRouteImport } from './routes/api/recommendations/analytics'
 import { Route as ApiRadioShuffleRouteImport } from './routes/api/radio/shuffle'
+import { Route as ApiRadioSeededRouteImport } from './routes/api/radio/seeded'
+import { Route as ApiRadioSaveAsPlaylistRouteImport } from './routes/api/radio/save-as-playlist'
 import { Route as ApiProfileUpdateRouteImport } from './routes/api/profile/update'
 import { Route as ApiPlaylistsSyncRouteImport } from './routes/api/playlists/sync'
 import { Route as ApiPlaylistsSpotifyStatusRouteImport } from './routes/api/playlists/spotify-status'
@@ -487,6 +489,16 @@ const ApiRecommendationsAnalyticsRoute =
 const ApiRadioShuffleRoute = ApiRadioShuffleRouteImport.update({
   id: '/api/radio/shuffle',
   path: '/api/radio/shuffle',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRadioSeededRoute = ApiRadioSeededRouteImport.update({
+  id: '/api/radio/seeded',
+  path: '/api/radio/seeded',
+  getParentRoute: () => rootRouteImport,
+} as any)
+const ApiRadioSaveAsPlaylistRoute = ApiRadioSaveAsPlaylistRouteImport.update({
+  id: '/api/radio/save-as-playlist',
+  path: '/api/radio/save-as-playlist',
   getParentRoute: () => rootRouteImport,
 } as any)
 const ApiProfileUpdateRoute = ApiProfileUpdateRouteImport.update({
@@ -1234,6 +1246,8 @@ export interface FileRoutesByFullPath {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
+  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
+  '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
@@ -1409,6 +1423,8 @@ export interface FileRoutesByTo {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
+  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
+  '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
@@ -1588,6 +1604,8 @@ export interface FileRoutesById {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
+  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
+  '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
   '/api/recommendations/clear': typeof ApiRecommendationsClearRoute
@@ -1767,6 +1785,8 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
+    | '/api/radio/save-as-playlist'
+    | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
@@ -1942,6 +1962,8 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
+    | '/api/radio/save-as-playlist'
+    | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
@@ -2120,6 +2142,8 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
+    | '/api/radio/save-as-playlist'
+    | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
     | '/api/recommendations/clear'
@@ -2287,6 +2311,8 @@ export interface RootRouteChildren {
   ApiPlaylistsSpotifyStatusRoute: typeof ApiPlaylistsSpotifyStatusRoute
   ApiPlaylistsSyncRoute: typeof ApiPlaylistsSyncRoute
   ApiProfileUpdateRoute: typeof ApiProfileUpdateRoute
+  ApiRadioSaveAsPlaylistRoute: typeof ApiRadioSaveAsPlaylistRoute
+  ApiRadioSeededRoute: typeof ApiRadioSeededRoute
   ApiRadioShuffleRoute: typeof ApiRadioShuffleRoute
   ApiSecurityDisable2faRoute: typeof ApiSecurityDisable2faRoute
   ApiSecurityEnable2faRoute: typeof ApiSecurityEnable2faRoute
@@ -2733,6 +2759,20 @@ declare module '@tanstack/react-router' {
       path: '/api/radio/shuffle'
       fullPath: '/api/radio/shuffle'
       preLoaderRoute: typeof ApiRadioShuffleRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/radio/seeded': {
+      id: '/api/radio/seeded'
+      path: '/api/radio/seeded'
+      fullPath: '/api/radio/seeded'
+      preLoaderRoute: typeof ApiRadioSeededRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/radio/save-as-playlist': {
+      id: '/api/radio/save-as-playlist'
+      path: '/api/radio/save-as-playlist'
+      fullPath: '/api/radio/save-as-playlist'
+      preLoaderRoute: typeof ApiRadioSaveAsPlaylistRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/profile/update': {
@@ -3847,6 +3887,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaylistsSpotifyStatusRoute: ApiPlaylistsSpotifyStatusRoute,
   ApiPlaylistsSyncRoute: ApiPlaylistsSyncRoute,
   ApiProfileUpdateRoute: ApiProfileUpdateRoute,
+  ApiRadioSaveAsPlaylistRoute: ApiRadioSaveAsPlaylistRoute,
+  ApiRadioSeededRoute: ApiRadioSeededRoute,
   ApiRadioShuffleRoute: ApiRadioShuffleRoute,
   ApiSecurityDisable2faRoute: ApiSecurityDisable2faRoute,
   ApiSecurityEnable2faRoute: ApiSecurityEnable2faRoute,
@@ -3884,12 +3926,3 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-import type { getRouter } from './router.tsx'
-import type { createStart } from '@tanstack/react-start'
-declare module '@tanstack/react-start' {
-  interface Register {
-    ssr: true
-    router: Awaited<ReturnType<typeof getRouter>>
-  }
-}

--- a/src/routes/api/listening-history/record.ts
+++ b/src/routes/api/listening-history/record.ts
@@ -44,7 +44,8 @@ export const Route = createFileRoute("/api/listening-history/record")({
         album: body.album || null,
         genre: body.genre || null,
         duration: body.duration ? Math.floor(body.duration) : undefined,
-      }, body.playDuration ? Math.floor(body.playDuration) : undefined, body.userInitiatedSkip === true);
+      }, body.playDuration ? Math.floor(body.playDuration) : undefined, body.userInitiatedSkip === true,
+        typeof body.source === 'string' ? body.source : undefined);
 
       return new Response(
         JSON.stringify({ success: true, message: 'Song play recorded' }),

--- a/src/routes/api/playlists/create-from-ids.ts
+++ b/src/routes/api/playlists/create-from-ids.ts
@@ -8,7 +8,7 @@ import {
 import { createPlaylist } from '@/lib/services/navidrome';
 import { getNavidromeUserCreds } from '@/lib/services/navidrome-users';
 
-const SaveAsPlaylistSchema = z.object({
+const CreateFromIdsSchema = z.object({
   name: z.string().min(1).max(120),
   songIds: z.array(z.string().min(1)).min(1).max(200),
 });
@@ -16,9 +16,9 @@ const SaveAsPlaylistSchema = z.object({
 const POST = withAuthAndErrorHandling(
   async ({ request, session }) => {
     const body = await request.json();
-    const parsed = SaveAsPlaylistSchema.safeParse(body);
+    const parsed = CreateFromIdsSchema.safeParse(body);
     if (!parsed.success) {
-      return errorResponse('VALIDATION_ERROR', 'Invalid save-as-playlist request', {
+      return errorResponse('VALIDATION_ERROR', 'Invalid create-from-ids request', {
         status: 400,
         details: { issues: parsed.error.issues },
       });
@@ -45,13 +45,13 @@ const POST = withAuthAndErrorHandling(
     );
   },
   {
-    service: 'radio',
-    operation: 'save-as-playlist',
-    defaultCode: 'RADIO_SAVE_PLAYLIST_ERROR',
-    defaultMessage: 'Failed to save radio as playlist',
+    service: 'playlists',
+    operation: 'create-from-ids',
+    defaultCode: 'PLAYLIST_CREATE_FROM_IDS_ERROR',
+    defaultMessage: 'Failed to create playlist from song ids',
   },
 );
 
-export const Route = createFileRoute('/api/radio/save-as-playlist')({
+export const Route = createFileRoute('/api/playlists/create-from-ids')({
   server: { handlers: { POST } },
 });

--- a/src/routes/api/profile/update.ts
+++ b/src/routes/api/profile/update.ts
@@ -54,6 +54,7 @@ export async function POST({ request }: { request: Request }) {
           compoundScores: result.compoundScores,
           artistAffinities: result.artistAffinities,
           temporalPreferences: result.temporalPreferences,
+          artistCooccurrenceRows: result.artistCooccurrenceRows,
           likedSongsSynced: result.likedSongsSync.synced,
           likedSongsUnstarred: result.likedSongsSync.unstarred,
         },

--- a/src/routes/api/radio/save-as-playlist.ts
+++ b/src/routes/api/radio/save-as-playlist.ts
@@ -1,0 +1,57 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+  errorResponse,
+} from '@/lib/utils/api-response';
+import { createPlaylist } from '@/lib/services/navidrome';
+import { getNavidromeUserCreds } from '@/lib/services/navidrome-users';
+
+const SaveAsPlaylistSchema = z.object({
+  name: z.string().min(1).max(120),
+  songIds: z.array(z.string().min(1)).min(1).max(200),
+});
+
+const POST = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const body = await request.json();
+    const parsed = SaveAsPlaylistSchema.safeParse(body);
+    if (!parsed.success) {
+      return errorResponse('VALIDATION_ERROR', 'Invalid save-as-playlist request', {
+        status: 400,
+        details: { issues: parsed.error.issues },
+      });
+    }
+
+    const { name, songIds } = parsed.data;
+    const creds = await getNavidromeUserCreds(session.user.id);
+    if (!creds) {
+      return errorResponse(
+        'NAVIDROME_USER_MISSING',
+        'No per-user Navidrome account is linked to this user. Re-onboard to create one.',
+        { status: 409 },
+      );
+    }
+
+    const playlist = await createPlaylist(name, songIds, creds);
+    return successResponse(
+      {
+        playlistId: playlist.id,
+        name: playlist.name,
+        songCount: playlist.songCount,
+      },
+      201,
+    );
+  },
+  {
+    service: 'radio',
+    operation: 'save-as-playlist',
+    defaultCode: 'RADIO_SAVE_PLAYLIST_ERROR',
+    defaultMessage: 'Failed to save radio as playlist',
+  },
+);
+
+export const Route = createFileRoute('/api/radio/save-as-playlist')({
+  server: { handlers: { POST } },
+});

--- a/src/routes/api/radio/seeded.ts
+++ b/src/routes/api/radio/seeded.ts
@@ -1,0 +1,53 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+  errorResponse,
+} from '@/lib/utils/api-response';
+import { generateSeededRadio } from '@/lib/services/seeded-radio';
+
+const SeededRadioSchema = z.object({
+  seed: z.discriminatedUnion('kind', [
+    z.object({ kind: z.literal('song'), songId: z.string().min(1) }),
+    z.object({ kind: z.literal('album'), albumId: z.string().min(1) }),
+    z.object({ kind: z.literal('playlist'), playlistId: z.string().min(1) }),
+    z.object({ kind: z.literal('artist'), artistId: z.string().min(1) }),
+  ]),
+  variety: z.enum(['low', 'medium', 'high']).optional(),
+  size: z.number().int().min(10).max(80).optional(),
+});
+
+const POST = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const body = await request.json();
+    const parsed = SeededRadioSchema.safeParse(body);
+    if (!parsed.success) {
+      return errorResponse('VALIDATION_ERROR', 'Invalid seeded-radio request', {
+        status: 400,
+        details: { issues: parsed.error.issues },
+      });
+    }
+
+    const { seed, variety, size } = parsed.data;
+    const result = await generateSeededRadio(session.user.id, seed, {
+      variety,
+      size,
+    });
+
+    return successResponse({
+      songs: result.songs,
+      seedInfo: result.seedInfo,
+    });
+  },
+  {
+    service: 'radio',
+    operation: 'seeded',
+    defaultCode: 'RADIO_SEEDED_ERROR',
+    defaultMessage: 'Failed to generate seeded radio',
+  },
+);
+
+export const Route = createFileRoute('/api/radio/seeded')({
+  server: { handlers: { POST } },
+});

--- a/src/routes/api/radio/seeded.ts
+++ b/src/routes/api/radio/seeded.ts
@@ -16,6 +16,7 @@ const SeededRadioSchema = z.object({
   ]),
   variety: z.enum(['low', 'medium', 'high']).optional(),
   size: z.number().int().min(10).max(80).optional(),
+  targetMinutes: z.number().int().min(10).max(300).optional(),
 });
 
 const POST = withAuthAndErrorHandling(
@@ -29,10 +30,11 @@ const POST = withAuthAndErrorHandling(
       });
     }
 
-    const { seed, variety, size } = parsed.data;
+    const { seed, variety, size, targetMinutes } = parsed.data;
     const result = await generateSeededRadio(session.user.id, seed, {
       variety,
       size,
+      targetMinutes,
     });
 
     return successResponse({

--- a/src/routes/library/artists/$id.tsx
+++ b/src/routes/library/artists/$id.tsx
@@ -21,6 +21,7 @@ import {
 import { toast } from '@/lib/toast';
 import { useArtistMetadata } from '@/lib/hooks/useArtistMetadata';
 import { ArtistMetadataHero } from '@/components/library/ArtistMetadataHero';
+import { StartRadioButton } from '@/components/radio/StartRadioButton';
 import { cn } from '@/lib/utils';
 import { getArtistGradient } from '@/lib/utils/artist-avatar';
 
@@ -319,6 +320,13 @@ function ArtistDetail() {
                   >
                     <Shuffle className="h-3.5 w-3.5 sm:h-4 sm:w-4" /> Shuffle All
                   </Button>
+                  <StartRadioButton
+                    seed={{ kind: 'artist', artistId: id }}
+                    label="Start Radio"
+                    size="sm"
+                    variant="outline"
+                    className="rounded-full gap-1.5 px-3 sm:px-4 sm:h-10 sm:text-sm border-border/50 bg-card/30 backdrop-blur-sm"
+                  />
                   <Button
                     variant="outline"
                     size="icon"

--- a/src/routes/library/artists/$id/albums/$albumId.tsx
+++ b/src/routes/library/artists/$id/albums/$albumId.tsx
@@ -3,7 +3,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useState } from 'react';
 import { getSongs, getAlbumDetail, getArtistDetail } from '@/lib/services/navidrome';
 import { useAudioStore } from '@/lib/stores/audio';
-import { Loader2, Play, Plus, ListPlus, Disc } from 'lucide-react';
+import { Loader2, Play, Plus, ListPlus, Disc, Radio } from 'lucide-react';
 import { SongFeedbackButtons } from '@/components/library/SongFeedbackButtons';
 import { useSongFeedback } from '@/lib/hooks/useSongFeedback';
 import { Button } from '@/components/ui/button';
@@ -16,6 +16,7 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { toast } from '@/lib/toast';
 import { PageLayout } from '@/components/ui/page-layout';
+import { StartRadioButton } from '@/components/radio/StartRadioButton';
 
 /** Album cover with Navidrome proxy fallback, then gradient placeholder */
 function AlbumCoverArt({ albumId, size = 300 }: { albumId: string; size?: number }) {
@@ -52,7 +53,7 @@ export const Route = createFileRoute('/library/artists/$id/albums/$albumId')({
 
 function AlbumSongs() {
   const { id: artistId, albumId } = useParams({ from: '/library/artists/$id/albums/$albumId' }) as { id: string; albumId: string };
-  const { playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress } = useAudioStore();
+  const { playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress, startRadio } = useAudioStore();
 
   // Fetch album details
   const {
@@ -195,6 +196,14 @@ function AlbumSongs() {
               {album?.genre && (
                 <p className="text-xs text-muted-foreground mt-1">{album.genre}</p>
               )}
+              <div className="mt-3 flex justify-center sm:justify-start">
+                <StartRadioButton
+                  seed={{ kind: 'album', albumId }}
+                  label="Start Radio"
+                  size="sm"
+                  variant="outline"
+                />
+              </div>
             </div>
           </div>
         </div>
@@ -282,6 +291,16 @@ function AlbumSongs() {
                     >
                       <Plus className="mr-2 h-4 w-4" />
                       Add to End
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      onClick={(e) => {
+                        e.stopPropagation();
+                        void startRadio({ kind: 'song', songId: song.id });
+                      }}
+                      className="min-h-[44px]"
+                    >
+                      <Radio className="mr-2 h-4 w-4" />
+                      Start Radio from Song
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/src/routes/playlists/$id.tsx
+++ b/src/routes/playlists/$id.tsx
@@ -25,13 +25,16 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
+  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
+import { Radio } from 'lucide-react';
 import { PageLayout } from '@/components/ui/page-layout';
 import { useAudioStore } from '@/lib/stores/audio';
 import { playPlaylist, loadPlaylistIntoQueue } from '@/lib/utils/playlist-helpers';
 import { cn } from '@/lib/utils';
 import { CollaborativePlaylistPanel } from '@/components/playlists/collaboration';
+import { StartRadioButton } from '@/components/radio/StartRadioButton';
 import {
   DndContext,
   closestCenter,
@@ -91,6 +94,7 @@ interface SongRowProps {
   onAddSongToQueue: (song: PlaylistSong, position: 'now' | 'next' | 'end') => void;
   onRemoveSong: (songId: string) => void;
   onToggleStar: (songId: string, currentlyStarred: boolean) => void;
+  onStartRadioFromSong: (songId: string) => void;
   isRemovePending: boolean;
 }
 
@@ -154,6 +158,7 @@ function SongRowContent({
   onAddSongToQueue,
   onRemoveSong,
   onToggleStar,
+  onStartRadioFromSong,
   isRemovePending,
   dragHandle,
 }: SongRowProps & { dragHandle?: JSX.Element }) {
@@ -293,6 +298,15 @@ function SongRowContent({
             <Plus className="mr-2 h-4 w-4" />
             Add to End
           </DropdownMenuItem>
+          <DropdownMenuSeparator />
+          <DropdownMenuItem
+            onClick={(e) => { e.stopPropagation(); onStartRadioFromSong(song.songId); }}
+            className="min-h-[40px]"
+          >
+            <Radio className="mr-2 h-4 w-4" />
+            Start Radio from Song
+          </DropdownMenuItem>
+          <DropdownMenuSeparator />
           <DropdownMenuItem
             onClick={(e) => { e.stopPropagation(); onRemoveSong(song.songId); }}
             disabled={isRemovePending}
@@ -377,6 +391,7 @@ interface VirtualizedPlaylistSongsProps {
   onAddSongToQueue: (song: PlaylistSong, position: 'now' | 'next' | 'end') => void;
   onRemoveSong: (songId: string) => void;
   onToggleStar: (songId: string, currentlyStarred: boolean) => void;
+  onStartRadioFromSong: (songId: string) => void;
   isRemovePending: boolean;
 }
 
@@ -390,6 +405,7 @@ function PlaylistSongsList({
   onAddSongToQueue,
   onRemoveSong,
   onToggleStar,
+  onStartRadioFromSong,
   isRemovePending,
 }: VirtualizedPlaylistSongsProps) {
   // Disable DnD on mobile — TouchSensor intercepts taps and wastes space
@@ -410,6 +426,7 @@ function PlaylistSongsList({
     onAddSongToQueue,
     onRemoveSong,
     onToggleStar,
+    onStartRadioFromSong,
     isRemovePending,
   };
 
@@ -473,7 +490,7 @@ function PlaylistDetailPage() {
   const { user } = Route.useRouteContext();
   const navigate = useNavigate();
   const queryClient = useQueryClient();
-  const { setPlaylist, playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress, currentSong, isPlaying } = useAudioStore();
+  const { setPlaylist, playSong, addToQueueNext, addToQueueEnd, setIsPlaying, setAIUserActionInProgress, currentSong, isPlaying, startRadio } = useAudioStore();
 
   // Collaboration panel state
   const [isCollaborationPanelOpen, setIsCollaborationPanelOpen] = useState(false);
@@ -935,6 +952,15 @@ function PlaylistDetailPage() {
             <Shuffle className="h-4 w-4" />
           </Button>
 
+          {/* Start Radio from this playlist */}
+          <StartRadioButton
+            seed={{ kind: 'playlist', playlistId: id }}
+            label="Start Radio"
+            size="icon"
+            variant="ghost"
+            className="rounded-full h-8 w-8 sm:h-9 sm:w-9 p-0"
+          />
+
           {/* More Menu */}
           <DropdownMenu>
             <DropdownMenuTrigger asChild>
@@ -1052,6 +1078,7 @@ function PlaylistDetailPage() {
                 onAddSongToQueue={handleAddSongToQueue}
                 onRemoveSong={handleRemoveSong}
                 onToggleStar={handleToggleStar}
+                onStartRadioFromSong={(songId) => { void startRadio({ kind: 'song', songId }); }}
                 isRemovePending={removeSongMutation.isPending}
               />
             )}

--- a/vite-ws-plugin.ts
+++ b/vite-ws-plugin.ts
@@ -86,6 +86,46 @@ async function getUserIdFromRequest(request: import('http').IncomingMessage): Pr
   }
 }
 
+/**
+ * Clear the active-device fields if the disconnecting device matches.
+ * Dev-mode mirror of `src/lib/auth/ws-playback-ops.ts`, using the same
+ * postgres connection used for session lookups.
+ */
+async function clearActiveDeviceIfMatches(
+  userId: string,
+  deviceId: string,
+): Promise<{ cleared: boolean; playStateUpdatedAt: string | null }> {
+  const db = getDb();
+  if (!db) {
+    return { cleared: false, playStateUpdatedAt: null };
+  }
+
+  try {
+    const rows = await db`
+      UPDATE playback_sessions
+      SET is_playing = false,
+          active_device_id = NULL,
+          active_device_name = NULL,
+          active_device_type = NULL,
+          play_state_updated_at = NOW(),
+          updated_at = NOW()
+      WHERE user_id = ${userId} AND active_device_id = ${deviceId}
+      RETURNING play_state_updated_at
+    `;
+
+    if (rows.length === 0) {
+      return { cleared: false, playStateUpdatedAt: null };
+    }
+
+    const ts = rows[0].play_state_updated_at as Date | string;
+    const iso = typeof ts === 'string' ? new Date(ts).toISOString() : ts.toISOString();
+    return { cleared: true, playStateUpdatedAt: iso };
+  } catch (err) {
+    console.error('[WS Dev] clearActiveDeviceIfMatches error:', err);
+    return { cleared: false, playStateUpdatedAt: null };
+  }
+}
+
 export function viteWebSocketPlugin(): Plugin {
   let wss: WebSocketServer | null = null;
 
@@ -97,7 +137,7 @@ export function viteWebSocketPlugin(): Plugin {
       wss = new WebSocketServer({ noServer: true });
 
       // Setup playback handlers
-      setupPlaybackWebSocket(wss, getUserIdFromRequest);
+      setupPlaybackWebSocket(wss, getUserIdFromRequest, clearActiveDeviceIfMatches);
 
       // Handle upgrade requests
       server.httpServer?.on('upgrade', (request, socket, head) => {


### PR DESCRIPTION
## Summary

Started as the **seeded radio** feature (PR title) but grew into a multi-area branch covering iOS audio reliability, cross-device playback gating, AI DJ recommendation freshness, and analytics labeling corrections. Each section below corresponds to a coherent group of commits.

## Seeded radio (7 commits)
Generates a ~40-track radio queue from a seed (song / album / playlist / artist) via the blended-recommendation scorer. Save-as-playlist endpoint and `StartRadioButton` component included.
- Artist-variety knob (Low / Medium / High) controls how much of the queue comes from the seed artist's own catalog.
- **Length constraint** (Auto / 30m / 1h / 2h / 3h+) added in `5d19af3` — over-estimates slot count from `targetMinutes`, runs the pipeline, then trims by accumulated duration.
- Liked-songs virtual playlist supported; radio state clears properly on playlist load.

## Session-based artist co-occurrence graph (1 commit)
`f21a3ee` — per-user bidirectional graph built from 90-day listening sessions (30-min gap threshold), with recency decay weighting. Surfaces "adjacent" artists the user actually plays together, used as a candidate source in the seeded-radio scorer.

## iOS audio reliability (10 commits)
Diagnosed and fixed two distinct pitch-shift / glitch causes on iOS PWA + Bluetooth:

**Cause A — Crossfade decode warmup.** Inactive deck advanced ~10% slower than wall clock for the first 5s of every crossfade overlap (decoder warm-up on freshly-loaded `src`), comb-filtering against the outgoing deck. Fix: 1000ms pre-warm window at gain=0 before the gain ramps start (commits `c8b0221`, `32b4bd3`). Drift caught and verified via per-deck snapshots at start/mid/end (`646570d`).

**Cause B — Short-interrupt over-recovery.** iOS screen-lock fires a 20-80ms AudioContext bounce. The existing recovery path always ran a 250ms `fadeInMaster` + element-volume toggle regardless of duration, which itself triggered Bluetooth codec re-buffer audible as pitch. Fix: fast path for `interruptDuration < 100ms` — instant masterGain restore, no fade (`0dd1241`).

Diagnostic-only commits (`a5a4851`, `acdba14`) ruled out sampleRate renegotiation and playbackRate drift as causes before zeroing in on the real ones.

Earlier fixes in the branch: iOS lock-screen recovery + next-song UI desync (`0239a75`), inactive-deck gesture-context priming (`658c8c0` after a revert of an earlier attempt).

## Cross-device playback hardening (5 commits)
- `60f8ac7` — clear stale active-device server-side on WS disconnect.
- `0c04d0b` — ignore own-device echo in the TAKEOVER race during WS reconnect.
- `694d446` + `71b8767` — gate `playSong` / `playNow` / `startRadio` with the existing remote-device indicator: when another device is the active player, refuse local playback and surface the existing DevicePicker via a toast action. `addToQueue` left ungated (queue-modify, not playback-start).
- `b1380ef` — fix transfer-to-self silently failing. `applyServerState` never sets `isPlaying=true` (correct guard for remote-state path), so the target device loaded the queue but never started playing. Explicit `setIsPlaying(true)` after `fetchAndReconcileState` when transfer.targetDeviceId === own deviceId AND payload.play === true.
- `9d376cd` — type-aware WS logging (`[WS RX] type=transfer target=… play=…`, `[WS TX] type=… to=N`). Caught the transfer-to-self bug exactly because we could see the message bodies.

## AI DJ recommendation freshness (3 commits)
- `0d53c97` — tag every recorded play with `source` (`ai_dj` / `radio` / `manual` / `autoplay`) at scrobble time. Surfaced in `📊 [ListeningHistory] Recorded play:` log line. Log-only first iteration; DB column deferred.
- `8ae92e8` — auto-refresh AI DJ affinity profile after 10 plays + 4h cooldown. Root cause: `calculateFullUserProfile` was invoked only at onboarding / manual `/api/profile/update` / Last.fm backfill. Profile froze at signup, AI DJ "profile-based recommendations (zero API calls)" path kept picking the same songs forever (verified: "TV on the Radio - Will Do" recommended again at score 0.343 after 8 prior plays in 14 days).
- `0ad6155` — analytics page labels: stop calling feedback events "plays" / "listening" / "songs rated" — they were sourced from `recommendation_feedback`, not `listening_history`. Misleading text fixed across Overview, Quality, Activity tabs + insight strings.

## Test coverage
- `1151c1d` — seeded-radio helpers + per-seed integration tests
- `5d19af3` — applyDurationTarget + estimateSizeFromMinutes unit tests + startRadio body-forwarding test

## Notes for next session
- Next slice: **Listening Analytics Overhaul** — listening_history-sourced charts (top artists, source breakdown, true DoW × hour heatmap, repeat offenders). Plan drafted; PR 1 will be schema + analytics filter to exclude `source='library'` bulk-sync rows that currently dominate the Activity tab.

🤖 Generated with [Claude Code](https://claude.com/claude-code)