### PR TITLE
feat(analytics): listening_history.source + exclude library-sync from feedback charts (PR 1 of overhaul)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,9 @@ Thumbs.db
 _bmad/
 _bmad-output/
 
-# Database dumps (local only)
+# Database dumps (local only). Drizzle migrations are tracked via exception.
 *.sql
+!drizzle/*.sql
 
 # Dependency managers / caches
 .pnp.js

--- a/drizzle/0026_listening_history_source.sql
+++ b/drizzle/0026_listening_history_source.sql
@@ -1,0 +1,9 @@
+-- Add `source` column to listening_history to tag the origin of each play
+-- (ai_dj | autoplay | radio | manual | NULL for pre-existing rows).
+-- Wire-up: PlayerBar.recordListeningHistory computes the source from audio
+-- store state, posts it through /api/listening-history/record, and
+-- recordSongPlay persists it. Used by the Listening Analytics page.
+--
+-- Idempotent so we can re-run safely against an already-migrated DB.
+
+ALTER TABLE "listening_history" ADD COLUMN IF NOT EXISTS "source" text;

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -34,9 +34,12 @@ interface EnhancedAnalyticsResponse {
     likedArtists: Array<{ artist: string; count: number }>;
     dislikedArtists: Array<{ artist: string; count: number }>;
     feedbackCount: {
+      /** Real interactions (excludes bulk library-sync rows). */
       total: number;
       thumbsUp: number;
       thumbsDown: number;
+      /** Bulk library-sync rows. May be missing on older responses. */
+      librarySynced?: number;
     };
   };
   tasteEvolution?: {
@@ -208,6 +211,12 @@ function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
           <p className="text-xs text-muted-foreground">
             {analytics.profile.feedbackCount.thumbsUp} up / {analytics.profile.feedbackCount.thumbsDown} down
           </p>
+          {analytics.profile.feedbackCount.librarySynced !== undefined &&
+           analytics.profile.feedbackCount.librarySynced > 0 && (
+            <p className="text-[10px] text-muted-foreground mt-1">
+              + {analytics.profile.feedbackCount.librarySynced} library-synced (excluded from charts)
+            </p>
+          )}
         </CardContent>
       </Card>
 

--- a/src/lib/db/schema/listening-history.schema.ts
+++ b/src/lib/db/schema/listening-history.schema.ts
@@ -53,6 +53,13 @@ export const listeningHistory = pgTable("listening_history", {
   // 0 = not skipped (completed or just not tracked)
   // 1 = skipped (played < 30% AND played > 5 seconds)
   skipDetected: integer("skip_detected").default(0),
+
+  // Origin of the play: 'ai_dj' | 'autoplay' | 'radio' | 'manual' | null.
+  // NULL for rows recorded before this column existed. Set by the client at
+  // scrobble time based on which queue path delivered the song; lets the
+  // analytics page tell true listening-history slices apart (e.g. how much
+  // of the user's listening came from AI DJ vs manual clicks).
+  source: text("source"),
 }, (table) => ({
   // Index for user's listening history
   userIdIdx: index("listening_history_user_id_idx").on(table.userId),

--- a/src/lib/services/listening-history.ts
+++ b/src/lib/services/listening-history.ts
@@ -115,6 +115,7 @@ export async function recordSongPlay(
     songDuration: song.duration || null,
     completed,
     skipDetected,
+    source: source ?? null,
   };
 
   await db.insert(listeningHistory).values(record);

--- a/src/lib/services/preferences.ts
+++ b/src/lib/services/preferences.ts
@@ -13,10 +13,20 @@ export interface UserPreferenceProfile {
   dislikedArtists: Array<{ artist: string; count: number }>;
   likedSongs: Array<{ songArtistTitle: string; timestamp: Date }>;
   dislikedSongs: Array<{ songArtistTitle: string; timestamp: Date }>;
+  /**
+   * Interaction-only counts (excludes source='library' bulk-sync rows).
+   * Use these for analytics display.
+   */
   totalFeedbackCount: number;
   thumbsUpCount: number;
   thumbsDownCount: number;
   feedbackRatio: number; // thumbsUp / total (0.0 - 1.0)
+  /**
+   * Count of bulk library-sync rows (source='library'). Surfaced separately
+   * so the UI can display "X interactions + Y library-synced" rather than
+   * lumping a single starred-songs import with real user feedback.
+   */
+  librarySyncedCount: number;
 }
 
 export interface ListeningPatterns {
@@ -53,12 +63,20 @@ export async function buildUserPreferenceProfile(userId: string): Promise<UserPr
     return cached.profile;
   }
 
-  // Fetch all user feedback
-  const allFeedback = await db
+  // Fetch all user feedback, then partition in memory into real
+  // interactions vs bulk library-sync rows (source='library'). The library
+  // slice represents starred songs imported in bulk and is surfaced as
+  // a separate count so a single sync spike doesn't dominate every chart.
+  // The scoring path queries the table directly with its own filters and
+  // is unaffected.
+  const rawFeedback = await db
     .select()
     .from(recommendationFeedback)
     .where(eq(recommendationFeedback.userId, userId))
     .orderBy(desc(recommendationFeedback.timestamp));
+
+  const allFeedback = rawFeedback.filter(f => f.source !== 'library');
+  const librarySyncedCount = rawFeedback.length - allFeedback.length;
 
   // Separate into liked/disliked
   const likedFeedback = allFeedback.filter(f => f.feedbackType === 'thumbs_up');
@@ -103,6 +121,7 @@ export async function buildUserPreferenceProfile(userId: string): Promise<UserPr
     thumbsUpCount: likedFeedback.length,
     thumbsDownCount: dislikedFeedback.length,
     feedbackRatio: allFeedback.length > 0 ? likedFeedback.length / allFeedback.length : 0,
+    librarySyncedCount,
   };
 
   // Cache the profile

--- a/src/lib/services/recommendation-analytics.ts
+++ b/src/lib/services/recommendation-analytics.ts
@@ -5,7 +5,7 @@
 
 import { db } from '../db';
 import { recommendationFeedback } from '../db/schema';
-import { eq, and, gte } from 'drizzle-orm';
+import { eq, and, gte, ne } from 'drizzle-orm';
 import {
   extractArtist,
   getDaysAgo,
@@ -103,6 +103,17 @@ export function clearAnalyticsCache(userId?: string): void {
 // Note: extractArtist, getDaysAgo, getStartOfWeek, getStartOfMonth
 // are now imported from '../utils/analytics-helpers'
 
+/**
+ * Exclude bulk library-sync rows (source='library') from analytics queries.
+ * The user's starred-songs sync writes one feedback row per starred song
+ * with `source='library'` — useful as signal for the scoring path, but
+ * meaningless on the analytics page (a single sync of 500 songs would
+ * spike the dow/hour heatmap and dominate the "top liked artists" chart
+ * over real user interactions). All analytics functions filter it out;
+ * the scoring path queries the table directly and is unaffected.
+ */
+const excludeLibrarySync = ne(recommendationFeedback.source, 'library');
+
 // ============================================================================
 // Taste Evolution Timeline (AC 1)
 // ============================================================================
@@ -125,14 +136,15 @@ export async function getTasteEvolutionTimeline(
   // Determine period type: weekly for <= 90 days, monthly for > 90 days
   const periodType: 'week' | 'month' = days <= 90 ? 'week' : 'month';
 
-  // Fetch all feedback in the time range
+  // Fetch all feedback in the time range (excluding library-sync rows)
   const feedback = await db
     .select()
     .from(recommendationFeedback)
     .where(
       and(
         eq(recommendationFeedback.userId, userId),
-        gte(recommendationFeedback.timestamp, startDate)
+        gte(recommendationFeedback.timestamp, startDate),
+        excludeLibrarySync,
       )
     )
     .orderBy(recommendationFeedback.timestamp);
@@ -218,11 +230,11 @@ export async function getRecommendationQualityMetrics(
   const cached = getCachedAnalytics<RecommendationQualityMetrics>(cacheKey);
   if (cached) return cached;
 
-  // Get all feedback
+  // Get all feedback (excluding library-sync rows)
   const allFeedback = await db
     .select()
     .from(recommendationFeedback)
-    .where(eq(recommendationFeedback.userId, userId))
+    .where(and(eq(recommendationFeedback.userId, userId), excludeLibrarySync))
     .orderBy(recommendationFeedback.timestamp);
 
   const totalRecommendations = allFeedback.length;
@@ -275,11 +287,11 @@ export async function getActivityTrends(userId: string): Promise<ActivityTrends>
   const cached = getCachedAnalytics<ActivityTrends>(cacheKey);
   if (cached) return cached;
 
-  // Get all feedback
+  // Get all feedback (excluding library-sync rows)
   const allFeedback = await db
     .select()
     .from(recommendationFeedback)
-    .where(eq(recommendationFeedback.userId, userId))
+    .where(and(eq(recommendationFeedback.userId, userId), excludeLibrarySync))
     .orderBy(recommendationFeedback.timestamp);
 
   const feedbackByDayOfWeek = new Map<number, number>();
@@ -365,14 +377,16 @@ export async function getDiscoveryInsights(
 
   const recentStartDate = getDaysAgo(recentDays);
 
-  // Get all liked feedback
+  // Get all liked feedback (excluding library-sync rows so a bulk import
+  // doesn't show up as "newly discovered artists")
   const allLikedFeedback = await db
     .select()
     .from(recommendationFeedback)
     .where(
       and(
         eq(recommendationFeedback.userId, userId),
-        eq(recommendationFeedback.feedbackType, 'thumbs_up')
+        eq(recommendationFeedback.feedbackType, 'thumbs_up'),
+        excludeLibrarySync,
       )
     )
     .orderBy(recommendationFeedback.timestamp);

--- a/src/routes/api/recommendations/analytics.ts
+++ b/src/routes/api/recommendations/analytics.ts
@@ -31,9 +31,12 @@ export interface EnhancedAnalyticsResponse {
     likedArtists: Array<{ artist: string; count: number }>;
     dislikedArtists: Array<{ artist: string; count: number }>;
     feedbackCount: {
+      /** Real interactions (excludes bulk library-sync rows). */
       total: number;
       thumbsUp: number;
       thumbsDown: number;
+      /** Bulk library-sync rows, surfaced separately for the Overview card. */
+      librarySynced: number;
     };
   };
 
@@ -123,6 +126,7 @@ export const Route = createFileRoute("/api/recommendations/analytics")({
             total: profile.totalFeedbackCount,
             thumbsUp: profile.thumbsUpCount,
             thumbsDown: profile.thumbsDownCount,
+            librarySynced: profile.librarySyncedCount,
           },
         },
       };


### PR DESCRIPTION
## Summary

PR 1 of the Listening Analytics Overhaul. Two coupled changes:

1. **Schema** — adds nullable \`source\` column to \`listening_history\` so every play carries its origin tag (\`ai_dj\` / \`autoplay\` / \`radio\` / \`manual\`). The client already computes this at scrobble time (commit \`7a14b6a\` on main); this PR persists it.

2. **Feedback chart normalization** — bulk Navidrome-stars imports write to \`recommendation_feedback\` with \`source='library'\`. They were dominating every analytics chart (the Activity tab Thursday-17:00 cell read 495 events from a single bulk-sync day in March 2026). Analytics queries now exclude these rows; the count is surfaced separately on the Overview "Total Feedback" card.

## Files changed

- \`src/lib/db/schema/listening-history.schema.ts\` — \`source: text("source")\` column
- \`drizzle/0026_listening_history_source.sql\` — idempotent \`ADD COLUMN IF NOT EXISTS\`
- \`src/lib/services/listening-history.ts\` — persists \`source\` in \`recordSongPlay\`
- \`src/lib/services/recommendation-analytics.ts\` — 4 query sites filter \`source != 'library'\`
- \`src/lib/services/preferences.ts\` — partitions feedback in memory; surfaces \`librarySyncedCount\` on the profile
- \`src/routes/api/recommendations/analytics.ts\` — exposes \`feedbackCount.librarySynced\` on the API response
- \`src/components/recommendations/AnalyticsDashboard.tsx\` — Overview card shows \"+ N library-synced (excluded from charts)\" sub-line
- \`.gitignore\` — exception for \`drizzle/*.sql\` so future migrations track without \`git add -f\`

## Scoring path untouched

\`compound-scoring.ts\` and \`profile-recommendations.ts\` query \`recommendation_feedback\` directly with their own filters. They continue to see all rows (including \`source='library'\`) as real "user likes this" signal. The filter only affects the analytics display layer.

## Deploy / migration

The Dockerfile doesn't auto-run migrations. After merge:

\`\`\`bash
ssh juan@10.0.0.227 'docker exec -i ywf93h18i1g99xit9g7shjne psql -U postgres -d ai_dj' \\
  < drizzle/0026_listening_history_source.sql
\`\`\`

Idempotent (uses \`ADD COLUMN IF NOT EXISTS\`) so safe to re-run.

## Tests

- \`preferences.test.ts\` — 17/17
- \`recommendation-analytics.test.ts\` — 14/14
- \`listening-history.test.ts\` — 10/10

## Test plan

- [ ] Apply the migration on production
- [ ] Reload the Analytics page → "Total Feedback" card shows \`80 (interactions) + 620 library-synced (excluded from charts)\` instead of \`700\`
- [ ] Activity tab \"Feedback Events by Day of Week / Hour\" charts: Thursday-17:00 spike disappears
- [ ] Play a song with AI DJ enabled → check container logs for \`source=ai_dj\` on the \`Recorded play\` line (was already working) → verify the new column gets populated in DB:
  \`\`\`sql
  SELECT source, COUNT(*) FROM listening_history WHERE played_at > NOW() - INTERVAL '1 hour' GROUP BY source;
  \`\`\`
- [ ] Scoring path: trigger an AI DJ drip — recommendations should still surface library-liked songs (they should: scoring is unchanged).

## Pre-existing issues not addressed

- \`src/routes/api/preferences.ts\` has 4 pre-existing TS errors related to the \`user_preferences\` table drift (TS schema has 37 columns the DB doesn't). Separate cleanup PR.
- \`routeTree.gen.ts\` is stale in places. Separate cleanup PR.

## Next slices

Listening tab (top played artists/songs), source breakdown pie, true DoW × Hour heatmap, repeat-offenders list — each as its own PR per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)