### PR TITLE
fix(radio): Keep dropdown open while picking Length/Variety options

### DIFF
--- a/src/components/radio/StartRadioButton.tsx
+++ b/src/components/radio/StartRadioButton.tsx
@@ -108,6 +108,15 @@ export function StartRadioButton({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-56">
+        {/*
+          Radix's DropdownMenuRadioItem closes the menu on select by default.
+          That made it impossible to pick a Length and then a Variety without
+          re-opening the dropdown — and impossible to confirm with "Start
+          Radio" after picking either. Calling e.preventDefault() in onSelect
+          on each option keeps the menu open. The final "Start Radio"
+          DropdownMenuItem deliberately does NOT preventDefault so it closes
+          the menu when the user commits.
+        */}
         <DropdownMenuLabel>Length</DropdownMenuLabel>
         <DropdownMenuRadioGroup
           value={lengthTag}
@@ -117,7 +126,11 @@ export function StartRadioButton({
           }}
         >
           {LENGTH_OPTIONS.map((o) => (
-            <DropdownMenuRadioItem key={o.tag} value={o.tag}>
+            <DropdownMenuRadioItem
+              key={o.tag}
+              value={o.tag}
+              onSelect={(e) => e.preventDefault()}
+            >
               {o.label}
             </DropdownMenuRadioItem>
           ))}
@@ -130,13 +143,13 @@ export function StartRadioButton({
               value={variety}
               onValueChange={(v) => setVariety(v as ArtistVariety)}
             >
-              <DropdownMenuRadioItem value="low">
+              <DropdownMenuRadioItem value="low" onSelect={(e) => e.preventDefault()}>
                 Low — mostly this artist
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="medium">
+              <DropdownMenuRadioItem value="medium" onSelect={(e) => e.preventDefault()}>
                 Medium — balanced mix
               </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem value="high">
+              <DropdownMenuRadioItem value="high" onSelect={(e) => e.preventDefault()}>
                 High — adventurous
               </DropdownMenuRadioItem>
             </DropdownMenuRadioGroup>


### PR DESCRIPTION
## Bug

Reported by Juan: clicking a Length option (e.g. \"1 hour\") in the Start Radio dropdown closes the menu before the user can pick a Variety or hit Start Radio. Effectively impossible to commit a custom selection.

## Cause

Radix's \`DropdownMenuRadioItem\` closes the menu on select by default. Same for \`DropdownMenuItem\`. Without preventing default, every option click dismissed the menu.

## Fix

Add \`onSelect={(e) => e.preventDefault()}\` to every Length and Variety RadioItem. The state still updates (via \`onValueChange\` on the parent \`DropdownMenuRadioGroup\`) but the menu stays open. The final \"Start Radio\" \`DropdownMenuItem\` deliberately does **not** preventDefault, so committing closes the menu as expected.

One file changed. No logic / behavior change beyond menu-open persistence.

## Test plan

- [x] Click Start Radio button → dropdown opens
- [x] Click \"1 hour\" → dropdown stays open, indicator shows on \"1 hour\"
- [x] Click \"Low — mostly this artist\" → dropdown stays open, indicator shows on Low
- [x] Click \"Start Radio\" → menu closes and radio fires with the picked options

🤖 Generated with [Claude Code](https://claude.com/claude-code)