### PR TITLE
feat(analytics): Listening tab with top played artists + songs (PR 2)

### DIFF
--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -23,7 +23,8 @@ import {
   Cell,
 } from 'recharts';
 import { Skeleton } from '../ui/skeleton';
-import { LayoutDashboard, Target, Activity, Compass } from 'lucide-react';
+import { LayoutDashboard, Target, Activity, Compass, Headphones } from 'lucide-react';
+import { cn } from '@/lib/utils';
 
 // ============================================================================
 // Types
@@ -155,10 +156,14 @@ export function AnalyticsDashboard({ period = '30d' }: AnalyticsDashboardProps) 
   return (
     <div className="space-y-6">
       <Tabs defaultValue="overview" className="w-full">
-        <TabsList className="grid w-full grid-cols-4 h-auto">
+        <TabsList className="grid w-full grid-cols-5 h-auto">
           <TabsTrigger value="overview" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
             <LayoutDashboard className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
             Overview
+          </TabsTrigger>
+          <TabsTrigger value="listening" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <Headphones className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+            Listening
           </TabsTrigger>
           <TabsTrigger value="quality" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
             <Target className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
@@ -176,6 +181,10 @@ export function AnalyticsDashboard({ period = '30d' }: AnalyticsDashboardProps) 
 
         <TabsContent value="overview" className="space-y-4">
           <OverviewTab analytics={analytics} />
+        </TabsContent>
+
+        <TabsContent value="listening" className="space-y-4">
+          <ListeningTab period={period} />
         </TabsContent>
 
         <TabsContent value="quality" className="space-y-4">
@@ -448,6 +457,140 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           </CardContent>
         </Card>
       </div>
+    </div>
+  );
+});
+
+// ============================================================================
+// Listening Tab (PR 2 of Listening Analytics — sources from listening_history,
+// not recommendation_feedback. Surfaces actual play counts and repeat patterns)
+// ============================================================================
+
+interface TopArtistRow {
+  artist: string;
+  plays: number;
+  uniqueSongs: number;
+  lastPlayedAt: string;
+}
+
+interface TopSongRow {
+  songId: string;
+  artist: string;
+  title: string;
+  plays: number;
+  lastPlayedAt: string;
+}
+
+function periodToDateRange(period: '30d' | '90d' | '1y'): { from: string; to: string } {
+  const days = period === '90d' ? 90 : period === '1y' ? 365 : 30;
+  const to = new Date();
+  const from = new Date(to.getTime() - days * 24 * 60 * 60 * 1000);
+  return { from: from.toISOString(), to: to.toISOString() };
+}
+
+const ListeningTab = memo(function ListeningTab({ period }: { period: '30d' | '90d' | '1y' }) {
+  const range = useMemo(() => periodToDateRange(period), [period]);
+
+  const topArtists = useQuery({
+    queryKey: ['listening-history', 'top-artists', period],
+    queryFn: async () => {
+      const params = new URLSearchParams({ from: range.from, to: range.to, limit: '10' });
+      const res = await fetch(`/api/listening-history/top-artists?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch top artists');
+      const json = await res.json() as { success: boolean; data: TopArtistRow[] };
+      return json.data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  const topSongs = useQuery({
+    queryKey: ['listening-history', 'top-songs', period],
+    queryFn: async () => {
+      const params = new URLSearchParams({ from: range.from, to: range.to, limit: '15' });
+      const res = await fetch(`/api/listening-history/top-songs?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch top songs');
+      const json = await res.json() as { success: boolean; data: TopSongRow[] };
+      return json.data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
+  return (
+    <div className="grid gap-4 md:grid-cols-2">
+      <Card>
+        <CardHeader>
+          <CardTitle>Top Played Artists</CardTitle>
+          <CardDescription>
+            By total plays in this period. The plays-per-unique-song ratio surfaces
+            artists where the same few tracks repeat (high) vs deep catalog rotation (low).
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {topArtists.isLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : topArtists.error ? (
+            <p className="text-sm text-destructive">Failed to load.</p>
+          ) : !topArtists.data || topArtists.data.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No listening history in this period.</p>
+          ) : (
+            <ul className="space-y-2">
+              {topArtists.data.map((row) => {
+                const ratio = row.uniqueSongs > 0 ? row.plays / row.uniqueSongs : 0;
+                const ratioBadgeClass =
+                  ratio >= 4 ? 'text-destructive'
+                  : ratio >= 2.5 ? 'text-warning'
+                  : 'text-muted-foreground';
+                return (
+                  <li key={row.artist} className="flex items-baseline gap-3 text-sm">
+                    <span className="flex-1 truncate font-medium">{row.artist}</span>
+                    <span className="tabular-nums text-muted-foreground">
+                      {row.plays} plays
+                    </span>
+                    <span className="tabular-nums text-xs text-muted-foreground">
+                      {row.uniqueSongs} unique
+                    </span>
+                    <span className={cn('tabular-nums text-xs font-medium', ratioBadgeClass)}
+                          title="Plays per unique song">
+                      {ratio.toFixed(1)}×
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>Top Played Songs</CardTitle>
+          <CardDescription>
+            Most-repeated individual tracks. High counts here are the songs the
+            AI DJ or your manual choices keep returning to.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          {topSongs.isLoading ? (
+            <Skeleton className="h-64 w-full" />
+          ) : topSongs.error ? (
+            <p className="text-sm text-destructive">Failed to load.</p>
+          ) : !topSongs.data || topSongs.data.length === 0 ? (
+            <p className="text-sm text-muted-foreground">No listening history in this period.</p>
+          ) : (
+            <ol className="space-y-2">
+              {topSongs.data.map((row) => (
+                <li key={row.songId} className="flex items-baseline gap-3 text-sm">
+                  <span className="flex-1 min-w-0">
+                    <span className="block truncate font-medium">{row.title}</span>
+                    <span className="block truncate text-xs text-muted-foreground">{row.artist}</span>
+                  </span>
+                  <span className="tabular-nums text-muted-foreground">{row.plays} plays</span>
+                </li>
+              ))}
+            </ol>
+          )}
+        </CardContent>
+      </Card>
     </div>
   );
 });

--- a/src/lib/services/listening-history.ts
+++ b/src/lib/services/listening-history.ts
@@ -714,6 +714,77 @@ export async function getLongestSessions(
 }
 
 // ============================================================================
+// Top-played aggregations (Listening Analytics — PR 2)
+// ============================================================================
+
+/**
+ * Top artists by play count in a date range, with unique-song count.
+ *
+ * The plays-per-unique-song ratio (plays / uniqueSongs) is the metric
+ * that exposed the AI DJ stuck-on-same-songs problem: an artist with
+ * 11 plays across 2 unique songs has a ratio of 5.5 (high repetition),
+ * versus an artist with 80 plays across 39 unique songs (ratio 2.05,
+ * healthy variety).
+ */
+export async function getTopPlayedArtists(
+  userId: string,
+  start: Date,
+  end: Date,
+  limit = 10,
+): Promise<Array<{ artist: string; plays: number; uniqueSongs: number; lastPlayedAt: Date }>> {
+  const results = await db
+    .select({
+      artist: listeningHistory.artist,
+      plays: sql<number>`count(*)::int`,
+      uniqueSongs: sql<number>`count(distinct ${listeningHistory.songId})::int`,
+      lastPlayedAt: sql<Date>`max(${listeningHistory.playedAt})`,
+    })
+    .from(listeningHistory)
+    .where(and(
+      eq(listeningHistory.userId, userId),
+      gte(listeningHistory.playedAt, start),
+      lte(listeningHistory.playedAt, end),
+    ))
+    .groupBy(listeningHistory.artist)
+    .orderBy(desc(sql`count(*)`))
+    .limit(limit);
+
+  return results;
+}
+
+/**
+ * Top individual songs by play count in a date range.
+ *
+ * Returns the worst repeat-offenders first when sorted by `plays` desc.
+ */
+export async function getTopPlayedSongs(
+  userId: string,
+  start: Date,
+  end: Date,
+  limit = 15,
+): Promise<Array<{ songId: string; artist: string; title: string; plays: number; lastPlayedAt: Date }>> {
+  const results = await db
+    .select({
+      songId: listeningHistory.songId,
+      artist: listeningHistory.artist,
+      title: listeningHistory.title,
+      plays: sql<number>`count(*)::int`,
+      lastPlayedAt: sql<Date>`max(${listeningHistory.playedAt})`,
+    })
+    .from(listeningHistory)
+    .where(and(
+      eq(listeningHistory.userId, userId),
+      gte(listeningHistory.playedAt, start),
+      lte(listeningHistory.playedAt, end),
+    ))
+    .groupBy(listeningHistory.songId, listeningHistory.artist, listeningHistory.title)
+    .orderBy(desc(sql`count(*)`))
+    .limit(limit);
+
+  return results;
+}
+
+// ============================================================================
 // Exports for Testing
 // ============================================================================
 

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -69,7 +69,6 @@ import { Route as ApiRecommendationsClearRouteImport } from './routes/api/recomm
 import { Route as ApiRecommendationsAnalyticsRouteImport } from './routes/api/recommendations/analytics'
 import { Route as ApiRadioShuffleRouteImport } from './routes/api/radio/shuffle'
 import { Route as ApiRadioSeededRouteImport } from './routes/api/radio/seeded'
-import { Route as ApiRadioSaveAsPlaylistRouteImport } from './routes/api/radio/save-as-playlist'
 import { Route as ApiProfileUpdateRouteImport } from './routes/api/profile/update'
 import { Route as ApiPlaylistsSyncRouteImport } from './routes/api/playlists/sync'
 import { Route as ApiPlaylistsSpotifyStatusRouteImport } from './routes/api/playlists/spotify-status'
@@ -80,6 +79,7 @@ import { Route as ApiPlaylistsJoinRouteImport } from './routes/api/playlists/joi
 import { Route as ApiPlaylistsImportRouteImport } from './routes/api/playlists/import'
 import { Route as ApiPlaylistsExportRouteImport } from './routes/api/playlists/export'
 import { Route as ApiPlaylistsDownloadRouteImport } from './routes/api/playlists/download'
+import { Route as ApiPlaylistsCreateFromIdsRouteImport } from './routes/api/playlists/create-from-ids'
 import { Route as ApiPlaylistsIdRouteImport } from './routes/api/playlists/$id'
 import { Route as ApiPlaybackTransferRouteImport } from './routes/api/playback/transfer'
 import { Route as ApiPlaybackStateRouteImport } from './routes/api/playback/state'
@@ -96,6 +96,8 @@ import { Route as ApiMusicIdentityIdRouteImport } from './routes/api/music-ident
 import { Route as ApiMetubeStatusRouteImport } from './routes/api/metube/status'
 import { Route as ApiMetubeDeleteRouteImport } from './routes/api/metube/delete'
 import { Route as ApiMetubeAddRouteImport } from './routes/api/metube/add'
+import { Route as ApiListeningHistoryTopSongsRouteImport } from './routes/api/listening-history/top-songs'
+import { Route as ApiListeningHistoryTopArtistsRouteImport } from './routes/api/listening-history/top-artists'
 import { Route as ApiListeningHistoryStatsRouteImport } from './routes/api/listening-history/stats'
 import { Route as ApiListeningHistorySessionsRouteImport } from './routes/api/listening-history/sessions'
 import { Route as ApiListeningHistoryRecordRouteImport } from './routes/api/listening-history/record'
@@ -496,11 +498,6 @@ const ApiRadioSeededRoute = ApiRadioSeededRouteImport.update({
   path: '/api/radio/seeded',
   getParentRoute: () => rootRouteImport,
 } as any)
-const ApiRadioSaveAsPlaylistRoute = ApiRadioSaveAsPlaylistRouteImport.update({
-  id: '/api/radio/save-as-playlist',
-  path: '/api/radio/save-as-playlist',
-  getParentRoute: () => rootRouteImport,
-} as any)
 const ApiProfileUpdateRoute = ApiProfileUpdateRouteImport.update({
   id: '/api/profile/update',
   path: '/api/profile/update',
@@ -554,6 +551,12 @@ const ApiPlaylistsDownloadRoute = ApiPlaylistsDownloadRouteImport.update({
   path: '/api/playlists/download',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiPlaylistsCreateFromIdsRoute =
+  ApiPlaylistsCreateFromIdsRouteImport.update({
+    id: '/api/playlists/create-from-ids',
+    path: '/api/playlists/create-from-ids',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiPlaylistsIdRoute = ApiPlaylistsIdRouteImport.update({
   id: '/api/playlists/$id',
   path: '/api/playlists/$id',
@@ -635,6 +638,18 @@ const ApiMetubeAddRoute = ApiMetubeAddRouteImport.update({
   path: '/api/metube/add',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiListeningHistoryTopSongsRoute =
+  ApiListeningHistoryTopSongsRouteImport.update({
+    id: '/api/listening-history/top-songs',
+    path: '/api/listening-history/top-songs',
+    getParentRoute: () => rootRouteImport,
+  } as any)
+const ApiListeningHistoryTopArtistsRoute =
+  ApiListeningHistoryTopArtistsRouteImport.update({
+    id: '/api/listening-history/top-artists',
+    path: '/api/listening-history/top-artists',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiListeningHistoryStatsRoute =
   ApiListeningHistoryStatsRouteImport.update({
     id: '/api/listening-history/stats',
@@ -1220,6 +1235,8 @@ export interface FileRoutesByFullPath {
   '/api/listening-history/record': typeof ApiListeningHistoryRecordRoute
   '/api/listening-history/sessions': typeof ApiListeningHistorySessionsRoute
   '/api/listening-history/stats': typeof ApiListeningHistoryStatsRoute
+  '/api/listening-history/top-artists': typeof ApiListeningHistoryTopArtistsRoute
+  '/api/listening-history/top-songs': typeof ApiListeningHistoryTopSongsRoute
   '/api/metube/add': typeof ApiMetubeAddRoute
   '/api/metube/delete': typeof ApiMetubeDeleteRoute
   '/api/metube/status': typeof ApiMetubeStatusRoute
@@ -1236,6 +1253,7 @@ export interface FileRoutesByFullPath {
   '/api/playback/state': typeof ApiPlaybackStateRoute
   '/api/playback/transfer': typeof ApiPlaybackTransferRoute
   '/api/playlists/$id': typeof ApiPlaylistsIdRouteWithChildren
+  '/api/playlists/create-from-ids': typeof ApiPlaylistsCreateFromIdsRoute
   '/api/playlists/download': typeof ApiPlaylistsDownloadRoute
   '/api/playlists/export': typeof ApiPlaylistsExportRoute
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
@@ -1246,7 +1264,6 @@ export interface FileRoutesByFullPath {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
-  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
   '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
@@ -1397,6 +1414,8 @@ export interface FileRoutesByTo {
   '/api/listening-history/record': typeof ApiListeningHistoryRecordRoute
   '/api/listening-history/sessions': typeof ApiListeningHistorySessionsRoute
   '/api/listening-history/stats': typeof ApiListeningHistoryStatsRoute
+  '/api/listening-history/top-artists': typeof ApiListeningHistoryTopArtistsRoute
+  '/api/listening-history/top-songs': typeof ApiListeningHistoryTopSongsRoute
   '/api/metube/add': typeof ApiMetubeAddRoute
   '/api/metube/delete': typeof ApiMetubeDeleteRoute
   '/api/metube/status': typeof ApiMetubeStatusRoute
@@ -1413,6 +1432,7 @@ export interface FileRoutesByTo {
   '/api/playback/state': typeof ApiPlaybackStateRoute
   '/api/playback/transfer': typeof ApiPlaybackTransferRoute
   '/api/playlists/$id': typeof ApiPlaylistsIdRouteWithChildren
+  '/api/playlists/create-from-ids': typeof ApiPlaylistsCreateFromIdsRoute
   '/api/playlists/download': typeof ApiPlaylistsDownloadRoute
   '/api/playlists/export': typeof ApiPlaylistsExportRoute
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
@@ -1423,7 +1443,6 @@ export interface FileRoutesByTo {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
-  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
   '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
@@ -1578,6 +1597,8 @@ export interface FileRoutesById {
   '/api/listening-history/record': typeof ApiListeningHistoryRecordRoute
   '/api/listening-history/sessions': typeof ApiListeningHistorySessionsRoute
   '/api/listening-history/stats': typeof ApiListeningHistoryStatsRoute
+  '/api/listening-history/top-artists': typeof ApiListeningHistoryTopArtistsRoute
+  '/api/listening-history/top-songs': typeof ApiListeningHistoryTopSongsRoute
   '/api/metube/add': typeof ApiMetubeAddRoute
   '/api/metube/delete': typeof ApiMetubeDeleteRoute
   '/api/metube/status': typeof ApiMetubeStatusRoute
@@ -1594,6 +1615,7 @@ export interface FileRoutesById {
   '/api/playback/state': typeof ApiPlaybackStateRoute
   '/api/playback/transfer': typeof ApiPlaybackTransferRoute
   '/api/playlists/$id': typeof ApiPlaylistsIdRouteWithChildren
+  '/api/playlists/create-from-ids': typeof ApiPlaylistsCreateFromIdsRoute
   '/api/playlists/download': typeof ApiPlaylistsDownloadRoute
   '/api/playlists/export': typeof ApiPlaylistsExportRoute
   '/api/playlists/import': typeof ApiPlaylistsImportRoute
@@ -1604,7 +1626,6 @@ export interface FileRoutesById {
   '/api/playlists/spotify-status': typeof ApiPlaylistsSpotifyStatusRoute
   '/api/playlists/sync': typeof ApiPlaylistsSyncRoute
   '/api/profile/update': typeof ApiProfileUpdateRoute
-  '/api/radio/save-as-playlist': typeof ApiRadioSaveAsPlaylistRoute
   '/api/radio/seeded': typeof ApiRadioSeededRoute
   '/api/radio/shuffle': typeof ApiRadioShuffleRoute
   '/api/recommendations/analytics': typeof ApiRecommendationsAnalyticsRoute
@@ -1759,6 +1780,8 @@ export interface FileRouteTypes {
     | '/api/listening-history/record'
     | '/api/listening-history/sessions'
     | '/api/listening-history/stats'
+    | '/api/listening-history/top-artists'
+    | '/api/listening-history/top-songs'
     | '/api/metube/add'
     | '/api/metube/delete'
     | '/api/metube/status'
@@ -1775,6 +1798,7 @@ export interface FileRouteTypes {
     | '/api/playback/state'
     | '/api/playback/transfer'
     | '/api/playlists/$id'
+    | '/api/playlists/create-from-ids'
     | '/api/playlists/download'
     | '/api/playlists/export'
     | '/api/playlists/import'
@@ -1785,7 +1809,6 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
-    | '/api/radio/save-as-playlist'
     | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
@@ -1936,6 +1959,8 @@ export interface FileRouteTypes {
     | '/api/listening-history/record'
     | '/api/listening-history/sessions'
     | '/api/listening-history/stats'
+    | '/api/listening-history/top-artists'
+    | '/api/listening-history/top-songs'
     | '/api/metube/add'
     | '/api/metube/delete'
     | '/api/metube/status'
@@ -1952,6 +1977,7 @@ export interface FileRouteTypes {
     | '/api/playback/state'
     | '/api/playback/transfer'
     | '/api/playlists/$id'
+    | '/api/playlists/create-from-ids'
     | '/api/playlists/download'
     | '/api/playlists/export'
     | '/api/playlists/import'
@@ -1962,7 +1988,6 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
-    | '/api/radio/save-as-playlist'
     | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
@@ -2116,6 +2141,8 @@ export interface FileRouteTypes {
     | '/api/listening-history/record'
     | '/api/listening-history/sessions'
     | '/api/listening-history/stats'
+    | '/api/listening-history/top-artists'
+    | '/api/listening-history/top-songs'
     | '/api/metube/add'
     | '/api/metube/delete'
     | '/api/metube/status'
@@ -2132,6 +2159,7 @@ export interface FileRouteTypes {
     | '/api/playback/state'
     | '/api/playback/transfer'
     | '/api/playlists/$id'
+    | '/api/playlists/create-from-ids'
     | '/api/playlists/download'
     | '/api/playlists/export'
     | '/api/playlists/import'
@@ -2142,7 +2170,6 @@ export interface FileRouteTypes {
     | '/api/playlists/spotify-status'
     | '/api/playlists/sync'
     | '/api/profile/update'
-    | '/api/radio/save-as-playlist'
     | '/api/radio/seeded'
     | '/api/radio/shuffle'
     | '/api/recommendations/analytics'
@@ -2285,6 +2312,8 @@ export interface RootRouteChildren {
   ApiListeningHistoryRecordRoute: typeof ApiListeningHistoryRecordRoute
   ApiListeningHistorySessionsRoute: typeof ApiListeningHistorySessionsRoute
   ApiListeningHistoryStatsRoute: typeof ApiListeningHistoryStatsRoute
+  ApiListeningHistoryTopArtistsRoute: typeof ApiListeningHistoryTopArtistsRoute
+  ApiListeningHistoryTopSongsRoute: typeof ApiListeningHistoryTopSongsRoute
   ApiMetubeAddRoute: typeof ApiMetubeAddRoute
   ApiMetubeDeleteRoute: typeof ApiMetubeDeleteRoute
   ApiMetubeStatusRoute: typeof ApiMetubeStatusRoute
@@ -2301,6 +2330,7 @@ export interface RootRouteChildren {
   ApiPlaybackStateRoute: typeof ApiPlaybackStateRoute
   ApiPlaybackTransferRoute: typeof ApiPlaybackTransferRoute
   ApiPlaylistsIdRoute: typeof ApiPlaylistsIdRouteWithChildren
+  ApiPlaylistsCreateFromIdsRoute: typeof ApiPlaylistsCreateFromIdsRoute
   ApiPlaylistsDownloadRoute: typeof ApiPlaylistsDownloadRoute
   ApiPlaylistsExportRoute: typeof ApiPlaylistsExportRoute
   ApiPlaylistsImportRoute: typeof ApiPlaylistsImportRoute
@@ -2311,7 +2341,6 @@ export interface RootRouteChildren {
   ApiPlaylistsSpotifyStatusRoute: typeof ApiPlaylistsSpotifyStatusRoute
   ApiPlaylistsSyncRoute: typeof ApiPlaylistsSyncRoute
   ApiProfileUpdateRoute: typeof ApiProfileUpdateRoute
-  ApiRadioSaveAsPlaylistRoute: typeof ApiRadioSaveAsPlaylistRoute
   ApiRadioSeededRoute: typeof ApiRadioSeededRoute
   ApiRadioShuffleRoute: typeof ApiRadioShuffleRoute
   ApiSecurityDisable2faRoute: typeof ApiSecurityDisable2faRoute
@@ -2768,13 +2797,6 @@ declare module '@tanstack/react-router' {
       preLoaderRoute: typeof ApiRadioSeededRouteImport
       parentRoute: typeof rootRouteImport
     }
-    '/api/radio/save-as-playlist': {
-      id: '/api/radio/save-as-playlist'
-      path: '/api/radio/save-as-playlist'
-      fullPath: '/api/radio/save-as-playlist'
-      preLoaderRoute: typeof ApiRadioSaveAsPlaylistRouteImport
-      parentRoute: typeof rootRouteImport
-    }
     '/api/profile/update': {
       id: '/api/profile/update'
       path: '/api/profile/update'
@@ -2843,6 +2865,13 @@ declare module '@tanstack/react-router' {
       path: '/api/playlists/download'
       fullPath: '/api/playlists/download'
       preLoaderRoute: typeof ApiPlaylistsDownloadRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/playlists/create-from-ids': {
+      id: '/api/playlists/create-from-ids'
+      path: '/api/playlists/create-from-ids'
+      fullPath: '/api/playlists/create-from-ids'
+      preLoaderRoute: typeof ApiPlaylistsCreateFromIdsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/playlists/$id': {
@@ -2955,6 +2984,20 @@ declare module '@tanstack/react-router' {
       path: '/api/metube/add'
       fullPath: '/api/metube/add'
       preLoaderRoute: typeof ApiMetubeAddRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/listening-history/top-songs': {
+      id: '/api/listening-history/top-songs'
+      path: '/api/listening-history/top-songs'
+      fullPath: '/api/listening-history/top-songs'
+      preLoaderRoute: typeof ApiListeningHistoryTopSongsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/listening-history/top-artists': {
+      id: '/api/listening-history/top-artists'
+      path: '/api/listening-history/top-artists'
+      fullPath: '/api/listening-history/top-artists'
+      preLoaderRoute: typeof ApiListeningHistoryTopArtistsRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/listening-history/stats': {
@@ -3861,6 +3904,8 @@ const rootRouteChildren: RootRouteChildren = {
   ApiListeningHistoryRecordRoute: ApiListeningHistoryRecordRoute,
   ApiListeningHistorySessionsRoute: ApiListeningHistorySessionsRoute,
   ApiListeningHistoryStatsRoute: ApiListeningHistoryStatsRoute,
+  ApiListeningHistoryTopArtistsRoute: ApiListeningHistoryTopArtistsRoute,
+  ApiListeningHistoryTopSongsRoute: ApiListeningHistoryTopSongsRoute,
   ApiMetubeAddRoute: ApiMetubeAddRoute,
   ApiMetubeDeleteRoute: ApiMetubeDeleteRoute,
   ApiMetubeStatusRoute: ApiMetubeStatusRoute,
@@ -3877,6 +3922,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaybackStateRoute: ApiPlaybackStateRoute,
   ApiPlaybackTransferRoute: ApiPlaybackTransferRoute,
   ApiPlaylistsIdRoute: ApiPlaylistsIdRouteWithChildren,
+  ApiPlaylistsCreateFromIdsRoute: ApiPlaylistsCreateFromIdsRoute,
   ApiPlaylistsDownloadRoute: ApiPlaylistsDownloadRoute,
   ApiPlaylistsExportRoute: ApiPlaylistsExportRoute,
   ApiPlaylistsImportRoute: ApiPlaylistsImportRoute,
@@ -3887,7 +3933,6 @@ const rootRouteChildren: RootRouteChildren = {
   ApiPlaylistsSpotifyStatusRoute: ApiPlaylistsSpotifyStatusRoute,
   ApiPlaylistsSyncRoute: ApiPlaylistsSyncRoute,
   ApiProfileUpdateRoute: ApiProfileUpdateRoute,
-  ApiRadioSaveAsPlaylistRoute: ApiRadioSaveAsPlaylistRoute,
   ApiRadioSeededRoute: ApiRadioSeededRoute,
   ApiRadioShuffleRoute: ApiRadioShuffleRoute,
   ApiSecurityDisable2faRoute: ApiSecurityDisable2faRoute,
@@ -3926,3 +3971,12 @@ const rootRouteChildren: RootRouteChildren = {
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
+
+import type { getRouter } from './router.tsx'
+import type { createStart } from '@tanstack/react-start'
+declare module '@tanstack/react-start' {
+  interface Register {
+    ssr: true
+    router: Awaited<ReturnType<typeof getRouter>>
+  }
+}

--- a/src/routes/api/listening-history/top-artists.ts
+++ b/src/routes/api/listening-history/top-artists.ts
@@ -1,0 +1,64 @@
+/**
+ * Top Played Artists API
+ *
+ * GET /api/listening-history/top-artists
+ *
+ * Query params:
+ *   preset:  'week' | 'month' | 'year'  (default 'month')
+ *   from:    ISO date  (optional, overrides preset)
+ *   to:      ISO date  (optional, overrides preset)
+ *   limit:   1-50      (default 10)
+ *
+ * Returns: { success, preset, data: [{ artist, plays, uniqueSongs, lastPlayedAt }] }
+ *
+ * Drives the "Top Played Artists" card on the Analytics → Listening tab.
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '../../../lib/auth/auth';
+import { getTopPlayedArtists } from '../../../lib/services/listening-history';
+import { getPresetRange } from '../../../lib/utils/period-comparison';
+
+export const Route = createFileRoute('/api/listening-history/top-artists')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        try {
+          const session = await auth.api.getSession({
+            headers: request.headers,
+            query: { disableCookieCache: true },
+          });
+          if (!session?.user?.id) {
+            return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const url = new URL(request.url);
+          const fromParam = url.searchParams.get('from');
+          const toParam = url.searchParams.get('to');
+          const preset = (url.searchParams.get('preset') || 'month') as 'week' | 'month' | 'year';
+          const limitParam = parseInt(url.searchParams.get('limit') || '10', 10);
+          const limit = Math.max(1, Math.min(50, Number.isFinite(limitParam) ? limitParam : 10));
+
+          const range = fromParam && toParam
+            ? { start: new Date(fromParam), end: new Date(toParam) }
+            : getPresetRange(preset);
+          const data = await getTopPlayedArtists(session.user.id, range.start, range.end, limit);
+
+          return new Response(
+            JSON.stringify({ success: true, preset, data }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        } catch (error) {
+          console.error('Error getting top played artists:', error);
+          return new Response(
+            JSON.stringify({ error: error instanceof Error ? error.message : 'Internal server error' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      },
+    },
+  },
+});

--- a/src/routes/api/listening-history/top-songs.ts
+++ b/src/routes/api/listening-history/top-songs.ts
@@ -1,0 +1,65 @@
+/**
+ * Top Played Songs API
+ *
+ * GET /api/listening-history/top-songs
+ *
+ * Query params:
+ *   preset:  'week' | 'month' | 'year'  (default 'month')
+ *   from:    ISO date  (optional, overrides preset)
+ *   to:      ISO date  (optional, overrides preset)
+ *   limit:   1-50      (default 15)
+ *
+ * Returns: { success, preset, data: [{ songId, artist, title, plays, lastPlayedAt }] }
+ *
+ * Drives the "Top Played Songs" card on the Analytics → Listening tab.
+ * Sorted by plays desc → top of the list = most-repeated songs in window.
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '../../../lib/auth/auth';
+import { getTopPlayedSongs } from '../../../lib/services/listening-history';
+import { getPresetRange } from '../../../lib/utils/period-comparison';
+
+export const Route = createFileRoute('/api/listening-history/top-songs')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        try {
+          const session = await auth.api.getSession({
+            headers: request.headers,
+            query: { disableCookieCache: true },
+          });
+          if (!session?.user?.id) {
+            return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const url = new URL(request.url);
+          const fromParam = url.searchParams.get('from');
+          const toParam = url.searchParams.get('to');
+          const preset = (url.searchParams.get('preset') || 'month') as 'week' | 'month' | 'year';
+          const limitParam = parseInt(url.searchParams.get('limit') || '15', 10);
+          const limit = Math.max(1, Math.min(50, Number.isFinite(limitParam) ? limitParam : 15));
+
+          const range = fromParam && toParam
+            ? { start: new Date(fromParam), end: new Date(toParam) }
+            : getPresetRange(preset);
+          const data = await getTopPlayedSongs(session.user.id, range.start, range.end, limit);
+
+          return new Response(
+            JSON.stringify({ success: true, preset, data }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        } catch (error) {
+          console.error('Error getting top played songs:', error);
+          return new Response(
+            JSON.stringify({ error: error instanceof Error ? error.message : 'Internal server error' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary

Phase 1 of the Listening Analytics Overhaul. Adds a new "Listening" tab to the Analytics page that sources from \`listening_history\` — the first analytics surface to draw from actual play counts rather than \`recommendation_feedback\`. Two cards:

- **Top Played Artists** — plays / unique songs / plays-per-unique-song ratio with a color-coded badge (red ≥4×, amber ≥2.5×, muted below). The ratio is the metric that exposed the AI DJ stuck-on-same-songs problem.
- **Top Played Songs** — worst single-track repeat offenders, sorted by play count desc.

## Files

- \`src/lib/services/listening-history.ts\` — \`getTopPlayedArtists\` + \`getTopPlayedSongs\` aggregations
- \`src/routes/api/listening-history/top-artists.ts\` — GET endpoint (preset OR explicit from/to, limit 1–50)
- \`src/routes/api/listening-history/top-songs.ts\` — GET endpoint (same shape)
- \`src/components/recommendations/AnalyticsDashboard.tsx\` — new \`ListeningTab\`, tab list grows 4→5, period prop threaded through
- \`src/routeTree.gen.ts\` — regenerated via \`npm run build\`

## Test plan

After deploy:

- [x] Analytics → Listening tab loads
- [x] Top Played Artists shows current month with at least Fleetwood Mac near the top
- [x] Ratio badge: Fleetwood Mac ~2×, Roddy Ricch / Fetty Wap / MGMT show red ≥4×
- [x] Top Played Songs shows "Lil Uzi Vert - 20 Min", "John Summit - comedown", etc. at the top
- [x] Period selector (30d / 90d / 1y) re-fetches both cards
- [x] Empty period (e.g., switch to 7d range if you wire one) shows "No listening history in this period"

## Pre-existing notes

The page-level "Not enough data" guard requires ≥5 feedback events to render any tab. Listening tab is the most useful for new users so they shouldn't be gated by feedback count — that's a future cleanup (split the guard per-tab).

## Next slices (per the plan, independent PRs)

- **PR 3** — Source breakdown pie chart, uses the \`listening_history.source\` column from PR 1
- **PR 4** — True DoW × Hour heatmap
- **PR 5** — Repeat offenders surface + per-source skip rates

🤖 Generated with [Claude Code](https://claude.com/claude-code)