### PR TITLE
feat(analytics): Plays-by-source pie chart on Listening tab (PR 3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,9 @@ out/
 
 # Coverage / Tests
 coverage/
+tests/.auth/
+test-results/
+playwright-report/
 
 # Environment files
 .env

--- a/docs/research/lastfm-genre-recap-findings.md
+++ b/docs/research/lastfm-genre-recap-findings.md
@@ -1,0 +1,161 @@
+# Findings — Last.fm genre patterns + Platypush recap method
+
+Research output for the brief at `lastfm-genre-recap-research-brief.md`. ~60 min budget. Sources at end.
+
+---
+
+## 1. Last.fm tag system primer
+
+Last.fm tags are a **folksonomy**: any user can apply any free-text tag to any artist, track, or album. Multiple endpoints surface them: `artist.getTopTags`, `track.getTopTags`, `album.getTopTags`, plus `tag.getInfo` / `tag.getSimilar` / `tag.getTopArtists` operating on the tag dimension itself.
+
+**Tag weights.** Each tag in `getTopTags` responses carries a `count` field that is **normalized 0–100 relative to the top tag for that entity** (it is *not* a raw count of applications, despite the field name). For Lana Del Rey the top tags are `female vocalists` = 100, `indie` = 93, `indie pop` = 88, etc. — i.e. the most-applied tag is anchored at 100 and others are proportional. This makes the values directly usable as similarity weights without further normalization. The official `artist.getTopTags` doc page is sparse and does not document the `count` semantics; the 0–100 normalization is confirmed by the unofficial docs and by sampling responses (see sources).
+
+**Noise tags.** Folksonomy noise on Last.fm is real and well-documented. Most-applied tags across the whole site include `seen live`, `favorites` / `favourite` / `favourites`, `male vocalists`, `female vocalists`, `singer-songwriter` (sometimes), `awesome`, `under 2000 listeners`, plus year/decade tags (`00s`, `70s`) and country tags (`british`, `american`). The Million Song Dataset's last.fm subset and academic semantic-map work both flag these as the dominant non-musical contamination.
+
+No project I found ships a canonical Last.fm noise-tag blocklist. The pragmatic recipes:
+- Hard-coded blocklist of ~20–40 strings (`seen live`, `favorites`, `male/female vocalists`, `awesome`, `good`, `under 2000 listeners`, `loved tracks`, `my music`, etc.).
+- Decade/year regex (`/^(19|20)\d0s?$/`, `/^\d{4}$/`).
+- A min-weight threshold (drop tags with `count < ~15`) — kills the long tail where one user invented a tag.
+- An artist-list overlap check (a "tag" that is also an artist name on Last.fm is almost always a fan tag like `fleetwood mac` applied to Fleetwood Mac tracks — drop it).
+
+ListenBrainz acknowledges the same problem with **its own** (MusicBrainz-sourced) tags and has an open discourse thread proposing a `mb:`/`ht:` prefix system; it explicitly does **not** use Last.fm tags in its radio engine.
+
+## 2. Tag-overlap vs. artist-similarity-graph vs. hybrid
+
+Three options for "should this candidate stay in a radio seeded from X":
+
+| Approach | Signal | Strengths | Weaknesses |
+|---|---|---|---|
+| **Tag overlap** (cosine on top-N tag vectors with weights) | Per-artist Last.fm `toptags` | Cheap to cache, smooth continuous score, handles cold-start artists with no `getsimilar` results, generalizes across genres ("70s mellow rock") | Folksonomy noise; biased toward popular artists with many taggers |
+| **Artist-similarity graph** (Last.fm `artist.getsimilar` distance) | Last.fm co-listening graph | Captures real human listening adjacency; works when no shared tags exist | Cliffs in sparse parts of the graph; opaque match scores; current AIDJ usage already feels these cliffs |
+| **Hybrid** | Both, combined | Filter for tag coherence *and* graph adjacency; either alone is allowed to rescue | More code, two caches |
+
+**What comparable projects do:**
+- **ListenBrainz Radio** (Troi): tag-driven, but uses **MusicBrainz** tags rather than Last.fm. Supports `tag:(trip hop)::nosim` to disable similar-tag expansion. Difficulty modes (easy/medium/hard) trade strictness of the tag match against recall.
+- **Funkwhale**: pre-populates its tag table from MusicBrainz's official genre taxonomy (canonical vocabulary) and lets user-added tags coexist with a `musicbrainz_id` foreign-key when names match exactly. References but does not implement a "quality filter" for noise.
+- **Maloja**: deliberately ships with no recommendation/radio at all; just stats.
+- **MusicBrainz** itself imported ~6M genre tags into 1.3M recordings in 2021, sourced from Discogs + Last.fm + beaTunes — so the editorial side has effectively *already laundered* the most useful Last.fm tags into MusicBrainz genres.
+- **Spotify Radio** (closed): widely reported to combine collaborative filtering (the graph side) with audio-feature similarity and editorial genre/mood tags — i.e. hybrid.
+
+**Concrete recommendation for AIDJ.** Hybrid, but with tag-overlap as the *gate* and graph-similarity as the *rank*:
+1. Cache `artist.getTopTags` per artist (covered below). Apply a blocklist + min-weight + decade-regex filter; keep the top 5–10 after filtering.
+2. Replace `tokenizeGenre` / `filterByGenreOverlap` in `seeded-radio.ts` with a cosine over those filtered tag vectors. Use it as a **soft gate**: candidates below a coherence threshold are dropped (keep the existing 25% fallback so empty results never ship).
+3. Keep `track.getsimilar` / `artist.getsimilar` as the rank signal you already pay for.
+4. For artist-radio specifically, tag-cosine resolves the "hip-hop pick leaking into a classic-rock radio" failure mode directly, because the leaking artist's tag vector won't overlap with the seed's.
+
+This sidesteps the brief's anti-goal of "don't rebuild the scorer" — the change is to the *gating* step, not the scorer.
+
+## 3. Platypush compound-scoring math + recap module
+
+The Platypush "music recommender" is a single ~2022 blog post by Fabio Manganiello (BlackLight): **["Automate your music collection"](https://blog.platypush.tech/article/Automate-your-music-collection)** (also mirrored on Medium / Better Programming). It is the source AIDJ already credits in `listening-history.schema.ts`.
+
+**Schema (verbatim from the post):**
+```sql
+create table music_similar(
+    source_track_id   int not null,
+    target_track_id   int not null,
+    match_score       float not null,
+    primary key(source_track_id, target_track_id),
+    foreign key(source_track_id) references music_track(id),
+    foreign key(target_track_id) references music_track(id)
+);
+```
+This is the same shape as AIDJ's `track_similarities`.
+
+**Scoring formula (verbatim from the post).** The ranking of the i-th suggested track is the sum of `match_score`s from each recently-listened source track that has that suggestion as a similar:
+```python
+.order_by(func.sum(TrackSimilar.match_score).desc())
+.limit(limit)
+```
+with a binary recency filter:
+```python
+listened_activity.c.created_at >= date.today() - timedelta(days=days)
+```
+
+**Two important differences from AIDJ's implementation:**
+1. Platypush uses a **flat sum over a hard window** (default 7 days). No time-decay. AIDJ's `compound-scoring.ts` uses **exponential decay** (`weight = e^(-0.15 * days_ago)`, ~50% at 5 days) over a 14-day window. AIDJ is strictly more nuanced here.
+2. Platypush has **no separate recap module**. The "recap" the maintainer referenced is the **`Discover Weekly [date]`** playlist generated by a cron: `@cron('0 6 * * 1')` (every Monday 6 AM), 25-track output ranked by the sum formula. There is also a **`New Releases [date]`** cron at Monday 7 AM that pulls from monitored artist releases — that's the "new music" half of the recap pattern, not similarity-based.
+
+So: the "Platypush method for recaps" is not a distinct algorithm. It is the **same compound-scoring summation, but run periodically and persisted as a named playlist** rather than served live. The recap is a *materialization* of a snapshot, not a separate model. Platypush does not use Last.fm tags anywhere in this flow — only `track.getsimilar`.
+
+## 4. Two concrete proposals
+
+### Short-term: Last.fm artist-tags integration
+
+Add a cache table and use it in `seeded-radio.ts`:
+
+```ts
+// drizzle schema sketch — src/lib/db/schema/artist-tags.schema.ts
+export const artistTags = pgTable('artist_tags', {
+  // Canonical artist key (lowercased, trimmed). Use name not Navidrome ID
+  // because we need this keyed by what Last.fm returns.
+  artistKey: text('artist_key').primaryKey(),
+  // Optional MusicBrainz ID for later cross-walk to MB genres.
+  mbid: text('mbid'),
+  // Filtered top tags: [{name, weight}] sorted desc, ~5–10 entries post-filter.
+  tags: jsonb('tags').$type<Array<{name: string; weight: number}>>().notNull(),
+  // Source-of-truth tracking for cache busting.
+  fetchedAt: timestamp('fetched_at').defaultNow().notNull(),
+  // TTL: tags barely change — 90 days is safe, 30 days conservative.
+  expiresAt: timestamp('expires_at').notNull(),
+});
+```
+
+Service surface:
+- `getArtistTags(artistName): Promise<Tag[]>` — read-through cache calling `artist.getTopTags`.
+- `applyTagFilter(rawTags): Tag[]` — apply blocklist + min-weight ≥ 15 + decade regex + drop tags equal to any artist name in the user's library.
+- `tagCosine(a, b): number` — standard cosine over the two weight vectors (treat missing tags as 0).
+- In `seeded-radio.ts`, replace `filterByGenreOverlap` body with: compute seed-artist tag vector once; for each candidate compute cosine vs seed; drop if below threshold (try 0.15). Keep the existing 25% fallback for empty-set safety.
+
+TTL precedent: Last.fm tag distributions move on the order of months; the existing `track_similarities` table uses an `expiresAt`. 30–90 days is in line with what Picard-plugin and Lidify-style tools do.
+
+This is roughly one schema file + one service file + a ~30-line edit to `seeded-radio.ts`. Single API call per uncached artist (one-time per artist for ~90 days).
+
+### Longer-term: Recap / smart-summary for the Analytics page
+
+Platypush's recap = **periodic materialization of the same scorer that drives the live recommender**. AIDJ already has the live scorer (`getBlendedRecommendations`) and the listening-history table. A "smart recap" module would:
+
+1. **Weekly digest cron** (mirrors Platypush's Monday 6 AM). Compute and persist:
+   - Top 10 tracks by play count (week / month / year scopes).
+   - Top 5 artists by play count + by *novelty* (first-heard-this-period).
+   - Top tag clusters from the new `artist_tags` cache (e.g. "53% of plays were `indie rock` / `dream pop` / `shoegaze`").
+   - Skip-rate outliers (most-skipped artists, most-completed albums).
+   - Listening peak hours (you already compute temporal prefs).
+   - Suggested "Discover [week]" playlist: same 25-track sum-over-similars output as Platypush, persisted so users can compare week to week.
+2. **Persistence shape**: a `recaps` table keyed by `(userId, periodKind, periodStart)` with a JSONB blob of the materialized summary. Cheap to render; immutable once written; trivially exportable.
+3. **UI**: Analytics page tab "Recaps" with cards for week/month/year. The year-end version is the obvious "Wrapped" play.
+
+What this *doesn't* do (per the brief's anti-goal): require a user Last.fm account. Everything aggregates over the local `listening_history` and the cached `artist_tags`.
+
+The infrastructure pieces are already present — listening history, compound scores, artist affinity, temporal preferences. The recap module is a thin aggregator + persistor over them, plus the new tag cache for the genre-cluster slice.
+
+## 5. Open questions and tradeoffs
+
+- **`artist.getTopTags` `count` semantics.** Last.fm's official doc page does not state the 0–100 normalization explicitly. I'm asserting it from sample responses and unofficial docs — *flagged as speculation*. Worth confirming on a sample of 5–10 artists before implementing the cosine threshold.
+- **MBID resolution.** The `artist_tags.mbid` column is optional and gives a path to swap in MusicBrainz editorial genres later. Navidrome surfaces MBIDs on tracks; whether that's reliably populated in this library is unverified.
+- **Track vs. artist tags.** Per-track `track.getTopTags` is more specific (one Fleetwood Mac song = `mellow gold`, not just `classic rock`) but ~50× the API cost and ~50× the cache rows. Start with artist tags; only escalate to track tags if the artist-level granularity is too coarse for AIDJ's failure modes.
+- **No public Last.fm noise-tag blocklist.** Every project that solves this rolls their own. I'd start with the obvious ~20 strings + heuristics in §1; expect to tune over a few weeks of observation.
+- **Cosine threshold.** 0.15 is a guess. The Million Song Dataset has tag data you could empirically tune against; not in scope here.
+- **Does Platypush have anything else hiding?** I checked the music-related blog index and only found the one recommender post + a 2025 mobile-streaming setup post. No separate recap engine. The "recap method" phrasing in the brief is best interpreted as "the cron-materialized weekly playlist version of the same compound formula."
+
+---
+
+## Sources
+
+- [Last.fm API home](https://www.last.fm/api)
+- [Last.fm `artist.getTopTags`](https://www.last.fm/api/show/artist.getTopTags)
+- [Last.fm `track.getTopTags`](https://www.last.fm/api/show/track.getTopTags)
+- [Unofficial Last.fm API docs (getTopTags JSON shapes)](https://lastfm-docs.github.io/api-docs/)
+- [Million Song Dataset — Last.fm subset](http://millionsongdataset.com/lastfm/)
+- [Skupin, "A Semantic Map of the last.fm Music Folksonomy"](https://cns.iu.edu/images/pres/2012-skupin-last-fm-giscience.pdf)
+- [Fabio Manganiello — "Automate your music collection" (Platypush blog)](https://blog.platypush.tech/article/Automate-your-music-collection)
+- [Fabio Manganiello — Better Programming mirror](https://medium.com/better-programming/automate-your-music-collection-using-this-python-package-3891754a48dc)
+- [Platypush GitHub](https://github.com/BlackLight/platypush)
+- [Maloja README](https://github.com/krateng/maloja)
+- [Funkwhale genre-tags spec](https://docs.funkwhale.audio/develop/specs/genre-tags/index.html)
+- [Funkwhale Picard tagging docs](https://docs.funkwhale.audio/user/libraries/content/tag.html)
+- [ListenBrainz Recommendations API](https://listenbrainz.readthedocs.io/en/latest/users/api/recommendation.html)
+- [Troi / LB Radio prompt reference](https://troi.readthedocs.io/en/latest/lb_radio.html)
+- [MetaBrainz — "Tags that should be ignored in ListenBrainz" discourse](https://community.metabrainz.org/t/tags-that-should-be-ingnored-in-listenbrainz/814571)
+- [MetaBrainz — genre-matching project (MB↔Last.fm/Discogs/beaTunes)](https://github.com/metabrainz/genre-matching)
+- [ListenBrainz 2023 Recap (MetaBrainz blog) — example of a "recap" deliverable](https://blog.metabrainz.org/2024/02/26/listenbrainz-2023-recap/)

--- a/docs/research/lastfm-genre-recap-research-brief.md
+++ b/docs/research/lastfm-genre-recap-research-brief.md
@@ -1,0 +1,102 @@
+# Research brief — Last.fm-based genre/recommendation patterns + Platypush "recaps"
+
+**Audience**: an agent or developer doing background research, output read by the AIDJ maintainer.
+**Goal**: inform the next round of recommendation-quality and analytics improvements with a clear picture of (a) what Last.fm exposes that we don't yet use, and (b) what the Platypush music ecosystem has already figured out about period-summary aggregation ("recaps").
+**Time budget**: ~60–90 minutes of research, ~600–1000 word writeup.
+
+---
+
+## What AIDJ is, in 60 seconds
+
+Self-hosted Subsonic (Navidrome) frontend with an AI DJ layer. Recommendations are produced by a "blended scorer" combining:
+- Last.fm `track.getsimilar` / `artist.getsimilar` for similarity signal.
+- Compound scoring (Platypush-inspired): every played song fans out into Last.fm similar tracks, weighted by recency; songs suggested by *multiple* played sources rank higher.
+- Per-user artist affinity, temporal preferences, skip-penalty, artist co-occurrence within sessions.
+- Profile-based path that uses only DB-computed weights and zero API calls.
+
+Genre tags currently come from Navidrome's `genre` column on each track — usually a single string (e.g. `"Rock"`, `"Hip Hop"`, `"Rock en Español"`). That's the only genre data the radio pipeline consults today.
+
+A recent fix (commit `72426dd`) added a token-based genre filter to the artist-radio adjacent slice: tokenize each catalog track's `genre`, build a set, filter candidate tracks whose tokens don't overlap. Lenient on missing data, with a 25% fallback threshold.
+
+## Current Last.fm surface we DO use
+
+From `src/lib/services/lastfm/client.ts`:
+- `track.getsimilar` (raw + enriched)
+- `artist.getsimilar` (raw + enriched)
+- `artist.gettoptracks`
+- `tag.gettoptracks`
+- `track.search`
+- `track.getInfo`
+- `user.getrecenttracks`
+
+## Last.fm surface we DON'T use (relevant to this research)
+
+- `artist.getInfo` — bio + similar artists + **top tags** (folksonomy: "classic rock", "soft rock", "70s", "fleetwood mac", "the queen and the king", etc.). Per-artist tag weights normalized 0–100.
+- `artist.getTopTags` — same as above but standalone, returns weighted tag list.
+- `track.getTopTags` — per-track folksonomy. A specific Fleetwood Mac track might be tagged `"blues rock"`, `"70s"`, `"mellow"` etc.
+- `album.getTopTags` — per-album tags.
+- `tag.getInfo` / `tag.getTopArtists` / `tag.getTopTracks` / `tag.getSimilar` — operate on the tag dimension itself.
+- `user.getTopArtists` / `user.getTopTracks` / `user.getTopTags` / `user.getWeeklyChartList` — period-based summaries from Last.fm's own scrobble history (if user has connected Last.fm).
+- `chart.gettopartists` / `chart.gettoptracks` — global popularity.
+
+## What we want to know
+
+### A. Genre coherence (improving the radio filter we just shipped)
+
+1. **How does Last.fm's tag system compare to Navidrome's single-string `genre` field for similarity gating?** Specifically: tag weighting (0–100), tag overlap as a distance metric, whether we can use cosine similarity between two artists' top-N tag vectors as a continuous coherence score instead of a binary filter.
+2. **What are common pitfalls of using Last.fm tags?** Folksonomy issues — tags like `"seen live"`, `"male vocalists"`, `"favorites"` aren't musical at all. What's the standard tag-blacklist or filtering approach?
+3. **How do similar projects (Listenbrainz, Maloja, Funkwhale, etc.) reconcile Last.fm tags with editorial genres** (MusicBrainz, Discogs)? Is there a hybrid pattern worth copying?
+4. **Caching strategy**: tags don't change often, but our pipeline currently fetches Last.fm on the hot path. What TTL is typical for tag data, and where would we store it? (We already have a `track_similarities` table; an `artist_tags` table is a natural addition.)
+5. **Specific question**: for a "make a radio that sounds like X" use case, is the standard pattern to filter by **tag overlap** with the seed, or by **artist similarity** (Last.fm graph distance), or both? What does Spotify Radio reportedly do?
+
+### B. The Platypush "recap" method
+
+Per `listening-history.schema.ts` the compound-scoring approach was already inspired by Platypush. But the user mentioned a separate "Platypush method for recaps" — likely a different artifact. Likely candidates:
+
+- Platypush's music plugins (`platypush.plugins.music.mpd`, `platypush.plugins.music.snapcast`) and its scrobbling / charts integrations.
+- The blog post(s) by Platypush author Fabio Manganiello on building a personal music recommendation engine — there's a well-known multi-part series.
+- Any code in the Platypush repo that aggregates listening history into periodic summaries (top tracks/artists/tags by week/month/year).
+
+Research goals for this branch:
+
+1. **Find the original Platypush blog post(s) on building a music recommender.** Author: Fabio Manganiello (BlackLight). Likely on platypush.tech or medium. Summarize: what does the compound-scoring math actually look like, what time-decay function does he use, how does he handle the cold-start problem, what does he do for periodic recaps vs. ongoing recommendation?
+2. **Is there a separate "recap" module** distinct from the recommendation module? If so, what does it surface (top tracks/artists/tags/sessions, mood arc over time, listening peaks, …)?
+3. **How does Platypush integrate Last.fm specifically** vs. local-only signal? Is Last.fm scrobbling treated as ground truth, or is internal play history the source?
+4. **Adjacent projects**: Maloja, ListenBrainz, FunkWhale — do any of them publish their recap/wrapped algorithms? Spotify Wrapped is a closed model; what do the open alternatives do?
+
+## Useful entry points for the agent
+
+- Last.fm API docs: https://www.last.fm/api
+- Platypush docs: https://docs.platypush.tech
+- Platypush music sources: https://git.platypush.tech/platypush/platypush
+- Maloja: https://github.com/krateng/maloja  (open-source self-hosted scrobbler + stats)
+- ListenBrainz API: https://listenbrainz.readthedocs.io
+- MusicBrainz tags/genre data model: https://musicbrainz.org/doc/Genre
+
+## Deliverable shape
+
+A markdown writeup of ~600–1000 words with these sections:
+
+1. **Last.fm tag system primer** — what tags are, how weights work, how to filter noise tags.
+2. **Comparison: tag-overlap filter vs. artist-similarity-graph vs. hybrid** — concrete recommendation for AIDJ's next step, including a sketch of what an `artist_tags` cache table would look like.
+3. **Platypush compound-scoring math and recap module** — what we got from him already vs. what we haven't pulled in. Direct quotes / pseudo-code preferred.
+4. **Two concrete proposals** for AIDJ's next quality improvement:
+   - Short-term: a one-shot tag-cache integration that upgrades the existing genre filter from Navidrome's `genre` string to Last.fm artist tags.
+   - Longer-term: a recap / smart-summary feature for the Analytics page that uses Platypush-style aggregation.
+5. **Open questions and tradeoffs** — anything the agent couldn't resolve.
+
+## Anti-goals
+
+- **Do not** rebuild the existing compound scorer. We have it.
+- **Do not** propose a "scrap Navidrome and use X" migration. Navidrome is the music server and stays.
+- **Do not** propose anything that requires the user to maintain a Last.fm account or scrobble there. We can use the Last.fm API key for similarity/tag lookups without user scrobbles flowing the other direction.
+
+## Context dump for follow-up
+
+Project root: `/home/default/Desktop/dev/aidj`. Relevant files:
+- `src/lib/services/lastfm/client.ts` — current Last.fm methods
+- `src/lib/services/seeded-radio.ts` — recently added `tokenizeGenre` + `filterByGenreOverlap`
+- `src/lib/services/compound-scoring.ts` — the Platypush-inspired scorer
+- `src/lib/db/schema/listening-history.schema.ts` — has the Platypush attribution comment
+
+User on host: `juan@10.0.0.227`. Production DB: container `ywf93h18i1g99xit9g7shjne`, name `ai_dj`. ~12,700 plays in `listening_history`, ~700 in `recommendation_feedback`.

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -195,9 +195,17 @@ export function PlayerBar() {
     // apart from manual clicks / radio sessions / autoplay in the logs.
     // Precedence: ai_dj > autoplay > radio > manual. AI DJ insertions can
     // happen during a radio session; the more specific tag wins.
+    //
+    // aiQueuedSongIds is a Set kept in memory only — it gets wiped on
+    // rehydrate (page reload, PWA resume). aiDJRecentlyRecommended is
+    // persisted with an 8h window, so we check it first to survive
+    // reloads of long sessions.
     const audioState = useAudioStore.getState();
+    const isAiDj =
+      audioState.aiQueuedSongIds.has(songId) ||
+      audioState.aiDJRecentlyRecommended.some((rec) => rec.songId === songId);
     const source: 'ai_dj' | 'autoplay' | 'radio' | 'manual' =
-      audioState.aiQueuedSongIds.has(songId) ? 'ai_dj'
+      isAiDj ? 'ai_dj'
       : audioState.autoplayQueuedSongIds.has(songId) ? 'autoplay'
       : audioState.isRadioSession ? 'radio'
       : 'manual';

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -23,7 +23,7 @@ import {
   Cell,
 } from 'recharts';
 import { Skeleton } from '../ui/skeleton';
-import { LayoutDashboard, Target, Activity, Compass, Headphones } from 'lucide-react';
+import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 // ============================================================================
@@ -210,52 +210,54 @@ export function AnalyticsDashboard({ period = '30d' }: AnalyticsDashboardProps) 
 function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
   return (
     <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {/* Stats Cards */}
+      {/* Stat cards */}
       <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">Total Feedback</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{analytics.profile.feedbackCount.total}</div>
-          <p className="text-xs text-muted-foreground">
-            {analytics.profile.feedbackCount.thumbsUp} up / {analytics.profile.feedbackCount.thumbsDown} down
+        <CardContent className="pt-6">
+          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total Feedback</p>
+          <div className="mt-2 text-3xl font-semibold tabular-nums">
+            {analytics.profile.feedbackCount.total.toLocaleString()}
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            <span className="font-medium text-emerald-500">{analytics.profile.feedbackCount.thumbsUp}</span> up
+            {' / '}
+            <span className="font-medium text-destructive">{analytics.profile.feedbackCount.thumbsDown}</span> down
           </p>
           {analytics.profile.feedbackCount.librarySynced !== undefined &&
            analytics.profile.feedbackCount.librarySynced > 0 && (
             <p className="text-[10px] text-muted-foreground mt-1">
-              + {analytics.profile.feedbackCount.librarySynced} library-synced (excluded from charts)
+              + {analytics.profile.feedbackCount.librarySynced.toLocaleString()} library-synced (excluded)
             </p>
           )}
         </CardContent>
       </Card>
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">Acceptance Rate</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">
-            {analytics.quality ? `${(analytics.quality.acceptanceRate * 100).toFixed(0)}%` : 'N/A'}
-          </div>
-          <p className="text-xs text-muted-foreground">
-            {analytics.quality?.qualityTrend === 'improving' && '📈 Improving'}
-            {analytics.quality?.qualityTrend === 'declining' && '📉 Declining'}
-            {analytics.quality?.qualityTrend === 'stable' && '➡️ Stable'}
-          </p>
-        </CardContent>
-      </Card>
+      <MetricCard
+        title="Acceptance Rate"
+        value={analytics.quality ? `${(analytics.quality.acceptanceRate * 100).toFixed(0)}%` : 'N/A'}
+        trend={
+          analytics.quality?.qualityTrend === 'improving' ? 'up'
+          : analytics.quality?.qualityTrend === 'declining' ? 'down'
+          : analytics.quality?.qualityTrend === 'stable' ? 'flat'
+          : undefined
+        }
+        description={
+          analytics.quality?.qualityTrend === 'improving' ? 'Improving'
+          : analytics.quality?.qualityTrend === 'declining' ? 'Declining'
+          : analytics.quality?.qualityTrend === 'stable' ? 'Stable'
+          : 'Not enough data'
+        }
+      />
 
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-sm font-medium">New Artists</CardTitle>
-        </CardHeader>
-        <CardContent>
-          <div className="text-2xl font-bold">{analytics.discovery?.newArtistsDiscovered || 0}</div>
-          <p className="text-xs text-muted-foreground">
-            Taste: {analytics.discovery?.diversityTrend || 'stable'}
-          </p>
-        </CardContent>
-      </Card>
+      <MetricCard
+        title="New Artists"
+        value={(analytics.discovery?.newArtistsDiscovered || 0).toString()}
+        description={`Taste: ${analytics.discovery?.diversityTrend || 'stable'}`}
+        trend={
+          analytics.discovery?.diversityTrend === 'expanding' ? 'up'
+          : analytics.discovery?.diversityTrend === 'narrowing' ? 'down'
+          : 'flat'
+        }
+      />
 
       {/* Top Artists */}
       <Card className="md:col-span-2">
@@ -327,14 +329,22 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         </CardHeader>
         <CardContent>
           <ResponsiveContainer width="100%" height={300}>
-            <BarChart data={chartData}>
-              <CartesianGrid strokeDasharray="3 3" />
-              <XAxis dataKey="period" />
-              <YAxis />
-              <Tooltip />
-              <Legend />
-              <Bar dataKey="liked" fill={COLORS.success} name="Liked" />
-              <Bar dataKey="disliked" fill={COLORS.danger} name="Disliked" />
+            <BarChart data={chartData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+              <XAxis dataKey="period" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+              <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
+              <Tooltip
+                cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
+                contentStyle={{
+                  borderRadius: 8,
+                  border: '1px solid hsl(var(--border))',
+                  background: 'hsl(var(--popover))',
+                  fontSize: 12,
+                }}
+              />
+              <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} iconType="circle" />
+              <Bar dataKey="liked" fill={COLORS.success} name="Liked" radius={[4, 4, 0, 0]} />
+              <Bar dataKey="disliked" fill={COLORS.danger} name="Disliked" radius={[4, 4, 0, 0]} />
             </BarChart>
           </ResponsiveContainer>
         </CardContent>
@@ -349,6 +359,11 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         <MetricCard
           title="Quality Trend"
           value={analytics.quality.qualityTrend}
+          trend={
+            analytics.quality.qualityTrend === 'improving' ? 'up'
+            : analytics.quality.qualityTrend === 'declining' ? 'down'
+            : 'flat'
+          }
           description={
             analytics.quality.qualityTrend === 'improving'
               ? 'Recommendations getting better'
@@ -410,13 +425,14 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           <CardDescription>When you most often rate AI DJ recommendations</CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="space-y-2">
+          <ul className="space-y-2">
             {analytics.activity.listeningPatternInsights.map((insight, i) => (
-              <p key={i} className="text-sm">
-                • {insight}
-              </p>
+              <li key={i} className="flex items-start gap-2 text-sm">
+                <span aria-hidden className="mt-2 size-1.5 shrink-0 rounded-full bg-primary/60" />
+                <span>{insight}</span>
+              </li>
             ))}
-          </div>
+          </ul>
         </CardContent>
       </Card>
 
@@ -428,12 +444,20 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
-              <BarChart data={dayData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="day" />
-                <YAxis />
-                <Tooltip />
-                <Bar dataKey="count" fill={COLORS.primary} />
+              <BarChart data={dayData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+                <XAxis dataKey="day" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
+                <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
+                <Tooltip
+                  cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
+                  contentStyle={{
+                    borderRadius: 8,
+                    border: '1px solid hsl(var(--border))',
+                    background: 'hsl(var(--popover))',
+                    fontSize: 12,
+                  }}
+                />
+                <Bar dataKey="count" fill={COLORS.primary} radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
           </CardContent>
@@ -446,12 +470,27 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           </CardHeader>
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
-              <LineChart data={hourData}>
-                <CartesianGrid strokeDasharray="3 3" />
-                <XAxis dataKey="hour" />
-                <YAxis />
-                <Tooltip />
-                <Line type="monotone" dataKey="count" stroke={COLORS.secondary} strokeWidth={2} />
+              <LineChart data={hourData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+                <XAxis dataKey="hour" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} interval={2} />
+                <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
+                <Tooltip
+                  cursor={{ stroke: 'hsl(var(--muted-foreground))', strokeWidth: 1 }}
+                  contentStyle={{
+                    borderRadius: 8,
+                    border: '1px solid hsl(var(--border))',
+                    background: 'hsl(var(--popover))',
+                    fontSize: 12,
+                  }}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="count"
+                  stroke={COLORS.secondary}
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: COLORS.secondary }}
+                  activeDot={{ r: 5 }}
+                />
               </LineChart>
             </ResponsiveContainer>
           </CardContent>
@@ -801,6 +840,11 @@ const DiscoveryTab = memo(function DiscoveryTab({ analytics }: { analytics: Enha
         <MetricCard
           title="Diversity Trend"
           value={analytics.discovery.diversityTrend}
+          trend={
+            analytics.discovery.diversityTrend === 'expanding' ? 'up'
+            : analytics.discovery.diversityTrend === 'narrowing' ? 'down'
+            : 'flat'
+          }
           description={
             analytics.discovery.diversityTrend === 'expanding'
               ? 'Exploring more variety'
@@ -843,14 +887,13 @@ const DiscoveryTab = memo(function DiscoveryTab({ analytics }: { analytics: Enha
 // ============================================================================
 
 const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Array<{ artist: string; count: number }> }) {
-  // Memoize chart data transformation
-  // eslint-disable-next-line react-hooks/preserve-manual-memoization
-  const chartData = useMemo(() => {
-    return artists.slice(0, 5).map((item, index) => ({
+  const { chartData, total } = useMemo(() => {
+    const data = artists.slice(0, 5).map((item, index) => ({
       name: item.artist,
       value: item.count,
       color: PIE_COLORS[index % PIE_COLORS.length],
     }));
+    return { chartData: data, total: data.reduce((acc, d) => acc + d.value, 0) };
   }, [artists]);
 
   if (artists.length === 0) {
@@ -858,25 +901,72 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
   }
 
   return (
-    <ResponsiveContainer width="100%" height={200}>
-      <PieChart>
-        <Pie
-          data={chartData}
-          cx="50%"
-          cy="50%"
-          labelLine={false}
-          label={(entry) => `${entry.name} (${entry.value})`}
-          outerRadius={80}
-          fill="#8884d8"
-          dataKey="value"
-        >
-          {chartData.map((entry) => (
-            <Cell key={entry.name} fill={entry.color} />
-          ))}
-        </Pie>
-        <Tooltip />
-      </PieChart>
-    </ResponsiveContainer>
+    <div className="grid gap-6 md:grid-cols-[220px_1fr]">
+      <div className="relative mx-auto md:mx-0">
+        <ResponsiveContainer width={220} height={220}>
+          <PieChart>
+            <Pie
+              data={chartData}
+              cx="50%"
+              cy="50%"
+              innerRadius={62}
+              outerRadius={92}
+              paddingAngle={2}
+              dataKey="value"
+              nameKey="name"
+              stroke="hsl(var(--background))"
+              strokeWidth={2}
+            >
+              {chartData.map((entry) => (
+                <Cell key={entry.name} fill={entry.color} />
+              ))}
+            </Pie>
+            <Tooltip
+              formatter={(value: number, name) => {
+                const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                return [`${value} thumbs-up (${pct}%)`, name];
+              }}
+              contentStyle={{
+                borderRadius: 8,
+                border: '1px solid hsl(var(--border))',
+                background: 'hsl(var(--popover))',
+                fontSize: 12,
+              }}
+            />
+          </PieChart>
+        </ResponsiveContainer>
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+          <span className="text-2xl font-semibold tabular-nums">{total.toLocaleString()}</span>
+          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Top {chartData.length}</span>
+        </div>
+      </div>
+      <ul className="space-y-1 self-center">
+        {chartData.map((entry, idx) => {
+          const pct = total > 0 ? (entry.value / total) * 100 : 0;
+          return (
+            <li
+              key={entry.name}
+              className="grid grid-cols-[1.5rem_1fr_auto] items-center gap-3 rounded-md px-2 py-1.5 text-sm hover:bg-muted/40"
+            >
+              <span className="flex items-center gap-1.5">
+                <span
+                  aria-hidden
+                  className="size-2 rounded-full"
+                  style={{ backgroundColor: entry.color }}
+                />
+                <span className="text-xs font-medium tabular-nums text-muted-foreground">{idx + 1}</span>
+              </span>
+              <span className="truncate font-medium">{entry.name}</span>
+              <span className="text-right tabular-nums text-xs text-muted-foreground">
+                <span className="font-semibold text-foreground">{entry.value}</span>
+                {' · '}
+                {pct.toFixed(0)}%
+              </span>
+            </li>
+          );
+        })}
+      </ul>
+    </div>
   );
 });
 
@@ -919,15 +1009,33 @@ const TasteProfileCard = memo(function TasteProfileCard({ analytics }: { analyti
   );
 });
 
-const MetricCard = memo(function MetricCard({ title, value, description }: { title: string; value: string; description: string }) {
+type MetricTrend = 'up' | 'down' | 'flat';
+
+const MetricCard = memo(function MetricCard({
+  title,
+  value,
+  description,
+  trend,
+}: {
+  title: string;
+  value: string;
+  description: string;
+  trend?: MetricTrend;
+}) {
+  const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : trend === 'flat' ? Minus : null;
+  const trendClass =
+    trend === 'up' ? 'text-emerald-500'
+    : trend === 'down' ? 'text-destructive'
+    : 'text-muted-foreground';
   return (
     <Card>
-      <CardHeader>
-        <CardTitle className="text-sm font-medium">{title}</CardTitle>
-      </CardHeader>
-      <CardContent>
-        <div className="text-2xl font-bold capitalize">{value}</div>
-        <p className="text-xs text-muted-foreground">{description}</p>
+      <CardContent className="pt-6">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{title}</p>
+        <div className="mt-2 flex items-baseline gap-2">
+          <span className="text-3xl font-semibold tabular-nums capitalize">{value}</span>
+          {TrendIcon && <TrendIcon className={cn('size-4 self-center', trendClass)} />}
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
       </CardContent>
     </Card>
   );

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -570,24 +570,31 @@ const ListeningTab = memo(function ListeningTab({ period }: { period: '30d' | '9
           ) : !topArtists.data || topArtists.data.length === 0 ? (
             <p className="text-sm text-muted-foreground">No listening history in this period.</p>
           ) : (
-            <ul className="space-y-2">
-              {topArtists.data.map((row) => {
+            <ul className="space-y-1">
+              {topArtists.data.map((row, idx) => {
                 const ratio = row.uniqueSongs > 0 ? row.plays / row.uniqueSongs : 0;
                 const ratioBadgeClass =
-                  ratio >= 4 ? 'text-destructive'
-                  : ratio >= 2.5 ? 'text-warning'
-                  : 'text-muted-foreground';
+                  ratio >= 4 ? 'bg-destructive/10 text-destructive'
+                  : ratio >= 2.5 ? 'bg-warning/10 text-warning'
+                  : 'bg-muted text-muted-foreground';
                 return (
-                  <li key={row.artist} className="flex items-baseline gap-3 text-sm">
-                    <span className="flex-1 truncate font-medium">{row.artist}</span>
-                    <span className="tabular-nums text-muted-foreground">
-                      {row.plays} plays
+                  <li
+                    key={row.artist}
+                    className="grid grid-cols-[1.5rem_1fr_auto_auto] items-center gap-3 rounded-md px-2 py-1.5 text-sm hover:bg-muted/40"
+                  >
+                    <span className="text-xs font-medium tabular-nums text-muted-foreground">
+                      {idx + 1}
                     </span>
-                    <span className="tabular-nums text-xs text-muted-foreground">
-                      {row.uniqueSongs} unique
+                    <span className="truncate font-medium">{row.artist}</span>
+                    <span className="text-right tabular-nums text-xs text-muted-foreground">
+                      <span className="font-semibold text-foreground">{row.plays}</span>
+                      {' / '}
+                      {row.uniqueSongs}
                     </span>
-                    <span className={cn('tabular-nums text-xs font-medium', ratioBadgeClass)}
-                          title="Plays per unique song">
+                    <span
+                      className={cn('rounded-full px-2 py-0.5 text-xs font-medium tabular-nums', ratioBadgeClass)}
+                      title="Plays per unique song"
+                    >
                       {ratio.toFixed(1)}×
                     </span>
                   </li>
@@ -614,14 +621,22 @@ const ListeningTab = memo(function ListeningTab({ period }: { period: '30d' | '9
           ) : !topSongs.data || topSongs.data.length === 0 ? (
             <p className="text-sm text-muted-foreground">No listening history in this period.</p>
           ) : (
-            <ol className="space-y-2">
-              {topSongs.data.map((row) => (
-                <li key={row.songId} className="flex items-baseline gap-3 text-sm">
-                  <span className="flex-1 min-w-0">
+            <ol className="space-y-1">
+              {topSongs.data.map((row, idx) => (
+                <li
+                  key={row.songId}
+                  className="grid grid-cols-[1.5rem_1fr_auto] items-center gap-3 rounded-md px-2 py-1.5 text-sm hover:bg-muted/40"
+                >
+                  <span className="text-xs font-medium tabular-nums text-muted-foreground">
+                    {idx + 1}
+                  </span>
+                  <span className="min-w-0">
                     <span className="block truncate font-medium">{row.title}</span>
                     <span className="block truncate text-xs text-muted-foreground">{row.artist}</span>
                   </span>
-                  <span className="tabular-nums text-muted-foreground">{row.plays} plays</span>
+                  <span className="rounded-full bg-muted px-2 py-0.5 text-xs font-semibold tabular-nums text-foreground">
+                    {row.plays}
+                  </span>
                 </li>
               ))}
             </ol>
@@ -649,6 +664,8 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
     return { rows: data, chartData: shaped, total: sum };
   }, [query.data]);
 
+  const top = rows[0];
+
   return (
     <Card>
       <CardHeader>
@@ -660,55 +677,88 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
       </CardHeader>
       <CardContent>
         {query.isLoading ? (
-          <Skeleton className="h-56 w-full" />
+          <Skeleton className="h-72 w-full" />
         ) : query.error ? (
           <p className="text-sm text-destructive">Failed to load.</p>
         ) : rows.length === 0 ? (
           <p className="text-sm text-muted-foreground">No listening history in this period.</p>
         ) : (
-          <div className="grid gap-4 md:grid-cols-[1fr_1fr] items-center">
-            <ResponsiveContainer width="100%" height={220}>
-              <PieChart>
-                <Pie
-                  data={chartData}
-                  cx="50%"
-                  cy="50%"
-                  innerRadius={50}
-                  outerRadius={85}
-                  paddingAngle={2}
-                  dataKey="value"
-                  nameKey="name"
-                >
-                  {chartData.map((entry) => (
-                    <Cell
-                      key={entry.source}
-                      fill={SOURCE_COLORS[entry.source] ?? '#94a3b8'}
-                    />
-                  ))}
-                </Pie>
-                <Tooltip
-                  formatter={(value: number, name) => {
-                    const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
-                    return [`${value} plays (${pct}%)`, name];
-                  }}
-                />
-              </PieChart>
-            </ResponsiveContainer>
-            <ul className="space-y-2 text-sm">
+          <div className="grid gap-6 md:grid-cols-[260px_1fr]">
+            {/* Donut + hero stat */}
+            <div className="relative mx-auto md:mx-0">
+              <ResponsiveContainer width={260} height={260}>
+                <PieChart>
+                  <Pie
+                    data={chartData}
+                    cx="50%"
+                    cy="50%"
+                    innerRadius={75}
+                    outerRadius={110}
+                    paddingAngle={2}
+                    dataKey="value"
+                    nameKey="name"
+                    stroke="hsl(var(--background))"
+                    strokeWidth={2}
+                  >
+                    {chartData.map((entry) => (
+                      <Cell
+                        key={entry.source}
+                        fill={SOURCE_COLORS[entry.source] ?? '#94a3b8'}
+                      />
+                    ))}
+                  </Pie>
+                  <Tooltip
+                    formatter={(value: number, name) => {
+                      const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                      return [`${value} plays (${pct}%)`, name];
+                    }}
+                    contentStyle={{
+                      borderRadius: 8,
+                      border: '1px solid hsl(var(--border))',
+                      background: 'hsl(var(--popover))',
+                      fontSize: 12,
+                    }}
+                  />
+                </PieChart>
+              </ResponsiveContainer>
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
+                <span className="text-3xl font-semibold tabular-nums">{total.toLocaleString()}</span>
+                <span className="text-xs uppercase tracking-wide text-muted-foreground">Total plays</span>
+              </div>
+            </div>
+
+            {/* Stat-card legend */}
+            <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 self-center">
               {rows.map((row) => {
                 const pct = total > 0 ? (row.plays / total) * 100 : 0;
+                const color = SOURCE_COLORS[row.source] ?? '#94a3b8';
+                const isTop = row === top;
                 return (
-                  <li key={row.source} className="flex items-baseline gap-3">
-                    <span
-                      aria-hidden
-                      className="inline-block size-3 rounded-sm shrink-0"
-                      style={{ backgroundColor: SOURCE_COLORS[row.source] ?? '#94a3b8' }}
-                    />
-                    <span className="flex-1 truncate">{SOURCE_LABELS[row.source] ?? row.source}</span>
-                    <span className="tabular-nums text-muted-foreground">{row.plays}</span>
-                    <span className="tabular-nums text-xs text-muted-foreground w-12 text-right">
-                      {pct.toFixed(1)}%
-                    </span>
+                  <li
+                    key={row.source}
+                    className={cn(
+                      'rounded-lg border bg-card/50 px-3 py-2.5 transition-colors',
+                      isTop && 'ring-1 ring-primary/20',
+                    )}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span
+                        aria-hidden
+                        className="size-2.5 rounded-full shrink-0"
+                        style={{ backgroundColor: color }}
+                      />
+                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                        {SOURCE_LABELS[row.source] ?? row.source}
+                      </span>
+                    </div>
+                    <div className="mt-1 flex items-baseline gap-2">
+                      <span className="text-xl font-semibold tabular-nums">
+                        {row.plays.toLocaleString()}
+                      </span>
+                      <span className="text-xs tabular-nums text-muted-foreground">
+                        {pct.toFixed(1)}%
+                      </span>
+                    </div>
                   </li>
                 );
               })}

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -157,24 +157,24 @@ export function AnalyticsDashboard({ period = '30d' }: AnalyticsDashboardProps) 
     <div className="space-y-6">
       <Tabs defaultValue="overview" className="w-full">
         <TabsList className="grid w-full grid-cols-5 h-auto">
-          <TabsTrigger value="overview" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
-            <LayoutDashboard className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+          <TabsTrigger value="overview" className="flex items-center justify-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <LayoutDashboard className="hidden sm:inline-block h-4 w-4 shrink-0" />
             Overview
           </TabsTrigger>
-          <TabsTrigger value="listening" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
-            <Headphones className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+          <TabsTrigger value="listening" className="flex items-center justify-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <Headphones className="hidden sm:inline-block h-4 w-4 shrink-0" />
             Listening
           </TabsTrigger>
-          <TabsTrigger value="quality" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
-            <Target className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+          <TabsTrigger value="quality" className="flex items-center justify-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <Target className="hidden sm:inline-block h-4 w-4 shrink-0" />
             Quality
           </TabsTrigger>
-          <TabsTrigger value="activity" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
-            <Activity className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+          <TabsTrigger value="activity" className="flex items-center justify-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <Activity className="hidden sm:inline-block h-4 w-4 shrink-0" />
             Activity
           </TabsTrigger>
-          <TabsTrigger value="discovery" className="flex items-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
-            <Compass className="h-3.5 w-3.5 sm:h-4 sm:w-4 shrink-0" />
+          <TabsTrigger value="discovery" className="flex items-center justify-center gap-1.5 py-2 px-1 sm:px-3 text-xs sm:text-sm">
+            <Compass className="hidden sm:inline-block h-4 w-4 shrink-0" />
             Discovery
           </TabsTrigger>
         </TabsList>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -481,6 +481,29 @@ interface TopSongRow {
   lastPlayedAt: string;
 }
 
+interface SourceCountRow {
+  source: string;
+  plays: number;
+}
+
+// Stable color per source. `unknown` is muted (gray) so the pre-instrumentation
+// backlog doesn't visually dominate while early data is sparse.
+const SOURCE_COLORS: Record<string, string> = {
+  ai_dj: '#8b5cf6',    // violet
+  manual: '#3b82f6',   // blue
+  radio: '#f59e0b',    // amber
+  autoplay: '#10b981', // emerald
+  unknown: '#94a3b8',  // slate
+};
+
+const SOURCE_LABELS: Record<string, string> = {
+  ai_dj: 'AI DJ',
+  manual: 'Manual',
+  radio: 'Radio',
+  autoplay: 'Autoplay',
+  unknown: 'Pre-tagged',
+};
+
 function periodToDateRange(period: '30d' | '90d' | '1y'): { from: string; to: string } {
   const days = period === '90d' ? 90 : period === '1y' ? 365 : 30;
   const to = new Date();
@@ -515,7 +538,21 @@ const ListeningTab = memo(function ListeningTab({ period }: { period: '30d' | '9
     staleTime: 5 * 60 * 1000,
   });
 
+  const bySource = useQuery({
+    queryKey: ['listening-history', 'by-source', period],
+    queryFn: async () => {
+      const params = new URLSearchParams({ from: range.from, to: range.to });
+      const res = await fetch(`/api/listening-history/by-source?${params}`);
+      if (!res.ok) throw new Error('Failed to fetch source breakdown');
+      const json = await res.json() as { success: boolean; data: SourceCountRow[] };
+      return json.data;
+    },
+    staleTime: 5 * 60 * 1000,
+  });
+
   return (
+    <div className="space-y-4">
+      <SourceBreakdownCard query={bySource} />
     <div className="grid gap-4 md:grid-cols-2">
       <Card>
         <CardHeader>
@@ -592,6 +629,94 @@ const ListeningTab = memo(function ListeningTab({ period }: { period: '30d' | '9
         </CardContent>
       </Card>
     </div>
+    </div>
+  );
+});
+
+const SourceBreakdownCard = memo(function SourceBreakdownCard({
+  query,
+}: {
+  query: { isLoading: boolean; error: unknown; data: SourceCountRow[] | undefined };
+}) {
+  const { rows, chartData, total } = useMemo(() => {
+    const data = query.data ?? [];
+    const sum = data.reduce((acc, r) => acc + r.plays, 0);
+    const shaped = data.map((r) => ({
+      name: SOURCE_LABELS[r.source] ?? r.source,
+      value: r.plays,
+      source: r.source,
+    }));
+    return { rows: data, chartData: shaped, total: sum };
+  }, [query.data]);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Plays by Source</CardTitle>
+        <CardDescription>
+          Where your plays came from. AI DJ, manual picks, radio, and autoplay are
+          tagged from instrumentation rollout onward; older plays show as "Pre-tagged".
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {query.isLoading ? (
+          <Skeleton className="h-56 w-full" />
+        ) : query.error ? (
+          <p className="text-sm text-destructive">Failed to load.</p>
+        ) : rows.length === 0 ? (
+          <p className="text-sm text-muted-foreground">No listening history in this period.</p>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-[1fr_1fr] items-center">
+            <ResponsiveContainer width="100%" height={220}>
+              <PieChart>
+                <Pie
+                  data={chartData}
+                  cx="50%"
+                  cy="50%"
+                  innerRadius={50}
+                  outerRadius={85}
+                  paddingAngle={2}
+                  dataKey="value"
+                  nameKey="name"
+                >
+                  {chartData.map((entry) => (
+                    <Cell
+                      key={entry.source}
+                      fill={SOURCE_COLORS[entry.source] ?? '#94a3b8'}
+                    />
+                  ))}
+                </Pie>
+                <Tooltip
+                  formatter={(value: number, name) => {
+                    const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
+                    return [`${value} plays (${pct}%)`, name];
+                  }}
+                />
+              </PieChart>
+            </ResponsiveContainer>
+            <ul className="space-y-2 text-sm">
+              {rows.map((row) => {
+                const pct = total > 0 ? (row.plays / total) * 100 : 0;
+                return (
+                  <li key={row.source} className="flex items-baseline gap-3">
+                    <span
+                      aria-hidden
+                      className="inline-block size-3 rounded-sm shrink-0"
+                      style={{ backgroundColor: SOURCE_COLORS[row.source] ?? '#94a3b8' }}
+                    />
+                    <span className="flex-1 truncate">{SOURCE_LABELS[row.source] ?? row.source}</span>
+                    <span className="tabular-nums text-muted-foreground">{row.plays}</span>
+                    <span className="tabular-nums text-xs text-muted-foreground w-12 text-right">
+                      {pct.toFixed(1)}%
+                    </span>
+                  </li>
+                );
+              })}
+            </ul>
+          </div>
+        )}
+      </CardContent>
+    </Card>
   );
 });
 

--- a/src/lib/services/__tests__/listening-history.test.ts
+++ b/src/lib/services/__tests__/listening-history.test.ts
@@ -38,6 +38,7 @@ import {
   getRecentListeningHistory,
   getUniqueSongsPlayed,
   getCachedSimilarTracks,
+  getPlayCountsBySource,
   COMPLETION_THRESHOLD,
   MAX_SIMILAR_TRACKS_PER_SONG,
 } from '../listening-history';
@@ -203,6 +204,54 @@ describe('Listening History Service', () => {
 
       expect(songs).toHaveLength(2);
       expect(songs[0].playCount).toBe(5);
+    });
+  });
+
+  describe('getPlayCountsBySource', () => {
+    it('returns rows grouped by source, sorted by plays desc', async () => {
+      const mockResults = [
+        { source: null, plays: 12673 },
+        { source: 'radio', plays: 30 },
+        { source: 'manual', plays: 5 },
+      ];
+
+      (db.select as Mock).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue(mockResults),
+            }),
+          }),
+        }),
+      });
+
+      const start = new Date('2026-04-01');
+      const end = new Date('2026-05-01');
+      const result = await getPlayCountsBySource('user-123', start, end);
+
+      expect(result).toEqual([
+        { source: 'unknown', plays: 12673 },
+        { source: 'radio', plays: 30 },
+        { source: 'manual', plays: 5 },
+      ]);
+    });
+
+    it('returns an empty array when no plays exist', async () => {
+      (db.select as Mock).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockReturnValue({
+            groupBy: vi.fn().mockReturnValue({
+              orderBy: vi.fn().mockResolvedValue([]),
+            }),
+          }),
+        }),
+      });
+
+      const start = new Date('2026-04-01');
+      const end = new Date('2026-05-01');
+      const result = await getPlayCountsBySource('user-123', start, end);
+
+      expect(result).toEqual([]);
     });
   });
 

--- a/src/lib/services/listening-history.ts
+++ b/src/lib/services/listening-history.ts
@@ -784,6 +784,38 @@ export async function getTopPlayedSongs(
   return results;
 }
 
+/**
+ * Play counts grouped by `source` column for the period.
+ *
+ * Rows with a null `source` (pre-instrumentation plays) are bucketed as
+ * `"unknown"` so callers always get a complete picture. Order is by count
+ * desc so the largest wedge is first.
+ */
+export async function getPlayCountsBySource(
+  userId: string,
+  start: Date,
+  end: Date,
+): Promise<Array<{ source: string; plays: number }>> {
+  const results = await db
+    .select({
+      source: sql<string | null>`${listeningHistory.source}`,
+      plays: sql<number>`count(*)::int`,
+    })
+    .from(listeningHistory)
+    .where(and(
+      eq(listeningHistory.userId, userId),
+      gte(listeningHistory.playedAt, start),
+      lte(listeningHistory.playedAt, end),
+    ))
+    .groupBy(listeningHistory.source)
+    .orderBy(desc(sql`count(*)`));
+
+  return results.map((r) => ({
+    source: r.source ?? 'unknown',
+    plays: r.plays,
+  }));
+}
+
 // ============================================================================
 // Exports for Testing
 // ============================================================================

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -105,6 +105,7 @@ import { Route as ApiListeningHistoryRecentRouteImport } from './routes/api/list
 import { Route as ApiListeningHistoryInterestOverTimeRouteImport } from './routes/api/listening-history/interest-over-time'
 import { Route as ApiListeningHistoryFullRouteImport } from './routes/api/listening-history/full'
 import { Route as ApiListeningHistoryCompoundScoresRouteImport } from './routes/api/listening-history/compound-scores'
+import { Route as ApiListeningHistoryBySourceRouteImport } from './routes/api/listening-history/by-source'
 import { Route as ApiListeningHistoryByHourRouteImport } from './routes/api/listening-history/by-hour'
 import { Route as ApiListeningHistoryAlbumAgesRouteImport } from './routes/api/listening-history/album-ages'
 import { Route as ApiLidarrUnmonitorRouteImport } from './routes/api/lidarr/unmonitor'
@@ -691,6 +692,12 @@ const ApiListeningHistoryCompoundScoresRoute =
     path: '/api/listening-history/compound-scores',
     getParentRoute: () => rootRouteImport,
   } as any)
+const ApiListeningHistoryBySourceRoute =
+  ApiListeningHistoryBySourceRouteImport.update({
+    id: '/api/listening-history/by-source',
+    path: '/api/listening-history/by-source',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiListeningHistoryByHourRoute =
   ApiListeningHistoryByHourRouteImport.update({
     id: '/api/listening-history/by-hour',
@@ -1228,6 +1235,7 @@ export interface FileRoutesByFullPath {
   '/api/lidarr/unmonitor': typeof ApiLidarrUnmonitorRoute
   '/api/listening-history/album-ages': typeof ApiListeningHistoryAlbumAgesRoute
   '/api/listening-history/by-hour': typeof ApiListeningHistoryByHourRoute
+  '/api/listening-history/by-source': typeof ApiListeningHistoryBySourceRoute
   '/api/listening-history/compound-scores': typeof ApiListeningHistoryCompoundScoresRoute
   '/api/listening-history/full': typeof ApiListeningHistoryFullRoute
   '/api/listening-history/interest-over-time': typeof ApiListeningHistoryInterestOverTimeRoute
@@ -1407,6 +1415,7 @@ export interface FileRoutesByTo {
   '/api/lidarr/unmonitor': typeof ApiLidarrUnmonitorRoute
   '/api/listening-history/album-ages': typeof ApiListeningHistoryAlbumAgesRoute
   '/api/listening-history/by-hour': typeof ApiListeningHistoryByHourRoute
+  '/api/listening-history/by-source': typeof ApiListeningHistoryBySourceRoute
   '/api/listening-history/compound-scores': typeof ApiListeningHistoryCompoundScoresRoute
   '/api/listening-history/full': typeof ApiListeningHistoryFullRoute
   '/api/listening-history/interest-over-time': typeof ApiListeningHistoryInterestOverTimeRoute
@@ -1590,6 +1599,7 @@ export interface FileRoutesById {
   '/api/lidarr/unmonitor': typeof ApiLidarrUnmonitorRoute
   '/api/listening-history/album-ages': typeof ApiListeningHistoryAlbumAgesRoute
   '/api/listening-history/by-hour': typeof ApiListeningHistoryByHourRoute
+  '/api/listening-history/by-source': typeof ApiListeningHistoryBySourceRoute
   '/api/listening-history/compound-scores': typeof ApiListeningHistoryCompoundScoresRoute
   '/api/listening-history/full': typeof ApiListeningHistoryFullRoute
   '/api/listening-history/interest-over-time': typeof ApiListeningHistoryInterestOverTimeRoute
@@ -1773,6 +1783,7 @@ export interface FileRouteTypes {
     | '/api/lidarr/unmonitor'
     | '/api/listening-history/album-ages'
     | '/api/listening-history/by-hour'
+    | '/api/listening-history/by-source'
     | '/api/listening-history/compound-scores'
     | '/api/listening-history/full'
     | '/api/listening-history/interest-over-time'
@@ -1952,6 +1963,7 @@ export interface FileRouteTypes {
     | '/api/lidarr/unmonitor'
     | '/api/listening-history/album-ages'
     | '/api/listening-history/by-hour'
+    | '/api/listening-history/by-source'
     | '/api/listening-history/compound-scores'
     | '/api/listening-history/full'
     | '/api/listening-history/interest-over-time'
@@ -2134,6 +2146,7 @@ export interface FileRouteTypes {
     | '/api/lidarr/unmonitor'
     | '/api/listening-history/album-ages'
     | '/api/listening-history/by-hour'
+    | '/api/listening-history/by-source'
     | '/api/listening-history/compound-scores'
     | '/api/listening-history/full'
     | '/api/listening-history/interest-over-time'
@@ -2305,6 +2318,7 @@ export interface RootRouteChildren {
   ApiLidarrUnmonitorRoute: typeof ApiLidarrUnmonitorRoute
   ApiListeningHistoryAlbumAgesRoute: typeof ApiListeningHistoryAlbumAgesRoute
   ApiListeningHistoryByHourRoute: typeof ApiListeningHistoryByHourRoute
+  ApiListeningHistoryBySourceRoute: typeof ApiListeningHistoryBySourceRoute
   ApiListeningHistoryCompoundScoresRoute: typeof ApiListeningHistoryCompoundScoresRoute
   ApiListeningHistoryFullRoute: typeof ApiListeningHistoryFullRoute
   ApiListeningHistoryInterestOverTimeRoute: typeof ApiListeningHistoryInterestOverTimeRoute
@@ -3047,6 +3061,13 @@ declare module '@tanstack/react-router' {
       path: '/api/listening-history/compound-scores'
       fullPath: '/api/listening-history/compound-scores'
       preLoaderRoute: typeof ApiListeningHistoryCompoundScoresRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/listening-history/by-source': {
+      id: '/api/listening-history/by-source'
+      path: '/api/listening-history/by-source'
+      fullPath: '/api/listening-history/by-source'
+      preLoaderRoute: typeof ApiListeningHistoryBySourceRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/listening-history/by-hour': {
@@ -3895,6 +3916,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiLidarrUnmonitorRoute: ApiLidarrUnmonitorRoute,
   ApiListeningHistoryAlbumAgesRoute: ApiListeningHistoryAlbumAgesRoute,
   ApiListeningHistoryByHourRoute: ApiListeningHistoryByHourRoute,
+  ApiListeningHistoryBySourceRoute: ApiListeningHistoryBySourceRoute,
   ApiListeningHistoryCompoundScoresRoute:
     ApiListeningHistoryCompoundScoresRoute,
   ApiListeningHistoryFullRoute: ApiListeningHistoryFullRoute,

--- a/src/routes/api/listening-history/by-source.ts
+++ b/src/routes/api/listening-history/by-source.ts
@@ -1,0 +1,61 @@
+/**
+ * Play Counts By Source API
+ *
+ * GET /api/listening-history/by-source
+ *
+ * Query params:
+ *   preset:  'week' | 'month' | 'year'  (default 'month')
+ *   from:    ISO date  (optional, overrides preset)
+ *   to:      ISO date  (optional, overrides preset)
+ *
+ * Returns: { success, preset, data: [{ source, plays }] }
+ *
+ * Drives the source breakdown pie chart on the Analytics → Listening tab.
+ */
+
+import { createFileRoute } from '@tanstack/react-router';
+import { auth } from '../../../lib/auth/auth';
+import { getPlayCountsBySource } from '../../../lib/services/listening-history';
+import { getPresetRange } from '../../../lib/utils/period-comparison';
+
+export const Route = createFileRoute('/api/listening-history/by-source')({
+  server: {
+    handlers: {
+      GET: async ({ request }) => {
+        try {
+          const session = await auth.api.getSession({
+            headers: request.headers,
+            query: { disableCookieCache: true },
+          });
+          if (!session?.user?.id) {
+            return new Response(JSON.stringify({ error: 'Unauthorized' }), {
+              status: 401,
+              headers: { 'Content-Type': 'application/json' },
+            });
+          }
+
+          const url = new URL(request.url);
+          const fromParam = url.searchParams.get('from');
+          const toParam = url.searchParams.get('to');
+          const preset = (url.searchParams.get('preset') || 'month') as 'week' | 'month' | 'year';
+
+          const range = fromParam && toParam
+            ? { start: new Date(fromParam), end: new Date(toParam) }
+            : getPresetRange(preset);
+          const data = await getPlayCountsBySource(session.user.id, range.start, range.end);
+
+          return new Response(
+            JSON.stringify({ success: true, preset, data }),
+            { status: 200, headers: { 'Content-Type': 'application/json' } },
+          );
+        } catch (error) {
+          console.error('Error getting play counts by source:', error);
+          return new Response(
+            JSON.stringify({ error: error instanceof Error ? error.message : 'Internal server error' }),
+            { status: 500, headers: { 'Content-Type': 'application/json' } },
+          );
+        }
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- Adds `getPlayCountsBySource(userId, start, end)` aggregating `listening_history.source`, with null bucketed as `unknown`.
- New `GET /api/listening-history/by-source` route mirroring the top-artists pattern.
- New donut chart on Analytics → Listening tab with color-coded AI DJ / Manual / Radio / Autoplay / Pre-tagged slices, with a legend showing counts and percentages.
- Test coverage for the aggregation (happy path + empty result).
- Bundles the prior research docs that informed the broader roadmap (lastfm-genre-recap brief + findings).

PR 3 of the Listening Analytics Overhaul. Prod source distribution today is 12,673 null / 30 radio / 5 manual — the chart will be 99.7% "Pre-tagged" until more data accumulates, which is expected and called out in the card description.

## Test plan
- [ ] Analytics → Listening tab loads without error
- [ ] Donut chart shows a single big "Pre-tagged" wedge (current prod data)
- [ ] Switching period (30d / 90d / 1y) refetches and updates the chart
- [ ] After a few new plays, AI DJ / Radio / Manual wedges appear with correct colors
- [ ] Hover shows `{N} plays ({P}%)` with the source label
- [ ] Mobile layout: chart and legend stack cleanly