### PR TITLE
fix(audio): Widen short-interrupt fast path 100ms → 500ms

### DIFF
--- a/src/lib/hooks/useWebAudioGraph.ts
+++ b/src/lib/hooks/useWebAudioGraph.ts
@@ -425,16 +425,24 @@ export function useWebAudioGraph(): WebAudioGraph {
         }
         console.log(`[WEB AUDIO] Context running — shouldResume=${shouldResume}, interruptMs=${interruptDuration}, needsResync=${needsResync}, sampleRate=${currentRate}${rateChanged ? ' (CHANGED)' : ''}, pbA=${pbA} pbB=${pbB}`);
 
-        // Fast path for sub-100ms iOS state bounces (screen lock / brief
-        // visibility blur). The full recovery sequence below — element-volume
-        // toggle + masterGain disconnect + 250ms fade-in — was designed for
-        // real suspensions. On a 30–80ms iOS bounce it's the recovery itself
-        // that becomes the audible event: the 250ms fade forces the Bluetooth
-        // A2DP codec to re-establish its time base, and the first ~200ms
-        // after resume plays at a perceptibly altered tempo (= "pitch shift"
-        // reported on screen-lock). For these short bounces we just reconnect
-        // masterGain at user volume directly. No fade, no element toggle.
-        if (interruptDuration > 0 && interruptDuration < 100) {
+        // Fast path for sub-500ms iOS state bounces. The full recovery
+        // sequence below — element-volume toggle + masterGain disconnect +
+        // 250ms fade-in — was designed for real suspensions. For any
+        // bounce that's not long enough to warrant the hard-resync path
+        // (>500ms, `needsResync=true` below) the recovery itself is
+        // louder than the actual interrupt would be: the 250ms fade
+        // forces the Bluetooth A2DP codec to re-establish its time base,
+        // and the first ~200ms after resume plays at a perceptibly
+        // altered tempo (= "pitch shift" reported on screen-lock).
+        //
+        // The threshold was originally 100ms based on the first wave of
+        // observations (21–65ms bounces). Real-world iOS produces bounces
+        // anywhere in 20–500ms (observed 25, 98, 298ms in one session) —
+        // anything in that window was getting the audible recovery.
+        // Aligning the threshold with `needsResync` means: short bounce →
+        // instant restore, real suspension → hard resync, no audible
+        // middle ground.
+        if (interruptDuration > 0 && interruptDuration < 500) {
           console.log(`[WEB AUDIO] Short interrupt (${interruptDuration}ms) — instant restore, skipping fade/element-toggle`);
           const masterFast = masterGainRef.current;
           if (masterFast) {


### PR DESCRIPTION
## Why

Production logs after the original \`0dd1241\` fix captured this sequence:

\`\`\`
01:53:58  interruptMs=25ms   → Short interrupt — instant restore  (fast path ✓)
02:02:02  interruptMs=98ms   → Short interrupt — instant restore  (fast path ✓)
02:02:42  interruptMs=298ms  → full recovery + 250ms fadeIn       ← AUDIBLE GLITCH
\`\`\`

Juan reported "two minor pitch shifts" in that window. The 02:02:42 bounce was over the 100ms fast-path threshold so it fell through to the full recovery, and on Bluetooth that 250ms \`fadeInMaster\` is exactly what triggers the A2DP codec re-buffer audible as pitch shift.

The original 100ms cutoff was a conservative pick from the first batch of observed bounces (21–65ms). iOS produces bounces all the way up to ~500ms (\`needsResync\` threshold). Anything in 100–500ms was getting the audible recovery treatment for no good reason.

## What changes

\`src/lib/hooks/useWebAudioGraph.ts\` — one-line threshold bump from \`< 100\` to \`< 500\`. Aligns with the existing \`needsResync\` threshold so the model becomes:

- **< 500ms bounce** → instant masterGain restore (fast path)
- **≥ 500ms bounce** → hard resync (source reload to fix pitch-shifted pipeline)

No middle band that gets the half-recovery anymore.

## Behavior for ≥ 500ms

Unchanged. The hard-resync path was the right call for real app-background suspensions and is still triggered the same way.

## Test plan

- [ ] After deploy + PWA cache bust, lock the phone several times under BT
- [ ] Pull \`[WEB AUDIO] Short interrupt (Xms) — instant restore\` lines, confirm we see them for bounces in the 100–500ms range that previously slipped through
- [ ] Confirm no audible glitch on any lock/unlock under 500ms
- [ ] Crossfade still clean (different code path; should be unaffected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)