### PR TITLE
fix(radio): Genre-coherent adjacent slice for artist radio

### DIFF
--- a/src/lib/services/__tests__/seeded-radio.test.ts
+++ b/src/lib/services/__tests__/seeded-radio.test.ts
@@ -289,6 +289,75 @@ describe('seeded-radio helpers', () => {
       expect(__internal.estimateSizeFromMinutes(180)).toBe(63);
     });
   });
+
+  describe('tokenizeGenre', () => {
+    it('lowercases and splits on common separators', () => {
+      expect(__internal.tokenizeGenre('Classic Rock')).toEqual(['classic', 'rock']);
+      expect(__internal.tokenizeGenre('Rock;Pop')).toEqual(['rock', 'pop']);
+      expect(__internal.tokenizeGenre('Rock/Folk')).toEqual(['rock', 'folk']);
+      expect(__internal.tokenizeGenre('Indie-Rock')).toEqual(['indie', 'rock']);
+      expect(__internal.tokenizeGenre('Rock & Roll')).toEqual(['rock', 'roll']);
+    });
+
+    it('drops short tokens and stop-words to avoid spurious matches', () => {
+      // "en" would match between "Rock en Español" and "Pop en Inglés" without filter
+      expect(__internal.tokenizeGenre('Rock en Español')).toEqual(['rock', 'español']);
+      expect(__internal.tokenizeGenre('The Rock and Roll')).toEqual(['rock', 'roll']);
+      // 1-2 char tokens dropped
+      expect(__internal.tokenizeGenre('UK Rock')).toEqual(['rock']);
+    });
+
+    it('returns empty array for null / empty / whitespace', () => {
+      expect(__internal.tokenizeGenre(null)).toEqual([]);
+      expect(__internal.tokenizeGenre(undefined)).toEqual([]);
+      expect(__internal.tokenizeGenre('')).toEqual([]);
+      expect(__internal.tokenizeGenre('   ')).toEqual([]);
+    });
+  });
+
+  describe('filterByGenreOverlap', () => {
+    const mk = (id: string, artist: string, genre: string | null): Song =>
+      ({
+        id,
+        name: id,
+        title: id,
+        artist,
+        album: '',
+        albumId: '',
+        track: 0,
+        duration: 180,
+        url: '',
+        genre,
+      }) as unknown as Song;
+
+    it('returns input unchanged when seed token set is empty', () => {
+      const songs = [mk('a', 'A', 'Rock'), mk('b', 'B', 'Hip Hop')];
+      expect(__internal.filterByGenreOverlap(songs, new Set())).toEqual(songs);
+    });
+
+    it('keeps tracks whose genre tokens overlap the seed set', () => {
+      const seed = new Set(['rock', 'classic', 'blues']);
+      const songs = [
+        mk('the-who', 'The Who', 'Rock'),              // rock ∈ seed → KEEP
+        mk('uzi', 'Lil Uzi Vert', 'Hip Hop'),          // no overlap → DROP
+        mk('summit', 'John Summit', 'House'),          // no overlap → DROP
+        mk('enanitos', 'Los Enanitos Verdes', 'Rock en Español'), // rock ∈ seed → KEEP
+      ];
+      const kept = __internal.filterByGenreOverlap(songs, seed);
+      expect(kept.map((s) => s.id)).toEqual(['the-who', 'enanitos']);
+    });
+
+    it('keeps tracks with no genre metadata (lenient on missing data)', () => {
+      const seed = new Set(['rock']);
+      const songs = [
+        mk('rock', 'Rock Band', 'Rock'),
+        mk('no-genre', 'Unknown Artist', null),
+        mk('hiphop', 'HH Artist', 'Hip Hop'),
+      ];
+      const kept = __internal.filterByGenreOverlap(songs, seed);
+      expect(kept.map((s) => s.id)).toEqual(['rock', 'no-genre']);
+    });
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/lib/services/seeded-radio.ts
+++ b/src/lib/services/seeded-radio.ts
@@ -85,6 +85,12 @@ const ARTIST_CATALOG_FRACTION: Record<ArtistVariety, number> = {
 // Per-seed scorer fetch size (we ask for more than we need so dedupe+cap leave headroom).
 const SCORER_LIMIT_PER_SEED = 20;
 
+// If the genre-coherence filter for artist radio would leave fewer than
+// MIN_FILTERED_FRACTION * (raw candidate count) candidates, we fall back to
+// the unfiltered pool with a warning. Prevents pathological cases (sparse or
+// missing genre tags) from producing an empty radio.
+const MIN_FILTERED_FRACTION = 0.25;
+
 // Conservative average track length used to estimate slot count from a duration target.
 // Generously over-shoots so the post-trim has room to land on the target.
 const AVG_TRACK_MINUTES = 3.75;
@@ -138,6 +144,47 @@ function shuffle<T>(arr: T[]): T[] {
 
 function sample<T>(arr: T[], n: number): T[] {
   return shuffle(arr).slice(0, n);
+}
+
+/**
+ * Split a genre string into lowercased tokens. Genre strings vary by source
+ * ("Classic Rock", "rock; pop", "Rock/Folk", "Indie-Rock") so we tokenize on
+ * common separators and lowercase. Stop-words and very-short tokens are
+ * dropped to avoid spurious matches (e.g., "en" in "Rock en Español").
+ */
+function tokenizeGenre(genre: string | null | undefined): string[] {
+  if (!genre) return [];
+  const STOP = new Set(['the', 'and', 'of', 'en', 'a', 'an', 'de', 'la', 'le']);
+  return genre
+    .toLowerCase()
+    .split(/[\s;,/\-&|]+/)
+    .map((t) => t.trim())
+    .filter((t) => t.length >= 3 && !STOP.has(t));
+}
+
+/**
+ * Filter candidates by genre-token overlap with the seed token set.
+ *
+ *  - Empty seed set → no filter applied (no seed-genre info to compare against).
+ *  - Candidate with no genre → KEPT (lenient: don't punish missing metadata).
+ *  - Candidate with genre → KEPT iff at least one of its tokens is in the seed set.
+ *
+ * Used by artist radio to keep the "adjacent" candidate pool genre-coherent
+ * with the seed artist. Without this, the blended scorer's broader candidate
+ * pool can leak in user-favorite artists from totally unrelated genres
+ * (e.g., hip-hop / EDM picks in a classic-rock radio) because they score high
+ * on the user's overall affinity profile.
+ */
+function filterByGenreOverlap(
+  candidates: Song[],
+  seedTokens: Set<string>,
+): Song[] {
+  if (seedTokens.size === 0) return candidates;
+  return candidates.filter((c) => {
+    const tokens = tokenizeGenre(c.genre);
+    if (tokens.length === 0) return true;
+    return tokens.some((t) => seedTokens.has(t));
+  });
 }
 
 function titleKey(song: { artist?: string; title?: string; name?: string }): string {
@@ -618,7 +665,41 @@ async function generateFromArtist(
     (s) => (s.artist ?? '').toLowerCase() !== artistName.toLowerCase(),
   );
 
-  let scorerSlice = dedupe([...coocFiltered, ...scorerMerged]);
+  // Genre-coherence filter on the adjacent slice. The blended scorer ranks
+  // candidates by the user's overall profile (compound score, artist
+  // affinity, temporal) — which has no notion of "should sound like the
+  // seed artist", so top-played user favorites can leak in regardless of
+  // genre (observed: hip-hop / EDM picks in a classic-rock radio). We
+  // build a token set from the seed catalog's genres and drop candidates
+  // whose genre tokens don't overlap. Tracks with no genre metadata are
+  // kept (lenient on missing data).
+  const seedTokens = new Set<string>();
+  for (const t of catalog) {
+    for (const tok of tokenizeGenre(t.genre)) seedTokens.add(tok);
+  }
+  const rawCount = coocFiltered.length + scorerMerged.length;
+  let filteredCooc = filterByGenreOverlap(coocFiltered, seedTokens);
+  let filteredScorer = filterByGenreOverlap(scorerMerged, seedTokens);
+  const filteredCount = filteredCooc.length + filteredScorer.length;
+  // Fallback: if the filter is too aggressive (sparse genre tags, mismatched
+  // taxonomy between seed catalog and candidates), fall back to unfiltered
+  // so the radio always has enough candidates to fill the queue.
+  if (rawCount > 0 && filteredCount < rawCount * MIN_FILTERED_FRACTION) {
+    console.warn(
+      `[seeded-radio] Genre filter too aggressive for "${artistName}" ` +
+      `(${filteredCount}/${rawCount} candidates, seed tokens=[${[...seedTokens].join(',')}]) ` +
+      `— falling back to unfiltered pool`,
+    );
+    filteredCooc = coocFiltered;
+    filteredScorer = scorerMerged;
+  } else if (rawCount > 0 && filteredCount < rawCount) {
+    console.log(
+      `[seeded-radio] Genre filter for "${artistName}": ${rawCount} → ${filteredCount} ` +
+      `candidates (seed tokens=[${[...seedTokens].join(',')}])`,
+    );
+  }
+
+  let scorerSlice = dedupe([...filteredCooc, ...filteredScorer]);
   scorerSlice = enforceArtistDiversity(scorerSlice);
 
   const interleaved = interleaveByFraction(artistSlice, scorerSlice, {
@@ -727,5 +808,8 @@ export const __internal = {
   interleaveByFraction,
   applyDurationTarget,
   estimateSizeFromMinutes,
+  tokenizeGenre,
+  filterByGenreOverlap,
   ARTIST_CATALOG_FRACTION,
+  MIN_FILTERED_FRACTION,
 };


### PR DESCRIPTION
## Why

Fleetwood Mac radio observed today (logs span 14:48 – 15:29 PDT, 15 plays):

\`\`\`
✓ Fleetwood Mac × 11    (73%, on-par with Low-variety setting)
✓ John Summit — comedown          (house/EDM)
✓ Lil Uzi Vert — 20 Min           (hip-hop)
✓ Los Enanitos Verdes — Piel de nopal  (Spanish rock)
✓ The Who — A Legal Matter        (genuinely classic-rock-adjacent ✓)
\`\`\`

3 of the 4 non-FM picks are wildly off genre. All 3 are in Juan's all-time top-played artists, which is why the blended scorer ranks them high regardless of seed. The variety knob (60/35/15% catalog) controls _fraction_ but not _genre coherence_ of the adjacent slice.

## What changes

\`generateFromArtist\` only. After building the adjacent candidate pool (co-occurrence + per-seed-track scorer output), filter both pools by genre-token overlap with the seed catalog before merging into the final queue.

- \`tokenizeGenre\` splits on common separators (space, semicolon, slash, dash, pipe), lowercases, drops tokens <3 chars or in a small stop-word set ("the", "and", "en", "de", ...). Fleetwood Mac → \`{rock, classic, blues, folk}\`. Lil Uzi Vert (\"Hip Hop\") → \`{hip, hop}\` → no overlap → dropped.
- \`filterByGenreOverlap\` is lenient on missing genre metadata (tracks with no genre are KEPT — don't punish indexing gaps).
- Fallback: if the filter would remove >75% of candidates (sparse tags or taxonomy mismatch), it falls back to the unfiltered pool with a warning, so radios never starve.

## What doesn't change

- Song / album / playlist seed paths — same code unchanged. We can extend later if the same incoherence shows up there; for now the user-reported problem is in artist radio specifically.
- Variety knob fractions, length constraint, recency cap, artist-diversity rules.
- Scoring weights in the blended recommender.

## Tests

6 new tests (34/34 passing):
- \`tokenizeGenre\` — separators, stop-words, null/empty handling
- \`filterByGenreOverlap\` — empty seed, overlap detection, lenient handling of missing genres

## Test plan

After deploy, fire a Fleetwood Mac radio at Low variety and listen for ~15 tracks. Expected:

- [ ] No hip-hop / EDM / non-rock genres in the adjacent slice
- [ ] The Who-style genuine classic-rock-adjacent picks still present
- [ ] If genre tags are sparse for some library tracks, those still appear (lenient fallback)
- [ ] Container logs: \`[seeded-radio] Genre filter for "Fleetwood Mac": N → M candidates (seed tokens=[rock,classic,blues,...])\`
- [ ] No \`Genre filter too aggressive\` warnings under normal use

## Position in the broader plan

Not part of the Listening Analytics Overhaul (PR 1 / PR 2 / future PRs) — that workstream is about visualizing data. This is about fixing the radio output itself. Independent diff, doesn't block any analytics PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)