### PR TITLE
style(analytics): Align main dashboard with Discovery analytics visual language (B)

### DIFF
--- a/playwright.screenshots.config.ts
+++ b/playwright.screenshots.config.ts
@@ -1,0 +1,44 @@
+/**
+ * Standalone Playwright config for ad-hoc screenshot runs against the deployed
+ * site. Differs from the main config: testDir points at tests/screenshots,
+ * no webServer (we hit a real URL), no retries (one-shot).
+ */
+import { defineConfig, devices } from '@playwright/test';
+
+const BASE = process.env.SCREENSHOT_BASE_URL ?? 'https://aidj.appahouse.com';
+
+export default defineConfig({
+  testDir: './tests/screenshots',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: [['list']],
+  use: {
+    baseURL: BASE,
+    trace: 'retain-on-failure',
+    screenshot: 'on',
+    storageState: 'tests/.auth/juan.json',
+  },
+  projects: [
+    {
+      name: 'chromium-headless',
+      use: { ...devices['Desktop Chrome'], headless: true },
+    },
+    {
+      name: 'mobile',
+      // Pixel 5 is chromium-based; iPhone 13 needs webkit which isn't
+      // installed on this host. Same ~390px viewport for the layout check.
+      use: { ...devices['Pixel 5'] },
+    },
+    {
+      name: 'fullhd',
+      use: { ...devices['Desktop Chrome'], viewport: { width: 1920, height: 1080 } },
+    },
+    {
+      name: '4k',
+      // True 4K is 3840x2160. Most browsers handle that fine; sanity-check
+      // for content that gets stranded in whitespace at extreme widths.
+      use: { ...devices['Desktop Chrome'], viewport: { width: 3840, height: 2160 } },
+    },
+  ],
+});

--- a/src/components/landing/HeroSection.tsx
+++ b/src/components/landing/HeroSection.tsx
@@ -23,9 +23,22 @@ export default function HeroSection() {
           />
         </div>
 
-        {/* Brand name */}
-        <h1 className="text-6xl sm:text-7xl lg:text-8xl font-bold tracking-tight mb-4 animate-fade-up">
-          <span className="text-gradient-brand">AIDJ</span>
+        {/* Eyebrow tagline — Syne 700 uppercase 0.32em, the small mark above
+            the wordmark, per the design system's brand-mark spec. */}
+        <p
+          className="font-accent text-xs sm:text-sm font-bold uppercase text-muted-foreground mb-3 animate-fade-up"
+          style={{ letterSpacing: '0.32em' }}
+        >
+          Command center · by appahouse
+        </p>
+
+        {/* Brand wordmark — Unbounded weight 900 for "AI" (wide geometric,
+            rave-flyer feel), Syne italic 800 for "DJ" (off-axis accent). */}
+        <h1 className="text-6xl sm:text-7xl lg:text-8xl mb-4 animate-fade-up leading-none">
+          <span className="text-gradient-brand">
+            <span className="font-brand font-black tracking-[-0.045em]">AI</span>
+            <span className="font-accent font-extrabold italic">DJ</span>
+          </span>
         </h1>
 
         {/* Tagline */}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -299,6 +299,9 @@ function LeftSidebar() {
   const [isSyncingLiked, setIsSyncingLiked] = useState(false);
   const { data: session } = authClient.useSession();
   const isAdmin = session?.user?.role === 'admin';
+  // DS rule: vinyl-disc icon spins when audio is playing. The sidebar's brand
+  // mark is the most visible Disc3 in the app — wire its spin to playback.
+  const isAudioPlaying = useAudioStore((s) => s.isPlaying);
 
   // Sidebar collapsed state with localStorage persistence
   const [isCollapsed, setIsCollapsed] = useState(() => {
@@ -378,7 +381,7 @@ function LeftSidebar() {
         {!isCollapsed && (
           <Link to="/dashboard" className="flex items-center gap-2 group">
             <div className="p-1.5 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
-              <Disc3 className="h-5 w-5 text-primary" />
+              <Disc3 className={cn('h-5 w-5 text-primary', isAudioPlaying && 'animate-spin-slow')} />
             </div>
             {/* Brand wordmark: Unbounded weight 900 for "AI" (wide geometric,
                 rave-flyer feel), Syne italic 800 for "DJ" (off-axis accent). */}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -380,7 +380,12 @@ function LeftSidebar() {
             <div className="p-1.5 rounded-lg bg-primary/10 group-hover:bg-primary/20 transition-colors">
               <Disc3 className="h-5 w-5 text-primary" />
             </div>
-            <span className="font-bold text-lg tracking-tight">AIDJ</span>
+            {/* Brand wordmark: Unbounded weight 900 for "AI" (wide geometric,
+                rave-flyer feel), Syne italic 800 for "DJ" (off-axis accent). */}
+            <span className="text-lg leading-none">
+              <span className="font-brand font-black tracking-[-0.045em]">AI</span>
+              <span className="font-accent font-extrabold italic">DJ</span>
+            </span>
           </Link>
         )}
         <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -870,7 +870,7 @@ export function PlayerBar() {
             {/* Song Info */}
             <div className="min-w-0 flex-1">
               <p
-                className={cn("font-medium text-sm truncate active:text-primary transition-colors", showRemoteTime && "text-green-500")}
+                className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors", showRemoteTime && "text-green-500")}
                 onClick={() => setShowFullscreen(true)}
               >
                 {currentSong.name || currentSong.title}
@@ -980,7 +980,7 @@ export function PlayerBar() {
             />
           </div>
           <div className="min-w-0">
-            <p className={cn("font-medium truncate text-sm", showRemoteTime && "text-green-500")}>{currentSong.name || currentSong.title}</p>
+            <p className={cn("font-display font-semibold truncate text-sm", showRemoteTime && "text-green-500")}>{currentSong.name || currentSong.title}</p>
             {(currentSong as { artistId?: string }).artistId ? (
               <Link
                 to="/library/artists/$id"

--- a/src/components/music-identity/AlbumAgeChart.tsx
+++ b/src/components/music-identity/AlbumAgeChart.tsx
@@ -161,7 +161,7 @@ export const AlbumAgeChart = memo(function AlbumAgeChart({
                   if (!active || !payload?.[0]) return null;
                   const d = payload[0].payload;
                   return (
-                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-lg">
                       <p className="font-medium">{d.decade}</p>
                       <p className="text-muted-foreground">{d.plays} plays</p>
                     </div>

--- a/src/components/music-identity/AlbumAgeChart.tsx
+++ b/src/components/music-identity/AlbumAgeChart.tsx
@@ -161,7 +161,7 @@ export const AlbumAgeChart = memo(function AlbumAgeChart({
                   if (!active || !payload?.[0]) return null;
                   const d = payload[0].payload;
                   return (
-                    <div className="rounded-lg border bg-background/95 backdrop-blur-sm px-3 py-2 shadow-md text-sm">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
                       <p className="font-medium">{d.decade}</p>
                       <p className="text-muted-foreground">{d.plays} plays</p>
                     </div>

--- a/src/components/music-identity/InterestOverTimeChart.tsx
+++ b/src/components/music-identity/InterestOverTimeChart.tsx
@@ -187,7 +187,7 @@ export const InterestOverTimeChart = memo(function InterestOverTimeChart({
                 content={({ active, payload, label }) => {
                   if (!active || !payload?.length) return null;
                   return (
-                    <div className="rounded-lg border bg-background/95 backdrop-blur-sm px-3 py-2 shadow-md text-sm">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
                       <p className="font-medium mb-1">{formatMonth(label as string)}</p>
                       {payload.map(p => (
                         <div key={p.name} className="flex items-center gap-2">

--- a/src/components/music-identity/InterestOverTimeChart.tsx
+++ b/src/components/music-identity/InterestOverTimeChart.tsx
@@ -187,7 +187,7 @@ export const InterestOverTimeChart = memo(function InterestOverTimeChart({
                 content={({ active, payload, label }) => {
                   if (!active || !payload?.length) return null;
                   return (
-                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-lg">
                       <p className="font-medium mb-1">{formatMonth(label as string)}</p>
                       {payload.map(p => (
                         <div key={p.name} className="flex items-center gap-2">

--- a/src/components/music-identity/ListeningHourChart.tsx
+++ b/src/components/music-identity/ListeningHourChart.tsx
@@ -195,7 +195,7 @@ export const ListeningHourChart = memo(function ListeningHourChart({
                   if (!active || !payload?.[0]) return null;
                   const d = payload[0].payload;
                   return (
-                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-lg">
                       <p className="font-medium">{formatHour(d.hour)} - {d.timeOfDay}</p>
                       <p className="text-muted-foreground">{d.plays} plays</p>
                     </div>

--- a/src/components/music-identity/ListeningHourChart.tsx
+++ b/src/components/music-identity/ListeningHourChart.tsx
@@ -195,7 +195,7 @@ export const ListeningHourChart = memo(function ListeningHourChart({
                   if (!active || !payload?.[0]) return null;
                   const d = payload[0].payload;
                   return (
-                    <div className="rounded-lg border bg-background/95 backdrop-blur-sm px-3 py-2 shadow-md text-sm">
+                    <div className="rounded-lg border border-border bg-popover text-popover-foreground px-3 py-2 text-sm shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
                       <p className="font-medium">{formatHour(d.hour)} - {d.timeOfDay}</p>
                       <p className="text-muted-foreground">{d.plays} plays</p>
                     </div>

--- a/src/components/music-identity/MoodProfileChart.tsx
+++ b/src/components/music-identity/MoodProfileChart.tsx
@@ -14,7 +14,7 @@ import {
   Tooltip,
 } from 'recharts';
 import { Heart, Sun, Moon, CloudRain, Zap, Music2, Focus, Flame } from 'lucide-react';
-import { chartTooltipContentStyle, chartTooltipLabelStyle } from '@/components/recommendations/chart-theme';
+import { chartTooltipContentStyle, chartTooltipLabelStyle, chartTooltipItemStyle } from '@/components/recommendations/chart-theme';
 import type { MoodProfile } from '@/lib/db/schema/music-identity.schema';
 
 // ============================================================================
@@ -190,6 +190,7 @@ export const MoodProfileChart = memo(function MoodProfileChart({
                   formatter={(value: number) => `${value}%`}
                   contentStyle={chartTooltipContentStyle}
                   labelStyle={chartTooltipLabelStyle}
+                  itemStyle={chartTooltipItemStyle}
                 />
               </PieChart>
             </ResponsiveContainer>

--- a/src/components/music-identity/MoodProfileChart.tsx
+++ b/src/components/music-identity/MoodProfileChart.tsx
@@ -14,6 +14,7 @@ import {
   Tooltip,
 } from 'recharts';
 import { Heart, Sun, Moon, CloudRain, Zap, Music2, Focus, Flame } from 'lucide-react';
+import { chartTooltipContentStyle, chartTooltipLabelStyle } from '@/components/recommendations/chart-theme';
 import type { MoodProfile } from '@/lib/db/schema/music-identity.schema';
 
 // ============================================================================
@@ -187,11 +188,8 @@ export const MoodProfileChart = memo(function MoodProfileChart({
                 </Pie>
                 <Tooltip
                   formatter={(value: number) => `${value}%`}
-                  contentStyle={{
-                    backgroundColor: 'hsl(var(--background))',
-                    border: '1px solid hsl(var(--border))',
-                    borderRadius: '8px',
-                  }}
+                  contentStyle={chartTooltipContentStyle}
+                  labelStyle={chartTooltipLabelStyle}
                 />
               </PieChart>
             </ResponsiveContainer>

--- a/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
+++ b/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
@@ -36,6 +36,7 @@ import {
   chartBarCursor,
   chartLineCursor,
 } from './chart-theme';
+import { StatCard, type MetricTrend } from './StatCard';
 import {
   TrendingUp,
   TrendingDown,
@@ -49,8 +50,6 @@ import {
   Calendar,
   Sparkles,
   Target,
-  ArrowUpRight,
-  ArrowDownRight,
 } from 'lucide-react';
 
 // ============================================================================
@@ -350,99 +349,43 @@ const SummaryCards = memo(function SummaryCards({
 }: {
   summary: NonNullable<DiscoveryAnalyticsResponse['metrics']['summary']>;
 }) {
-  const trendIcon = (change: number) => {
-    if (change > 0) return <TrendingUp className="h-3 w-3 sm:h-4 sm:w-4 text-success" />;
-    if (change < 0) return <TrendingDown className="h-3 w-3 sm:h-4 sm:w-4 text-danger" />;
-    return <Minus className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground" />;
-  };
+  const weekTrend: MetricTrend =
+    summary.weekOverWeekChange > 0 ? 'up'
+    : summary.weekOverWeekChange < 0 ? 'down'
+    : 'flat';
+  const monthTrend: MetricTrend =
+    summary.monthOverMonthChange > 0 ? 'up'
+    : summary.monthOverMonthChange < 0 ? 'down'
+    : 'flat';
 
   return (
-    <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
-      <Card>
-        <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-          <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
-            <BarChart3 className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">Feedback</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-          <div className="text-lg sm:text-2xl font-bold">{summary.totalFeedback}</div>
-          <p className="text-[10px] sm:text-xs text-muted-foreground">
-            Feedback events
-          </p>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-          <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
-            <Target className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">Accept Rate</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-          <div className="text-lg sm:text-2xl font-bold">
-            {(summary.overallAcceptanceRate * 100).toFixed(1)}%
-          </div>
-          <div className="flex items-center gap-1 text-[10px] sm:text-xs">
-            {trendIcon(summary.weekOverWeekChange)}
-            <span
-              className={
-                summary.weekOverWeekChange > 0
-                  ? 'text-success'
-                  : summary.weekOverWeekChange < 0
-                    ? 'text-danger'
-                    : 'text-muted-foreground'
-              }
-            >
-              {summary.weekOverWeekChange > 0 ? '+' : ''}
-              {summary.weekOverWeekChange.toFixed(1)}%
-            </span>
-          </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-          <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
-            <Sparkles className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">Discovery</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-          <div className="text-lg sm:text-2xl font-bold">
-            {summary.discoveryScore.toFixed(0)}
-          </div>
-          <Progress value={summary.discoveryScore} className="mt-1 sm:mt-2 h-1.5 sm:h-2" />
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-          <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
-            <Calendar className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
-            <span className="truncate">Monthly</span>
-          </CardTitle>
-        </CardHeader>
-        <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-          <div className="flex items-center gap-1 sm:gap-2">
-            <div className="text-lg sm:text-2xl font-bold">
-              {summary.monthOverMonthChange > 0 ? '+' : ''}
-              {summary.monthOverMonthChange.toFixed(1)}%
-            </div>
-            {summary.monthOverMonthChange > 0 ? (
-              <ArrowUpRight className="h-4 w-4 sm:h-5 sm:w-5 text-success" />
-            ) : summary.monthOverMonthChange < 0 ? (
-              <ArrowDownRight className="h-4 w-4 sm:h-5 sm:w-5 text-danger" />
-            ) : (
-              <Minus className="h-4 w-4 sm:h-5 sm:w-5 text-muted-foreground" />
-            )}
-          </div>
-          <p className="text-[10px] sm:text-xs text-muted-foreground">
-            vs prev month
-          </p>
-        </CardContent>
-      </Card>
+    <div className="grid grid-cols-2 gap-2 sm:gap-4 xl:grid-cols-4">
+      <StatCard
+        icon={BarChart3}
+        label="Feedback"
+        value={summary.totalFeedback.toLocaleString()}
+        caption="Feedback events"
+      />
+      <StatCard
+        icon={Target}
+        label="Accept Rate"
+        value={`${(summary.overallAcceptanceRate * 100).toFixed(1)}%`}
+        trend={weekTrend}
+        trendValue={`${summary.weekOverWeekChange > 0 ? '+' : ''}${summary.weekOverWeekChange.toFixed(1)}% wk`}
+      />
+      <StatCard
+        icon={Sparkles}
+        label="Discovery"
+        value={summary.discoveryScore.toFixed(0)}
+        progress={summary.discoveryScore}
+      />
+      <StatCard
+        icon={Calendar}
+        label="Monthly"
+        value={`${summary.monthOverMonthChange > 0 ? '+' : ''}${summary.monthOverMonthChange.toFixed(1)}%`}
+        trend={monthTrend}
+        caption="vs prev month"
+      />
     </div>
   );
 });

--- a/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
+++ b/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
@@ -33,6 +33,7 @@ import { Progress } from '../ui/progress';
 import {
   chartTooltipContentStyle,
   chartTooltipLabelStyle,
+  chartTooltipItemStyle,
   chartBarCursor,
   chartLineCursor,
 } from './chart-theme';
@@ -469,6 +470,7 @@ const RecommendationModesTab = memo(function RecommendationModesTab({
                 }
                 contentStyle={chartTooltipContentStyle}
                 labelStyle={chartTooltipLabelStyle}
+                itemStyle={chartTooltipItemStyle}
               />
               <Bar
                 dataKey="share"
@@ -514,7 +516,7 @@ const RecommendationModesTab = memo(function RecommendationModesTab({
                   <Cell key={`cell-${index}`} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+              <Tooltip contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
             </PieChart>
           </ResponsiveContainer>
@@ -706,6 +708,7 @@ const TopContentTab = memo(function TopContentTab({
                   formatter={(v: number) => [`${v} songs`, 'Count']}
                   contentStyle={chartTooltipContentStyle}
                   labelStyle={chartTooltipLabelStyle}
+                  itemStyle={chartTooltipItemStyle}
                 />
                 <Bar dataKey="count" fill={COLORS.primary} name="Songs" radius={[0, 4, 4, 0]} />
               </BarChart>
@@ -804,7 +807,7 @@ const EngagementTab = memo(function EngagementTab({
                 tickFormatter={(v) => `${v}%`}
                 tick={{ fontSize: 10 }}
               />
-              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
               <Bar
                 yAxisId="left"
@@ -848,7 +851,7 @@ const EngagementTab = memo(function EngagementTab({
                 tickFormatter={(v) => `${v}%`}
                 tick={{ fontSize: 10 }}
               />
-              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
               <Line
                 yAxisId="left"

--- a/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
+++ b/src/components/recommendations/AdvancedDiscoveryAnalytics.tsx
@@ -31,6 +31,12 @@ import { Skeleton } from '../ui/skeleton';
 import { Badge } from '../ui/badge';
 import { Progress } from '../ui/progress';
 import {
+  chartTooltipContentStyle,
+  chartTooltipLabelStyle,
+  chartBarCursor,
+  chartLineCursor,
+} from './chart-theme';
+import {
   TrendingUp,
   TrendingDown,
   Minus,
@@ -514,15 +520,12 @@ const RecommendationModesTab = memo(function RecommendationModesTab({
               />
               <YAxis dataKey="name" type="category" width={70} tick={{ fontSize: 10 }} />
               <Tooltip
+                cursor={chartBarCursor}
                 formatter={(value: number, _name: string, props: { payload: { total: number } }) =>
                   [`${value.toFixed(1)}% (${props.payload.total} songs)`, 'Share']
                 }
-                labelStyle={{ color: 'var(--foreground)' }}
-                contentStyle={{
-                  backgroundColor: 'var(--background)',
-                  border: '1px solid var(--border)',
-                  fontSize: '12px',
-                }}
+                contentStyle={chartTooltipContentStyle}
+                labelStyle={chartTooltipLabelStyle}
               />
               <Bar
                 dataKey="share"
@@ -568,7 +571,7 @@ const RecommendationModesTab = memo(function RecommendationModesTab({
                   <Cell key={`cell-${index}`} fill={entry.color} />
                 ))}
               </Pie>
-              <Tooltip />
+              <Tooltip contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
             </PieChart>
           </ResponsiveContainer>
@@ -756,8 +759,10 @@ const TopContentTab = memo(function TopContentTab({
                 <XAxis type="number" tick={{ fontSize: 9 }} />
                 <YAxis type="category" dataKey="genre" tick={{ fontSize: 9 }} width={80} />
                 <Tooltip
+                  cursor={chartBarCursor}
                   formatter={(v: number) => [`${v} songs`, 'Count']}
-                  contentStyle={{ fontSize: '11px' }}
+                  contentStyle={chartTooltipContentStyle}
+                  labelStyle={chartTooltipLabelStyle}
                 />
                 <Bar dataKey="count" fill={COLORS.primary} name="Songs" radius={[0, 4, 4, 0]} />
               </BarChart>
@@ -856,7 +861,7 @@ const EngagementTab = memo(function EngagementTab({
                 tickFormatter={(v) => `${v}%`}
                 tick={{ fontSize: 10 }}
               />
-              <Tooltip contentStyle={{ fontSize: '12px' }} />
+              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
               <Bar
                 yAxisId="left"
@@ -900,7 +905,7 @@ const EngagementTab = memo(function EngagementTab({
                 tickFormatter={(v) => `${v}%`}
                 tick={{ fontSize: 10 }}
               />
-              <Tooltip contentStyle={{ fontSize: '12px' }} />
+              <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
               <Legend wrapperStyle={{ fontSize: '10px' }} />
               <Line
                 yAxisId="left"

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -29,6 +29,7 @@ import { cn } from '@/lib/utils';
 import {
   chartTooltipContentStyle,
   chartTooltipLabelStyle,
+  chartTooltipItemStyle,
   chartBarCursor,
   chartLineCursor,
   chartPalette,
@@ -349,7 +350,7 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
               <XAxis dataKey="period" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
               <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-              <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+              <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
               <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} iconType="circle" />
               <Bar dataKey="liked" fill={COLORS.success} name="Liked" radius={[4, 4, 0, 0]} />
               <Bar dataKey="disliked" fill={COLORS.danger} name="Disliked" radius={[4, 4, 0, 0]} />
@@ -459,7 +460,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
                 <XAxis dataKey="day" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-                <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+                <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
                 <Bar dataKey="count" fill={COLORS.primary} radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
@@ -477,7 +478,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
                 <XAxis dataKey="hour" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} interval={2} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-                <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
+                <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} itemStyle={chartTooltipItemStyle} />
                 <Line
                   type="monotone"
                   dataKey="count"
@@ -742,6 +743,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                     }}
                     contentStyle={chartTooltipContentStyle}
                     labelStyle={chartTooltipLabelStyle}
+                    itemStyle={chartTooltipItemStyle}
                   />
                 </PieChart>
               </ResponsiveContainer>
@@ -916,6 +918,7 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
               }}
               contentStyle={chartTooltipContentStyle}
               labelStyle={chartTooltipLabelStyle}
+              itemStyle={chartTooltipItemStyle}
             />
           </PieChart>
         </ResponsiveContainer>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -23,8 +23,8 @@ import {
   Cell,
 } from 'recharts';
 import { Skeleton } from '../ui/skeleton';
-import { Progress } from '../ui/progress';
-import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus, BarChart3, Sparkles, type LucideIcon } from 'lucide-react';
+import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus, BarChart3, Sparkles } from 'lucide-react';
+import { StatCard, type MetricTrend } from './StatCard';
 import { cn } from '@/lib/utils';
 import {
   chartTooltipContentStyle,
@@ -993,89 +993,6 @@ const TasteProfileCard = memo(function TasteProfileCard({ analytics }: { analyti
   );
 });
 
-type MetricTrend = 'up' | 'down' | 'flat';
-
-function trendVisual(trend?: MetricTrend) {
-  if (!trend) return null;
-  const Icon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus;
-  const klass =
-    trend === 'up' ? 'text-emerald-500'
-    : trend === 'down' ? 'text-destructive'
-    : 'text-muted-foreground';
-  return { Icon, klass };
-}
-
-/**
- * Compact stat card matching the visual language of AdvancedDiscoveryAnalytics:
- * icon-prefixed header, dense padding on mobile, value with optional inline
- * trend chip or progress bar.
- */
-const StatCard = memo(function StatCard({
-  icon: Icon,
-  label,
-  value,
-  caption,
-  trend,
-  trendValue,
-  progress,
-  gradient,
-  glow,
-}: {
-  icon: LucideIcon;
-  label: string;
-  value: string;
-  caption?: string;
-  trend?: MetricTrend;
-  /** Optional explicit delta string shown next to the trend icon, e.g. "+3.4%". */
-  trendValue?: string;
-  /** 0–100 progress bar shown under the value. */
-  progress?: number;
-  /** Render the value in the AIDJ brand gradient. Reserve for the
-   *  hero/featured stat in a row — overuse dilutes it. */
-  gradient?: boolean;
-  /** Apply the brand glow shadow. Same rule: hero stat only. */
-  glow?: boolean;
-}) {
-  const t = trendVisual(trend);
-  return (
-    <Card className={cn(glow && 'card-glow')}>
-      <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-        <CardTitle
-          // AIDJ eyebrow per design system: 11px, 0.12em tracking, weight 600,
-          // uppercase, muted. Tighter weight than the rest of the card titles
-          // so the BIG number reads as the primary mark.
-          className="flex items-center gap-1.5 sm:gap-2 eyebrow"
-        >
-          <Icon className="h-3 w-3 sm:h-4 sm:w-4 shrink-0" />
-          <span className="truncate">{label}</span>
-        </CardTitle>
-      </CardHeader>
-      <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-        <div
-          className={cn(
-            'font-display font-extrabold tabular-nums capitalize tracking-tight leading-none',
-            'text-2xl sm:text-3xl',
-            gradient && 'bg-[image:var(--gradient-brand)] bg-clip-text text-transparent',
-          )}
-        >
-          {value}
-        </div>
-        {t && (
-          <div className={cn('mt-1.5 flex items-center gap-1 font-mono text-[11px]', t.klass)}>
-            <t.Icon className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
-            <span>{trendValue ?? (trend === 'up' ? 'Improving' : trend === 'down' ? 'Declining' : 'Stable')}</span>
-          </div>
-        )}
-        {progress != null && (
-          <Progress value={progress} className="mt-2 h-1.5 sm:h-2" />
-        )}
-        {caption && (
-          <p className="mt-1.5 text-[11px] sm:text-xs text-muted-foreground">{caption}</p>
-        )}
-      </CardContent>
-    </Card>
-  );
-});
 
 const AnalyticsLoadingSkeleton = memo(function AnalyticsLoadingSkeleton() {
   return (

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -31,6 +31,9 @@ import {
   chartTooltipLabelStyle,
   chartBarCursor,
   chartLineCursor,
+  chartPalette,
+  chartMutedColor,
+  sourceColors,
 } from './chart-theme';
 
 // ============================================================================
@@ -107,7 +110,10 @@ const COLORS = {
   info: '#3b82f6',
 };
 
-const PIE_COLORS = ['#8b5cf6', '#ec4899', '#10b981', '#f59e0b', '#3b82f6', '#06b6d4', '#84cc16'];
+// Use the AIDJ design-system chart palette (chart-1..5 CSS vars) so theme
+// switches repaint the charts. PIE_COLORS is kept as a name for back-compat
+// with existing callsites but routes through chartPalette.
+const PIE_COLORS = chartPalette;
 
 // ============================================================================
 // Components
@@ -236,6 +242,8 @@ function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
           icon={BarChart3}
           label="Feedback"
           value={analytics.profile.feedbackCount.total.toLocaleString()}
+          gradient
+          glow
           caption={
             analytics.profile.feedbackCount.librarySynced &&
             analytics.profile.feedbackCount.librarySynced > 0
@@ -512,15 +520,9 @@ interface SourceCountRow {
   plays: number;
 }
 
-// Stable color per source. `unknown` is muted (gray) so the pre-instrumentation
-// backlog doesn't visually dominate while early data is sparse.
-const SOURCE_COLORS: Record<string, string> = {
-  ai_dj: '#8b5cf6',    // violet
-  manual: '#3b82f6',   // blue
-  radio: '#f59e0b',    // amber
-  autoplay: '#10b981', // emerald
-  unknown: '#94a3b8',  // slate
-};
+// Pulled from chart-theme.ts so source colors track the AIDJ design-system
+// chart palette and stay consistent with theme switches.
+const SOURCE_COLORS = sourceColors;
 
 const SOURCE_LABELS: Record<string, string> = {
   ai_dj: 'AI DJ',
@@ -729,7 +731,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                     {chartData.map((entry) => (
                       <Cell
                         key={entry.source}
-                        fill={SOURCE_COLORS[entry.source] ?? '#94a3b8'}
+                        fill={SOURCE_COLORS[entry.source] ?? chartMutedColor}
                       />
                     ))}
                   </Pie>
@@ -743,9 +745,9 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                   />
                 </PieChart>
               </ResponsiveContainer>
-              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-                <span className="text-3xl font-semibold tabular-nums">{total.toLocaleString()}</span>
-                <span className="text-xs uppercase tracking-wide text-muted-foreground">Total plays</span>
+              <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1">
+                <span className="font-display text-3xl font-extrabold tabular-nums tracking-tight leading-none">{total.toLocaleString()}</span>
+                <span className="text-[10px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">Total plays</span>
               </div>
             </div>
 
@@ -753,7 +755,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
             <ul className="grid grid-cols-1 gap-2 sm:grid-cols-2 self-center">
               {rows.map((row) => {
                 const pct = total > 0 ? (row.plays / total) * 100 : 0;
-                const color = SOURCE_COLORS[row.source] ?? '#94a3b8';
+                const color = SOURCE_COLORS[row.source] ?? chartMutedColor;
                 const isTop = row === top;
                 return (
                   <li
@@ -769,15 +771,15 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                         className="size-2.5 rounded-full shrink-0"
                         style={{ backgroundColor: color }}
                       />
-                      <span className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+                      <span className="text-[11px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">
                         {SOURCE_LABELS[row.source] ?? row.source}
                       </span>
                     </div>
                     <div className="mt-1 flex items-baseline gap-2">
-                      <span className="text-xl font-semibold tabular-nums">
+                      <span className="font-display text-xl font-extrabold tabular-nums tracking-tight">
                         {row.plays.toLocaleString()}
                       </span>
-                      <span className="text-xs tabular-nums text-muted-foreground">
+                      <span className="font-mono text-[11px] tabular-nums text-muted-foreground">
                         {pct.toFixed(1)}%
                       </span>
                     </div>
@@ -917,9 +919,9 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
             />
           </PieChart>
         </ResponsiveContainer>
-        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center">
-          <span className="text-2xl font-semibold tabular-nums">{total.toLocaleString()}</span>
-          <span className="text-[10px] uppercase tracking-wide text-muted-foreground">Top {chartData.length}</span>
+        <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1">
+          <span className="font-display text-2xl font-extrabold tabular-nums tracking-tight leading-none">{total.toLocaleString()}</span>
+          <span className="text-[10px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">Top {chartData.length}</span>
         </div>
       </div>
       <ul className="space-y-1 self-center">
@@ -1016,6 +1018,8 @@ const StatCard = memo(function StatCard({
   trend,
   trendValue,
   progress,
+  gradient,
+  glow,
 }: {
   icon: LucideIcon;
   label: string;
@@ -1026,29 +1030,47 @@ const StatCard = memo(function StatCard({
   trendValue?: string;
   /** 0–100 progress bar shown under the value. */
   progress?: number;
+  /** Render the value in the AIDJ brand gradient. Reserve for the
+   *  hero/featured stat in a row — overuse dilutes it. */
+  gradient?: boolean;
+  /** Apply the brand glow shadow. Same rule: hero stat only. */
+  glow?: boolean;
 }) {
   const t = trendVisual(trend);
   return (
-    <Card>
+    <Card className={cn(glow && 'shadow-[var(--shadow-glow-sm)]')}>
       <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
-        <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
-          <Icon className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
+        <CardTitle
+          // AIDJ eyebrow per design system: 11px, 0.12em tracking, weight 600,
+          // uppercase, muted. Tighter weight than the rest of the card titles
+          // so the BIG number reads as the primary mark.
+          className="flex items-center gap-1.5 sm:gap-2 text-[11px] tracking-[0.12em] uppercase font-semibold text-muted-foreground"
+        >
+          <Icon className="h-3 w-3 sm:h-4 sm:w-4 shrink-0" />
           <span className="truncate">{label}</span>
         </CardTitle>
       </CardHeader>
       <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
-        <div className="text-lg sm:text-2xl font-bold tabular-nums capitalize">{value}</div>
+        <div
+          className={cn(
+            'font-display font-extrabold tabular-nums capitalize tracking-tight leading-none',
+            'text-2xl sm:text-3xl',
+            gradient && 'bg-[image:var(--gradient-brand)] bg-clip-text text-transparent',
+          )}
+        >
+          {value}
+        </div>
         {t && (
-          <div className={cn('mt-0.5 flex items-center gap-1 text-[10px] sm:text-xs', t.klass)}>
-            <t.Icon className="h-3 w-3 sm:h-4 sm:w-4" />
+          <div className={cn('mt-1.5 flex items-center gap-1 font-mono text-[11px]', t.klass)}>
+            <t.Icon className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
             <span>{trendValue ?? (trend === 'up' ? 'Improving' : trend === 'down' ? 'Declining' : 'Stable')}</span>
           </div>
         )}
         {progress != null && (
-          <Progress value={progress} className="mt-1 sm:mt-2 h-1.5 sm:h-2" />
+          <Progress value={progress} className="mt-2 h-1.5 sm:h-2" />
         )}
         {caption && (
-          <p className="mt-1 text-[10px] sm:text-xs text-muted-foreground">{caption}</p>
+          <p className="mt-1.5 text-[11px] sm:text-xs text-muted-foreground">{caption}</p>
         )}
       </CardContent>
     </Card>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -23,7 +23,8 @@ import {
   Cell,
 } from 'recharts';
 import { Skeleton } from '../ui/skeleton';
-import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus } from 'lucide-react';
+import { Progress } from '../ui/progress';
+import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus, BarChart3, Sparkles, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
 
 // ============================================================================
@@ -208,78 +209,79 @@ export function AnalyticsDashboard({ period = '30d' }: AnalyticsDashboardProps) 
 // ============================================================================
 
 function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
+  const acceptanceTrend: MetricTrend | undefined =
+    analytics.quality?.qualityTrend === 'improving' ? 'up'
+    : analytics.quality?.qualityTrend === 'declining' ? 'down'
+    : analytics.quality?.qualityTrend === 'stable' ? 'flat'
+    : undefined;
+
+  const diversityTrend: MetricTrend =
+    analytics.discovery?.diversityTrend === 'expanding' ? 'up'
+    : analytics.discovery?.diversityTrend === 'narrowing' ? 'down'
+    : 'flat';
+
+  const diversityScore = (analytics.discovery?.genreDiversityScore ?? 0) * 100;
+
   return (
-    <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-      {/* Stat cards */}
-      <Card>
-        <CardContent className="pt-6">
-          <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">Total Feedback</p>
-          <div className="mt-2 text-3xl font-semibold tabular-nums">
-            {analytics.profile.feedbackCount.total.toLocaleString()}
-          </div>
-          <p className="mt-1 text-xs text-muted-foreground">
-            <span className="font-medium text-emerald-500">{analytics.profile.feedbackCount.thumbsUp}</span> up
-            {' / '}
-            <span className="font-medium text-destructive">{analytics.profile.feedbackCount.thumbsDown}</span> down
-          </p>
-          {analytics.profile.feedbackCount.librarySynced !== undefined &&
-           analytics.profile.feedbackCount.librarySynced > 0 && (
-            <p className="text-[10px] text-muted-foreground mt-1">
-              + {analytics.profile.feedbackCount.librarySynced.toLocaleString()} library-synced (excluded)
-            </p>
-          )}
-        </CardContent>
-      </Card>
+    <div className="space-y-4">
+      {/* Compact 4-up stat row matching the Discovery analytics summary cards */}
+      <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
+        <StatCard
+          icon={BarChart3}
+          label="Feedback"
+          value={analytics.profile.feedbackCount.total.toLocaleString()}
+          caption={
+            analytics.profile.feedbackCount.librarySynced &&
+            analytics.profile.feedbackCount.librarySynced > 0
+              ? `${analytics.profile.feedbackCount.thumbsUp} up / ${analytics.profile.feedbackCount.thumbsDown} down (+${analytics.profile.feedbackCount.librarySynced.toLocaleString()} synced)`
+              : `${analytics.profile.feedbackCount.thumbsUp} up / ${analytics.profile.feedbackCount.thumbsDown} down`
+          }
+        />
+        <StatCard
+          icon={Target}
+          label="Accept Rate"
+          value={analytics.quality ? `${(analytics.quality.acceptanceRate * 100).toFixed(0)}%` : 'N/A'}
+          trend={acceptanceTrend}
+        />
+        <StatCard
+          icon={Sparkles}
+          label="New Artists"
+          value={(analytics.discovery?.newArtistsDiscovered || 0).toString()}
+          caption="In the selected period"
+          trend={diversityTrend}
+          trendValue={analytics.discovery?.diversityTrend ?? 'stable'}
+        />
+        <StatCard
+          icon={Compass}
+          label="Diversity"
+          value={`${diversityScore.toFixed(0)}%`}
+          progress={diversityScore}
+        />
+      </div>
 
-      <MetricCard
-        title="Acceptance Rate"
-        value={analytics.quality ? `${(analytics.quality.acceptanceRate * 100).toFixed(0)}%` : 'N/A'}
-        trend={
-          analytics.quality?.qualityTrend === 'improving' ? 'up'
-          : analytics.quality?.qualityTrend === 'declining' ? 'down'
-          : analytics.quality?.qualityTrend === 'stable' ? 'flat'
-          : undefined
-        }
-        description={
-          analytics.quality?.qualityTrend === 'improving' ? 'Improving'
-          : analytics.quality?.qualityTrend === 'declining' ? 'Declining'
-          : analytics.quality?.qualityTrend === 'stable' ? 'Stable'
-          : 'Not enough data'
-        }
-      />
+      <div className="grid gap-4 lg:grid-cols-3">
+        {/* Top Artists */}
+        <Card className="lg:col-span-2">
+          <CardHeader>
+            <CardTitle>Top Liked Artists</CardTitle>
+            <CardDescription>Artists you've thumbed up most on AI DJ recommendations</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TopArtistsChart artists={analytics.profile.likedArtists.slice(0, 10)} />
+          </CardContent>
+        </Card>
 
-      <MetricCard
-        title="New Artists"
-        value={(analytics.discovery?.newArtistsDiscovered || 0).toString()}
-        description={`Taste: ${analytics.discovery?.diversityTrend || 'stable'}`}
-        trend={
-          analytics.discovery?.diversityTrend === 'expanding' ? 'up'
-          : analytics.discovery?.diversityTrend === 'narrowing' ? 'down'
-          : 'flat'
-        }
-      />
-
-      {/* Top Artists */}
-      <Card className="md:col-span-2">
-        <CardHeader>
-          <CardTitle>Top Liked Artists</CardTitle>
-          <CardDescription>Artists you've thumbed up most on AI DJ recommendations</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <TopArtistsChart artists={analytics.profile.likedArtists.slice(0, 10)} />
-        </CardContent>
-      </Card>
-
-      {/* Taste Profile */}
-      <Card>
-        <CardHeader>
-          <CardTitle>Taste Profile</CardTitle>
-          <CardDescription>Your musical fingerprint</CardDescription>
-        </CardHeader>
-        <CardContent>
-          <TasteProfileCard analytics={analytics} />
-        </CardContent>
-      </Card>
+        {/* Taste Profile */}
+        <Card>
+          <CardHeader>
+            <CardTitle>Taste Profile</CardTitle>
+            <CardDescription>Your musical fingerprint</CardDescription>
+          </CardHeader>
+          <CardContent>
+            <TasteProfileCard analytics={analytics} />
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }
@@ -350,21 +352,23 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         </CardContent>
       </Card>
 
-      <div className="grid gap-4 md:grid-cols-3">
-        <MetricCard
-          title="Acceptance Rate"
+      <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-3">
+        <StatCard
+          icon={Target}
+          label="Acceptance Rate"
           value={`${(analytics.quality.acceptanceRate * 100).toFixed(1)}%`}
-          description={`${analytics.quality.thumbsUpCount} liked out of ${analytics.quality.totalRecommendations}`}
+          caption={`${analytics.quality.thumbsUpCount} liked of ${analytics.quality.totalRecommendations}`}
         />
-        <MetricCard
-          title="Quality Trend"
+        <StatCard
+          icon={TrendingUp}
+          label="Quality Trend"
           value={analytics.quality.qualityTrend}
           trend={
             analytics.quality.qualityTrend === 'improving' ? 'up'
             : analytics.quality.qualityTrend === 'declining' ? 'down'
             : 'flat'
           }
-          description={
+          caption={
             analytics.quality.qualityTrend === 'improving'
               ? 'Recommendations getting better'
               : analytics.quality.qualityTrend === 'declining'
@@ -372,10 +376,11 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
                 : 'Recommendations are consistent'
           }
         />
-        <MetricCard
-          title="Total Ratings"
-          value={analytics.quality.totalRecommendations.toString()}
-          description="Feedback events (a song may be rated more than once)"
+        <StatCard
+          icon={BarChart3}
+          label="Total Ratings"
+          value={analytics.quality.totalRecommendations.toLocaleString()}
+          caption="Feedback events"
         />
       </div>
     </div>
@@ -826,26 +831,29 @@ const DiscoveryTab = memo(function DiscoveryTab({ analytics }: { analytics: Enha
 
   return (
     <div className="grid gap-4">
-      <div className="grid gap-4 md:grid-cols-3">
-        <MetricCard
-          title="New Artists Discovered"
+      <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-3">
+        <StatCard
+          icon={Sparkles}
+          label="New Artists Discovered"
           value={analytics.discovery.newArtistsDiscovered.toString()}
-          description="In the selected period"
+          caption="In the selected period"
         />
-        <MetricCard
-          title="Diversity Score"
+        <StatCard
+          icon={Compass}
+          label="Diversity Score"
           value={`${(analytics.discovery.genreDiversityScore * 100).toFixed(0)}%`}
-          description="How varied your taste is"
+          progress={analytics.discovery.genreDiversityScore * 100}
         />
-        <MetricCard
-          title="Diversity Trend"
+        <StatCard
+          icon={TrendingUp}
+          label="Diversity Trend"
           value={analytics.discovery.diversityTrend}
           trend={
             analytics.discovery.diversityTrend === 'expanding' ? 'up'
             : analytics.discovery.diversityTrend === 'narrowing' ? 'down'
             : 'flat'
           }
-          description={
+          caption={
             analytics.discovery.diversityTrend === 'expanding'
               ? 'Exploring more variety'
               : analytics.discovery.diversityTrend === 'narrowing'
@@ -1011,31 +1019,63 @@ const TasteProfileCard = memo(function TasteProfileCard({ analytics }: { analyti
 
 type MetricTrend = 'up' | 'down' | 'flat';
 
-const MetricCard = memo(function MetricCard({
-  title,
-  value,
-  description,
-  trend,
-}: {
-  title: string;
-  value: string;
-  description: string;
-  trend?: MetricTrend;
-}) {
-  const TrendIcon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : trend === 'flat' ? Minus : null;
-  const trendClass =
+function trendVisual(trend?: MetricTrend) {
+  if (!trend) return null;
+  const Icon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus;
+  const klass =
     trend === 'up' ? 'text-emerald-500'
     : trend === 'down' ? 'text-destructive'
     : 'text-muted-foreground';
+  return { Icon, klass };
+}
+
+/**
+ * Compact stat card matching the visual language of AdvancedDiscoveryAnalytics:
+ * icon-prefixed header, dense padding on mobile, value with optional inline
+ * trend chip or progress bar.
+ */
+const StatCard = memo(function StatCard({
+  icon: Icon,
+  label,
+  value,
+  caption,
+  trend,
+  trendValue,
+  progress,
+}: {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  caption?: string;
+  trend?: MetricTrend;
+  /** Optional explicit delta string shown next to the trend icon, e.g. "+3.4%". */
+  trendValue?: string;
+  /** 0–100 progress bar shown under the value. */
+  progress?: number;
+}) {
+  const t = trendVisual(trend);
   return (
     <Card>
-      <CardContent className="pt-6">
-        <p className="text-xs font-medium uppercase tracking-wide text-muted-foreground">{title}</p>
-        <div className="mt-2 flex items-baseline gap-2">
-          <span className="text-3xl font-semibold tabular-nums capitalize">{value}</span>
-          {TrendIcon && <TrendIcon className={cn('size-4 self-center', trendClass)} />}
-        </div>
-        <p className="mt-1 text-xs text-muted-foreground">{description}</p>
+      <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
+        <CardTitle className="flex items-center gap-1.5 sm:gap-2 text-xs sm:text-sm font-medium">
+          <Icon className="h-3 w-3 sm:h-4 sm:w-4 text-muted-foreground shrink-0" />
+          <span className="truncate">{label}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
+        <div className="text-lg sm:text-2xl font-bold tabular-nums capitalize">{value}</div>
+        {t && (
+          <div className={cn('mt-0.5 flex items-center gap-1 text-[10px] sm:text-xs', t.klass)}>
+            <t.Icon className="h-3 w-3 sm:h-4 sm:w-4" />
+            <span>{trendValue ?? (trend === 'up' ? 'Improving' : trend === 'down' ? 'Declining' : 'Stable')}</span>
+          </div>
+        )}
+        {progress != null && (
+          <Progress value={progress} className="mt-1 sm:mt-2 h-1.5 sm:h-2" />
+        )}
+        {caption && (
+          <p className="mt-1 text-[10px] sm:text-xs text-muted-foreground">{caption}</p>
+        )}
       </CardContent>
     </Card>
   );

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -747,7 +747,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
               </ResponsiveContainer>
               <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1">
                 <span className="font-display text-3xl font-extrabold tabular-nums tracking-tight leading-none">{total.toLocaleString()}</span>
-                <span className="text-[10px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">Total plays</span>
+                <span className="eyebrow text-[10px]">Total plays</span>
               </div>
             </div>
 
@@ -771,7 +771,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                         className="size-2.5 rounded-full shrink-0"
                         style={{ backgroundColor: color }}
                       />
-                      <span className="text-[11px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">
+                      <span className="eyebrow">
                         {SOURCE_LABELS[row.source] ?? row.source}
                       </span>
                     </div>
@@ -921,7 +921,7 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
         </ResponsiveContainer>
         <div className="pointer-events-none absolute inset-0 flex flex-col items-center justify-center gap-1">
           <span className="font-display text-2xl font-extrabold tabular-nums tracking-tight leading-none">{total.toLocaleString()}</span>
-          <span className="text-[10px] tracking-[0.12em] uppercase font-semibold text-muted-foreground">Top {chartData.length}</span>
+          <span className="eyebrow text-[10px]">Top {chartData.length}</span>
         </div>
       </div>
       <ul className="space-y-1 self-center">
@@ -1038,13 +1038,13 @@ const StatCard = memo(function StatCard({
 }) {
   const t = trendVisual(trend);
   return (
-    <Card className={cn(glow && 'shadow-[var(--shadow-glow-sm)]')}>
+    <Card className={cn(glow && 'card-glow')}>
       <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
         <CardTitle
           // AIDJ eyebrow per design system: 11px, 0.12em tracking, weight 600,
           // uppercase, muted. Tighter weight than the rest of the card titles
           // so the BIG number reads as the primary mark.
-          className="flex items-center gap-1.5 sm:gap-2 text-[11px] tracking-[0.12em] uppercase font-semibold text-muted-foreground"
+          className="flex items-center gap-1.5 sm:gap-2 eyebrow"
         >
           <Icon className="h-3 w-3 sm:h-4 sm:w-4 shrink-0" />
           <span className="truncate">{label}</span>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -237,7 +237,7 @@ function OverviewTab({ analytics }: { analytics: EnhancedAnalyticsResponse }) {
   return (
     <div className="space-y-4">
       {/* Compact 4-up stat row matching the Discovery analytics summary cards */}
-      <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-4">
+      <div className="grid grid-cols-2 gap-2 sm:gap-4 xl:grid-cols-4">
         <StatCard
           icon={BarChart3}
           label="Feedback"

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -26,6 +26,12 @@ import { Skeleton } from '../ui/skeleton';
 import { Progress } from '../ui/progress';
 import { LayoutDashboard, Target, Activity, Compass, Headphones, TrendingUp, TrendingDown, Minus, BarChart3, Sparkles, type LucideIcon } from 'lucide-react';
 import { cn } from '@/lib/utils';
+import {
+  chartTooltipContentStyle,
+  chartTooltipLabelStyle,
+  chartBarCursor,
+  chartLineCursor,
+} from './chart-theme';
 
 // ============================================================================
 // Types
@@ -335,15 +341,7 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
               <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
               <XAxis dataKey="period" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
               <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-              <Tooltip
-                cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
-                contentStyle={{
-                  borderRadius: 8,
-                  border: '1px solid hsl(var(--border))',
-                  background: 'hsl(var(--popover))',
-                  fontSize: 12,
-                }}
-              />
+              <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
               <Legend wrapperStyle={{ fontSize: 12, paddingTop: 8 }} iconType="circle" />
               <Bar dataKey="liked" fill={COLORS.success} name="Liked" radius={[4, 4, 0, 0]} />
               <Bar dataKey="disliked" fill={COLORS.danger} name="Disliked" radius={[4, 4, 0, 0]} />
@@ -453,15 +451,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
                 <XAxis dataKey="day" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-                <Tooltip
-                  cursor={{ fill: 'hsl(var(--muted))', opacity: 0.4 }}
-                  contentStyle={{
-                    borderRadius: 8,
-                    border: '1px solid hsl(var(--border))',
-                    background: 'hsl(var(--popover))',
-                    fontSize: 12,
-                  }}
-                />
+                <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
                 <Bar dataKey="count" fill={COLORS.primary} radius={[4, 4, 0, 0]} />
               </BarChart>
             </ResponsiveContainer>
@@ -479,15 +469,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
                 <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
                 <XAxis dataKey="hour" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} interval={2} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
-                <Tooltip
-                  cursor={{ stroke: 'hsl(var(--muted-foreground))', strokeWidth: 1 }}
-                  contentStyle={{
-                    borderRadius: 8,
-                    border: '1px solid hsl(var(--border))',
-                    background: 'hsl(var(--popover))',
-                    fontSize: 12,
-                  }}
-                />
+                <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
                 <Line
                   type="monotone"
                   dataKey="count"
@@ -756,12 +738,8 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                       const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
                       return [`${value} plays (${pct}%)`, name];
                     }}
-                    contentStyle={{
-                      borderRadius: 8,
-                      border: '1px solid hsl(var(--border))',
-                      background: 'hsl(var(--popover))',
-                      fontSize: 12,
-                    }}
+                    contentStyle={chartTooltipContentStyle}
+                    labelStyle={chartTooltipLabelStyle}
                   />
                 </PieChart>
               </ResponsiveContainer>
@@ -934,12 +912,8 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
                 const pct = total > 0 ? ((value / total) * 100).toFixed(1) : '0.0';
                 return [`${value} thumbs-up (${pct}%)`, name];
               }}
-              contentStyle={{
-                borderRadius: 8,
-                border: '1px solid hsl(var(--border))',
-                background: 'hsl(var(--popover))',
-                fontSize: 12,
-              }}
+              contentStyle={chartTooltipContentStyle}
+              labelStyle={chartTooltipLabelStyle}
             />
           </PieChart>
         </ResponsiveContainer>

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -346,7 +346,7 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         <CardContent>
           <ResponsiveContainer width="100%" height={300}>
             <BarChart data={chartData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
-              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+              <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
               <XAxis dataKey="period" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
               <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
               <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
@@ -456,7 +456,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
               <BarChart data={dayData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
                 <XAxis dataKey="day" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
                 <Tooltip cursor={chartBarCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
@@ -474,7 +474,7 @@ const ActivityTab = memo(function ActivityTab({ analytics }: { analytics: Enhanc
           <CardContent>
             <ResponsiveContainer width="100%" height={250}>
               <LineChart data={hourData} margin={{ top: 10, right: 10, left: -10, bottom: 0 }}>
-                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="hsl(var(--border))" />
+                <CartesianGrid strokeDasharray="3 3" vertical={false} stroke="var(--border)" />
                 <XAxis dataKey="hour" tick={{ fontSize: 11 }} tickLine={false} axisLine={false} interval={2} />
                 <YAxis tick={{ fontSize: 11 }} tickLine={false} axisLine={false} width={32} />
                 <Tooltip cursor={chartLineCursor} contentStyle={chartTooltipContentStyle} labelStyle={chartTooltipLabelStyle} />
@@ -725,7 +725,7 @@ const SourceBreakdownCard = memo(function SourceBreakdownCard({
                     paddingAngle={2}
                     dataKey="value"
                     nameKey="name"
-                    stroke="hsl(var(--background))"
+                    stroke="var(--background)"
                     strokeWidth={2}
                   >
                     {chartData.map((entry) => (
@@ -902,7 +902,7 @@ const TopArtistsChart = memo(function TopArtistsChart({ artists }: { artists: Ar
               paddingAngle={2}
               dataKey="value"
               nameKey="name"
-              stroke="hsl(var(--background))"
+              stroke="var(--background)"
               strokeWidth={2}
             >
               {chartData.map((entry) => (

--- a/src/components/recommendations/AnalyticsDashboard.tsx
+++ b/src/components/recommendations/AnalyticsDashboard.tsx
@@ -361,13 +361,13 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
       <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-3">
         <StatCard
           icon={Target}
-          label="Acceptance Rate"
+          label="Accept Rate"
           value={`${(analytics.quality.acceptanceRate * 100).toFixed(1)}%`}
           caption={`${analytics.quality.thumbsUpCount} liked of ${analytics.quality.totalRecommendations}`}
         />
         <StatCard
           icon={TrendingUp}
-          label="Quality Trend"
+          label="Trend"
           value={analytics.quality.qualityTrend}
           trend={
             analytics.quality.qualityTrend === 'improving' ? 'up'
@@ -384,7 +384,7 @@ const QualityTab = memo(function QualityTab({ analytics }: { analytics: Enhanced
         />
         <StatCard
           icon={BarChart3}
-          label="Total Ratings"
+          label="Ratings"
           value={analytics.quality.totalRecommendations.toLocaleString()}
           caption="Feedback events"
         />
@@ -814,19 +814,19 @@ const DiscoveryTab = memo(function DiscoveryTab({ analytics }: { analytics: Enha
       <div className="grid grid-cols-2 gap-2 sm:gap-4 lg:grid-cols-3">
         <StatCard
           icon={Sparkles}
-          label="New Artists Discovered"
+          label="New Artists"
           value={analytics.discovery.newArtistsDiscovered.toString()}
-          caption="In the selected period"
+          caption="Discovered this period"
         />
         <StatCard
           icon={Compass}
-          label="Diversity Score"
+          label="Diversity"
           value={`${(analytics.discovery.genreDiversityScore * 100).toFixed(0)}%`}
           progress={analytics.discovery.genreDiversityScore * 100}
         />
         <StatCard
           icon={TrendingUp}
-          label="Diversity Trend"
+          label="Trend"
           value={analytics.discovery.diversityTrend}
           trend={
             analytics.discovery.diversityTrend === 'expanding' ? 'up'

--- a/src/components/recommendations/MoodTimeline.tsx
+++ b/src/components/recommendations/MoodTimeline.tsx
@@ -188,7 +188,7 @@ const MoodTimelineTooltip = memo(function MoodTimelineTooltip({ active, payload 
   const hasMoodData = Object.keys(moodDistribution).length > 0;
 
   return (
-    <div className="bg-popover border border-border rounded-lg p-3 shadow-lg max-w-xs">
+    <div className="rounded-lg border border-border bg-popover text-popover-foreground p-3 max-w-xs shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
       <p className="font-medium text-sm mb-2">{dataPoint.periodLabel || 'Unknown Period'}</p>
 
       {/* Mood Breakdown */}

--- a/src/components/recommendations/MoodTimeline.tsx
+++ b/src/components/recommendations/MoodTimeline.tsx
@@ -188,7 +188,7 @@ const MoodTimelineTooltip = memo(function MoodTimelineTooltip({ active, payload 
   const hasMoodData = Object.keys(moodDistribution).length > 0;
 
   return (
-    <div className="rounded-lg border border-border bg-popover text-popover-foreground p-3 max-w-xs shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]">
+    <div className="rounded-lg border border-border bg-popover text-popover-foreground p-3 max-w-xs shadow-lg">
       <p className="font-medium text-sm mb-2">{dataPoint.periodLabel || 'Unknown Period'}</p>
 
       {/* Mood Breakdown */}
@@ -857,7 +857,7 @@ export function MoodTimeline({
                 dataKey="name"
                 height={30}
                 stroke="#8b5cf6"
-                fill="hsl(var(--muted))"
+                fill="var(--muted)"
                 onChange={handleBrushChange}
               />
             </AreaChart>

--- a/src/components/recommendations/StatCard.tsx
+++ b/src/components/recommendations/StatCard.tsx
@@ -1,0 +1,94 @@
+/**
+ * Shared StatCard primitive for the analytics suite.
+ *
+ * AIDJ design-system .stat treatment:
+ * - icon-prefixed eyebrow header (11px, 0.12em tracking, weight 600, uppercase)
+ * - font-display value (Plus Jakarta Sans, extrabold, tracking-tight)
+ * - optional inline trend chip (font-mono, colored by direction)
+ * - optional progress bar under the value
+ * - optional brand gradient + glow for hero/featured stats (use sparingly)
+ */
+import { memo } from 'react';
+import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
+import { Progress } from '../ui/progress';
+import { TrendingUp, TrendingDown, Minus, type LucideIcon } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+export type MetricTrend = 'up' | 'down' | 'flat';
+
+export function trendVisual(trend?: MetricTrend) {
+  if (!trend) return null;
+  const Icon = trend === 'up' ? TrendingUp : trend === 'down' ? TrendingDown : Minus;
+  const klass =
+    trend === 'up' ? 'text-emerald-500'
+    : trend === 'down' ? 'text-destructive'
+    : 'text-muted-foreground';
+  return { Icon, klass };
+}
+
+interface StatCardProps {
+  icon: LucideIcon;
+  label: string;
+  value: string;
+  caption?: string;
+  trend?: MetricTrend;
+  /** Optional explicit delta string shown next to the trend icon, e.g. "+3.4%". */
+  trendValue?: string;
+  /** 0–100 progress bar shown under the value. */
+  progress?: number;
+  /** Render the value in the AIDJ brand gradient. Reserve for the
+   *  hero/featured stat in a row — overuse dilutes it. */
+  gradient?: boolean;
+  /** Apply the brand glow shadow. Same rule: hero stat only. */
+  glow?: boolean;
+}
+
+export const StatCard = memo(function StatCard({
+  icon: Icon,
+  label,
+  value,
+  caption,
+  trend,
+  trendValue,
+  progress,
+  gradient,
+  glow,
+}: StatCardProps) {
+  const t = trendVisual(trend);
+  return (
+    <Card className={cn(glow && 'card-glow')}>
+      <CardHeader className="pb-1 sm:pb-2 p-3 sm:p-6">
+        <CardTitle className="flex items-center gap-1.5 sm:gap-2 eyebrow">
+          <Icon className="h-3 w-3 sm:h-4 sm:w-4 shrink-0" />
+          {/* Don't truncate — at narrow mobile widths uppercase + 0.12em
+              tracking pushes some labels past one line; let them wrap to
+              two rather than cut to "FEED…". */}
+          <span className="leading-snug">{label}</span>
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-0 sm:p-6 sm:pt-0">
+        <div
+          className={cn(
+            'font-display font-extrabold tabular-nums capitalize tracking-tight leading-none',
+            'text-2xl sm:text-3xl',
+            gradient && 'bg-[image:var(--gradient-brand)] bg-clip-text text-transparent',
+          )}
+        >
+          {value}
+        </div>
+        {t && (
+          <div className={cn('mt-1.5 flex items-center gap-1 font-mono text-[11px]', t.klass)}>
+            <t.Icon className="h-3 w-3 sm:h-3.5 sm:w-3.5" />
+            <span>{trendValue ?? (trend === 'up' ? 'Improving' : trend === 'down' ? 'Declining' : 'Stable')}</span>
+          </div>
+        )}
+        {progress != null && (
+          <Progress value={progress} className="mt-2 h-1.5 sm:h-2" />
+        )}
+        {caption && (
+          <p className="mt-1.5 text-[11px] sm:text-xs text-muted-foreground">{caption}</p>
+        )}
+      </CardContent>
+    </Card>
+  );
+});

--- a/src/components/recommendations/chart-theme.ts
+++ b/src/components/recommendations/chart-theme.ts
@@ -1,0 +1,70 @@
+/**
+ * Shared chart-theming helpers for recharts.
+ *
+ * The Analytics page, AdvancedDiscoveryAnalytics, MoodTimeline, and the
+ * music-identity dashboard all use recharts. Without these shared values
+ * each chart drifts: some show heavy default tooltips, others have
+ * `contentStyle={{ fontSize: '12px' }}` and nothing else, etc.
+ *
+ * Use these to keep tooltip popovers and cursors consistent everywhere.
+ */
+
+import type { CSSProperties } from 'react';
+
+/**
+ * Tooltip popover style — rounded, hairline border, themed background,
+ * small body type. Pass to `<Tooltip contentStyle={chartTooltipContentStyle}>`.
+ */
+export const chartTooltipContentStyle: CSSProperties = {
+  borderRadius: 8,
+  border: '1px solid hsl(var(--border))',
+  background: 'hsl(var(--popover))',
+  color: 'hsl(var(--popover-foreground))',
+  fontSize: 12,
+  padding: '8px 10px',
+  boxShadow: '0 4px 12px -2px hsl(var(--foreground) / 0.08)',
+};
+
+/**
+ * Label style for tooltip body — slightly muted to match the popover.
+ */
+export const chartTooltipLabelStyle: CSSProperties = {
+  color: 'hsl(var(--muted-foreground))',
+  fontSize: 11,
+  fontWeight: 500,
+  marginBottom: 2,
+};
+
+/**
+ * Cursor for bar charts. Sits *behind* the bars as a subtle muted fill.
+ */
+export const chartBarCursor = {
+  fill: 'hsl(var(--muted))',
+  opacity: 0.4,
+} as const;
+
+/**
+ * Cursor for line/area charts. A thin vertical guide line.
+ */
+export const chartLineCursor = {
+  stroke: 'hsl(var(--muted-foreground))',
+  strokeWidth: 1,
+  strokeDasharray: '3 3',
+} as const;
+
+/**
+ * Sensible default axis tick style for the analytics suite.
+ */
+export const chartAxisTick = { fontSize: 11 } as const;
+
+/**
+ * Tailwind class string for wrapping a custom recharts `Tooltip content` prop.
+ * Keeps custom multi-line tooltip layouts visually aligned with the simple
+ * single-line tooltips that use `chartTooltipContentStyle`.
+ *
+ * Usage:
+ *   <Tooltip content={({active, payload, label}) =>
+ *     active ? <div className={chartTooltipPopoverClass}>{...}</div> : null} />
+ */
+export const chartTooltipPopoverClass =
+  'rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]';

--- a/src/components/recommendations/chart-theme.ts
+++ b/src/components/recommendations/chart-theme.ts
@@ -41,6 +41,18 @@ export const chartTooltipLabelStyle: CSSProperties = {
 };
 
 /**
+ * Item-row style. Recharts colors each row by its series color by default,
+ * which is unreadable on the popover background for pale series. Force the
+ * label/value text to the popover-foreground; series color lives on the
+ * marker dot, not the text.
+ */
+export const chartTooltipItemStyle: CSSProperties = {
+  color: 'var(--popover-foreground)',
+  fontSize: 12,
+  padding: 0,
+};
+
+/**
  * Cursor for bar charts. Sits *behind* the bars as a subtle muted fill.
  */
 export const chartBarCursor = {

--- a/src/components/recommendations/chart-theme.ts
+++ b/src/components/recommendations/chart-theme.ts
@@ -14,22 +14,27 @@ import type { CSSProperties } from 'react';
 /**
  * Tooltip popover style — rounded, hairline border, themed background,
  * small body type. Pass to `<Tooltip contentStyle={chartTooltipContentStyle}>`.
+ *
+ * IMPORTANT: AIDJ tokens are stored as full `oklch(...)` values (not raw
+ * H/S/L components), so wrapping in `hsl(var(--popover))` produces invalid
+ * CSS and the tooltip renders with default browser styling (black text on
+ * transparent bg). Use `var(--popover)` etc. directly.
  */
 export const chartTooltipContentStyle: CSSProperties = {
   borderRadius: 8,
-  border: '1px solid hsl(var(--border))',
-  background: 'hsl(var(--popover))',
-  color: 'hsl(var(--popover-foreground))',
+  border: '1px solid var(--border)',
+  background: 'var(--popover)',
+  color: 'var(--popover-foreground)',
   fontSize: 12,
   padding: '8px 10px',
-  boxShadow: '0 4px 12px -2px hsl(var(--foreground) / 0.08)',
+  boxShadow: 'var(--shadow-md)',
 };
 
 /**
  * Label style for tooltip body — slightly muted to match the popover.
  */
 export const chartTooltipLabelStyle: CSSProperties = {
-  color: 'hsl(var(--muted-foreground))',
+  color: 'var(--muted-foreground)',
   fontSize: 11,
   fontWeight: 500,
   marginBottom: 2,
@@ -39,7 +44,7 @@ export const chartTooltipLabelStyle: CSSProperties = {
  * Cursor for bar charts. Sits *behind* the bars as a subtle muted fill.
  */
 export const chartBarCursor = {
-  fill: 'hsl(var(--muted))',
+  fill: 'var(--muted)',
   opacity: 0.4,
 } as const;
 
@@ -47,7 +52,7 @@ export const chartBarCursor = {
  * Cursor for line/area charts. A thin vertical guide line.
  */
 export const chartLineCursor = {
-  stroke: 'hsl(var(--muted-foreground))',
+  stroke: 'var(--muted-foreground)',
   strokeWidth: 1,
   strokeDasharray: '3 3',
 } as const;
@@ -76,7 +81,7 @@ export const chartPalette = [
 
 /** Soft slate fill for "unknown / pre-tagged" buckets that shouldn't compete
  *  for visual attention with real data. */
-export const chartMutedColor = 'hsl(var(--muted-foreground))';
+export const chartMutedColor = 'var(--muted-foreground)';
 
 /**
  * Stable color for known play sources. Reaches into `--chart-N` for typed
@@ -101,4 +106,4 @@ export const sourceColors: Record<string, string> = {
  *     active ? <div className={chartTooltipPopoverClass}>{...}</div> : null} />
  */
 export const chartTooltipPopoverClass =
-  'rounded-lg border border-border bg-popover text-popover-foreground shadow-[0_4px_12px_-2px_hsl(var(--foreground)/0.08)]';
+  'rounded-lg border border-border bg-popover text-popover-foreground shadow-lg';

--- a/src/components/recommendations/chart-theme.ts
+++ b/src/components/recommendations/chart-theme.ts
@@ -58,6 +58,40 @@ export const chartLineCursor = {
 export const chartAxisTick = { fontSize: 11 } as const;
 
 /**
+ * Canonical AIDJ chart palette. Maps to the `--chart-1` … `--chart-5` CSS
+ * variables defined in styles.css and themed in themes.css. Use these for
+ * recharts `fill` / `stroke` props so a theme switch (Midnight Club, Vinyl
+ * Lounge, etc.) repaints the charts automatically.
+ *
+ * Slot 1 (magenta in the default dark theme) is the "now playing / featured"
+ * accent. Slot 2 is violet, 3 is cyan, 4 is emerald, 5 is amber.
+ */
+export const chartPalette = [
+  'var(--chart-1)',
+  'var(--chart-2)',
+  'var(--chart-3)',
+  'var(--chart-4)',
+  'var(--chart-5)',
+] as const;
+
+/** Soft slate fill for "unknown / pre-tagged" buckets that shouldn't compete
+ *  for visual attention with real data. */
+export const chartMutedColor = 'hsl(var(--muted-foreground))';
+
+/**
+ * Stable color for known play sources. Reaches into `--chart-N` for typed
+ * sources so themes repaint them; null/unknown stays muted slate so the
+ * pre-instrumentation backlog doesn't dominate.
+ */
+export const sourceColors: Record<string, string> = {
+  ai_dj: 'var(--chart-2)',     // violet — AI accent
+  manual: 'var(--chart-3)',    // cyan
+  radio: 'var(--chart-5)',     // amber
+  autoplay: 'var(--chart-4)',  // emerald
+  unknown: chartMutedColor,
+};
+
+/**
  * Tailwind class string for wrapping a custom recharts `Tooltip content` prop.
  * Keeps custom multi-line tooltip layouts visually aligned with the simple
  * single-line tooltips that use `chartTooltipContentStyle`.

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -32,7 +32,10 @@ const CardTitle = ({ className, ref, ...props }: CardTitleProps) => (
   <h3
     ref={ref}
     className={cn(
-      "text-2xl font-semibold leading-none tracking-tight",
+      // Responsive sizing: narrow mobile cards looked broken at the
+      // shadcn default of text-2xl (24px). Scale down to text-lg on
+      // mobile, restore at sm+.
+      "text-lg sm:text-2xl font-semibold leading-tight tracking-tight",
       className
     )}
     {...props}

--- a/src/components/ui/page-layout.tsx
+++ b/src/components/ui/page-layout.tsx
@@ -16,6 +16,13 @@ interface PageLayoutProps {
   fullWidth?: boolean;
   /** Compact header for secondary pages */
   compact?: boolean;
+  /**
+   * Opt-in to a wider max-width on large displays for content that benefits
+   * from horizontal real estate (analytics dashboards, multi-column lists).
+   * Forms/reading-heavy pages should leave this off so line lengths stay
+   * comfortable.
+   */
+  wide?: boolean;
 }
 
 /**
@@ -33,6 +40,7 @@ export function PageLayout({
   className,
   fullWidth = false,
   compact = false,
+  wide = false,
 }: PageLayoutProps) {
   return (
     <div className={cn(
@@ -45,7 +53,14 @@ export function PageLayout({
         // On mobile: push content below the fixed top bar (safe-area + 3rem bar height)
         // On desktop: just safe-area is enough (no top bar)
         'pt-[calc(env(safe-area-inset-top)+3.5rem)] md:pt-[env(safe-area-inset-top)]',
-        !fullWidth && 'max-w-7xl px-4 sm:px-6 lg:px-8 pb-4 sm:pb-6',
+        !fullWidth && [
+          'px-4 sm:px-6 lg:px-8 pb-4 sm:pb-6',
+          // Default ladder: 1280 → 1600 (2xl) → 1900 (3xl).
+          // Wide ladder for dashboards: 1280 → 1800 (2xl) → 2400 (3xl).
+          wide
+            ? 'max-w-7xl 2xl:max-w-[1800px] 3xl:max-w-[2400px]'
+            : 'max-w-7xl 2xl:max-w-[1600px] 3xl:max-w-[1900px]',
+        ],
         fullWidth && 'pb-4 sm:pb-6'
       )}>
         {/* Page Header */}

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -716,14 +716,21 @@ export function QueuePanel() {
         </CardHeader>
         <CardContent className="pb-2 md:pb-3 px-3 md:px-6 flex-1 overflow-hidden flex flex-col min-h-0">
           {currentSong && (
-            <div className="mb-2 md:mb-3 pb-2 md:pb-3 border-b border-border/50 bg-gradient-to-r from-primary/5 to-transparent -mx-3 md:-mx-4 px-3 md:px-4 py-2 md:py-3">
-              <p className="text-[10px] md:text-xs font-semibold text-primary/80 mb-1.5 md:mb-2 uppercase tracking-wider">Now Playing</p>
+            <div
+              className="mb-2 md:mb-3 pb-2 md:pb-3 border-b border-border/50 -mx-3 md:-mx-4 px-3 md:px-4 py-2 md:py-3"
+              style={{ background: 'linear-gradient(to right, oklch(from var(--aidj-magenta) l c h / 0.06), transparent)' }}
+            >
+              {/* DS rule: magenta is the "now playing" accent. */}
+              <p className="eyebrow text-[10px] md:text-xs mb-1.5 md:mb-2" style={{ color: 'var(--aidj-magenta)' }}>Now Playing</p>
               <div className="flex items-center gap-2 md:gap-3">
-                <div className="p-1.5 md:p-2 bg-gradient-to-br from-primary/20 to-purple-500/20 rounded-lg shadow-sm animate-pulse">
-                  <Music className="h-3.5 w-3.5 md:h-4 md:w-4 text-primary" />
+                <div
+                  className="p-1.5 md:p-2 rounded-lg shadow-sm animate-pulse"
+                  style={{ background: 'oklch(from var(--aidj-magenta) l c h / 0.15)' }}
+                >
+                  <Music className="h-3.5 w-3.5 md:h-4 md:w-4" style={{ color: 'var(--aidj-magenta)' }} />
                 </div>
                 <div className="min-w-0 flex-1">
-                  <p className="font-semibold text-xs md:text-sm truncate bg-gradient-to-r from-foreground to-foreground/80 bg-clip-text">{currentSong.title}</p>
+                  <p className="font-display font-semibold text-xs md:text-sm truncate">{currentSong.title}</p>
                   <p className="text-[10px] md:text-xs text-muted-foreground/80 truncate">{currentSong.artist}</p>
                 </div>
               </div>

--- a/src/routes/dashboard/analytics.tsx
+++ b/src/routes/dashboard/analytics.tsx
@@ -65,6 +65,7 @@ function AnalyticsPage() {
       icon={<BarChart3 className="h-5 w-5" />}
       backLink="/dashboard"
       backLabel="Dashboard"
+      wide
       actions={
         <div className="flex items-center gap-2">
           {tab === 'discovery' && (

--- a/src/routes/dashboard/discover.tsx
+++ b/src/routes/dashboard/discover.tsx
@@ -67,6 +67,7 @@ function DiscoverPage() {
       title="Discover"
       description="Personalized music recommendations based on your listening patterns"
       icon={<Sparkles className="h-6 w-6" />}
+      wide
     >
       <PageSection>
         <Suspense fallback={<DiscoveryFeedSkeleton />}>

--- a/src/routes/dashboard/history.tsx
+++ b/src/routes/dashboard/history.tsx
@@ -131,6 +131,7 @@ function HistoryPage() {
       icon={<Clock className="h-5 w-5" />}
       backLink="/dashboard"
       backLabel="Dashboard"
+      wide
       actions={
         <div className="flex gap-1 rounded-lg border p-1 bg-muted/30">
           {(Object.keys(PERIOD_LABELS) as TimePeriod[]).map((p) => (

--- a/src/routes/dashboard/library-growth.tsx
+++ b/src/routes/dashboard/library-growth.tsx
@@ -42,6 +42,7 @@ function LibraryGrowthPage() {
       title="Library Growth"
       description="Discover new music based on your listening habits and grow your collection"
       icon={<TrendingUp className="h-6 w-6" />}
+      wide
     >
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
         {/* Main suggestions panel */}

--- a/src/routes/library/search.tsx
+++ b/src/routes/library/search.tsx
@@ -131,6 +131,7 @@ function SearchPage() {
         backLink="/dashboard"
         backLabel="Dashboard"
         compact
+        wide
       >
         <Card>
           <CardContent className="p-4 sm:p-6">

--- a/src/routes/music-identity/index.tsx
+++ b/src/routes/music-identity/index.tsx
@@ -34,6 +34,7 @@ function MusicIdentityPage() {
       title="Music Identity"
       description="AI-powered listening reports"
       backLink=""
+      wide
     >
       <Suspense fallback={<MusicIdentityPageSkeleton />}>
         <MusicIdentityDashboard />

--- a/src/routes/playlists/index.tsx
+++ b/src/routes/playlists/index.tsx
@@ -22,6 +22,7 @@ function PlaylistsPage() {
       icon={<ListMusic className="h-5 w-5" />}
       backLink="/dashboard"
       backLabel="Dashboard"
+      wide
       actions={
         <div className="flex items-center gap-2">
           <CreatePlaylistDialog />

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,7 @@
 @import "./themes.css";
 
 /* Display fonts — swap font-display below to try alternatives */
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Sora:wght@500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=Outfit:wght@500;600;700;800&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Sora:wght@500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
 
 @custom-variant dark (&:is(.dark *));
 @custom-variant landscape (@media (orientation: landscape));
@@ -14,6 +14,11 @@
   /* Custom screen for very wide displays (1920p / 4K). Default Tailwind tops
      out at 2xl=1536px; without 3xl, layouts strand content on big monitors. */
   --breakpoint-3xl: 1920px;
+
+  /* Display + mono font utilities. font-display drives big stat numbers and
+     headings; font-mono is reserved for stats, timestamps, BPM/key labels. */
+  --font-display: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
+  --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, 'Menlo', monospace;
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/styles.css
+++ b/src/styles.css
@@ -5,7 +5,7 @@
 @import "./themes.css";
 
 /* Display fonts — swap font-display below to try alternatives */
-@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Sora:wght@500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@500;600;700;800&family=Sora:wght@500;600;700;800&family=Space+Grotesk:wght@500;600;700&family=Outfit:wght@500;600;700;800&family=JetBrains+Mono:wght@400;500;600&family=Unbounded:wght@700;800;900&family=Syne:ital,wght@0,700;1,800&display=swap');
 
 @custom-variant dark (&:is(.dark *));
 @custom-variant landscape (@media (orientation: landscape));
@@ -19,6 +19,13 @@
      headings; font-mono is reserved for stats, timestamps, BPM/key labels. */
   --font-display: 'Plus Jakarta Sans', ui-sans-serif, system-ui, sans-serif;
   --font-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, 'Menlo', monospace;
+  /* Brand-mark accents. font-brand is Unbounded (geometric, wide, rave-flyer
+     feel) — reserved for the "AI" half of the AIDJ wordmark and other hero
+     brand moments. font-accent is Syne (off-axis, italic-leaning) — used for
+     the "DJ" half and for taglines / eyebrow accents that need contrast
+     against the stricter geometric face. */
+  --font-brand: 'Unbounded', 'Plus Jakarta Sans', ui-sans-serif, sans-serif;
+  --font-accent: 'Syne', 'Plus Jakarta Sans', ui-sans-serif, sans-serif;
 
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);

--- a/src/styles.css
+++ b/src/styles.css
@@ -863,6 +863,65 @@
            bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300;
   }
 
+  /* ─────────────────────────────────────────────────────────────────────
+     AIDJ Design-System primitives
+     Curated utilities that replace repeated inline class strings around
+     the analytics + brand surfaces. Keep this section narrow — only add
+     primitives that show up in 3+ places.
+     ───────────────────────────────────────────────────────────────────── */
+
+  /* Eyebrow — small uppercase label above a stat or chart overlay.
+     11px / 0.12em tracking / weight 600 / muted, per the AIDJ DS .stat .label. */
+  .eyebrow {
+    @apply text-[11px] uppercase font-semibold text-muted-foreground;
+    letter-spacing: 0.12em;
+  }
+
+  /* Brand glow — soft brand-tinted shadow for hero stats and feature cards.
+     Pair with bg-card so the glow reads as halo, not the card surface. */
+  .card-glow {
+    box-shadow: var(--shadow-glow-sm);
+  }
+
+  /* AIDJ brand-hue badges — translucent fill + matching border + colored text,
+     per the DS badge-violet/magenta/cyan/emerald/amber pattern. Use these for
+     mood tags, source labels, and small categorical indicators. */
+  .badge-violet {
+    @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5
+           text-xs font-semibold;
+    background: oklch(from var(--aidj-violet) l c h / 0.12);
+    color: var(--aidj-violet);
+    border-color: oklch(from var(--aidj-violet) l c h / 0.25);
+  }
+  .badge-magenta {
+    @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5
+           text-xs font-semibold;
+    background: oklch(from var(--aidj-magenta) l c h / 0.12);
+    color: var(--aidj-magenta);
+    border-color: oklch(from var(--aidj-magenta) l c h / 0.25);
+  }
+  .badge-cyan {
+    @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5
+           text-xs font-semibold;
+    background: oklch(from var(--aidj-cyan) l c h / 0.12);
+    color: var(--aidj-cyan);
+    border-color: oklch(from var(--aidj-cyan) l c h / 0.25);
+  }
+  .badge-emerald {
+    @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5
+           text-xs font-semibold;
+    background: oklch(from var(--aidj-emerald) l c h / 0.12);
+    color: var(--aidj-emerald);
+    border-color: oklch(from var(--aidj-emerald) l c h / 0.25);
+  }
+  .badge-amber {
+    @apply inline-flex items-center gap-1 rounded-full border px-2.5 py-0.5
+           text-xs font-semibold;
+    background: oklch(from var(--aidj-amber) l c h / 0.12);
+    color: var(--aidj-amber);
+    border-color: oklch(from var(--aidj-amber) l c h / 0.25);
+  }
+
   /* ── Hero Glow Tertiary ── */
   .hero-glow-tertiary {
     @apply absolute w-80 h-80 rounded-full blur-3xl opacity-25 pointer-events-none;

--- a/src/styles.css
+++ b/src/styles.css
@@ -11,6 +11,10 @@
 @custom-variant landscape (@media (orientation: landscape));
 
 @theme inline {
+  /* Custom screen for very wide displays (1920p / 4K). Default Tailwind tops
+     out at 2xl=1536px; without 3xl, layouts strand content on big monitors. */
+  --breakpoint-3xl: 1920px;
+
   --radius-sm: calc(var(--radius) - 4px);
   --radius-md: calc(var(--radius) - 2px);
   --radius-lg: var(--radius);

--- a/tests/screenshots/all-tabs.spec.ts
+++ b/tests/screenshots/all-tabs.spec.ts
@@ -1,0 +1,37 @@
+/**
+ * Sweep all analytics tabs in both desktop and mobile viewports.
+ * Output filenames are prefixed with the project name so headless desktop
+ * and mobile shots land in distinct files.
+ */
+import { test, type Page } from '@playwright/test';
+import path from 'node:path';
+
+const TABS = ['Overview', 'Listening', 'Quality', 'Activity', 'Discovery'] as const;
+
+async function snapTab(page: Page, tab: typeof TABS[number], outPrefix: string) {
+  // The analytics page nests an inner tablist (Overview/Listening/Quality/...)
+  // inside an outer page-level tablist (Overview/Discovery/Mood Timeline).
+  // The inner one is the only tablist that contains "Listening", so we use
+  // that as the disambiguating anchor.
+  const inner = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+  await inner.getByRole('tab', { name: tab, exact: true }).click();
+  // Best-effort wait for any data fetch to settle.
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  // Recharts default animation is 1500ms; wait long enough to clear it.
+  await page.waitForTimeout(1800);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', `${outPrefix}-${tab.toLowerCase()}.png`),
+    fullPage: true,
+  });
+}
+
+test('Analytics — all tabs', async ({ page }, testInfo) => {
+  const prefix = testInfo.project.name === 'mobile' ? 'mobile' : 'desktop';
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+
+  for (const tab of TABS) {
+    await snapTab(page, tab, prefix);
+  }
+});

--- a/tests/screenshots/brand-mark.spec.ts
+++ b/tests/screenshots/brand-mark.spec.ts
@@ -1,0 +1,34 @@
+/**
+ * Verify the Unbounded + Syne brand wordmark lands in the sidebar
+ * and on the landing hero.
+ */
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test('sidebar wordmark (zoomed)', async ({ page }, testInfo) => {
+  const prefix = testInfo.project.name; // chromium-headless | mobile | fullhd | 4k
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+
+  // Zoom on the sidebar header area where the AIDJ wordmark sits.
+  const sidebarHeader = page.locator('aside').first().locator('a').filter({ hasText: 'AIDJ' }).first();
+  await sidebarHeader.scrollIntoViewIfNeeded().catch(() => undefined);
+  await sidebarHeader.screenshot({
+    path: path.join('tests', 'screenshots', 'out', `${prefix}-brand-sidebar.png`),
+  }).catch(() => undefined);
+});
+
+test('landing hero wordmark', async ({ page, context }, testInfo) => {
+  const prefix = testInfo.project.name;
+  // Land at "/" without auth to see the marketing hero. Drop the auth cookies
+  // for this nav so we hit the unauthenticated landing page.
+  await context.clearCookies();
+  await page.goto('/');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', `${prefix}-landing-hero.png`),
+    fullPage: false,
+  });
+});

--- a/tests/screenshots/large-viewport.spec.ts
+++ b/tests/screenshots/large-viewport.spec.ts
@@ -1,0 +1,39 @@
+/**
+ * Snap key routes at large/extra-large viewports (1080p + 4K) to triage
+ * "stranded content in whitespace" issues on big monitors.
+ */
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+const ROUTES: Array<{ name: string; url: string }> = [
+  { name: 'analytics-overview', url: '/dashboard/analytics' },
+  { name: 'analytics-listening', url: '/dashboard/analytics' }, // tab clicked below
+  { name: 'discover', url: '/dashboard/discover' },
+  { name: 'history', url: '/dashboard/history' },
+  { name: 'discovery-analytics', url: '/dashboard/analytics?tab=discovery' },
+  { name: 'mood-timeline', url: '/dashboard/analytics?tab=mood-timeline' },
+  { name: 'library-artists', url: '/library/artists' },
+  { name: 'library-search', url: '/library/search' },
+  { name: 'playlists', url: '/playlists' },
+  { name: 'music-identity', url: '/music-identity' },
+  { name: 'library-growth', url: '/dashboard/library-growth' },
+];
+
+for (const { name, url } of ROUTES) {
+  test(name, async ({ page }, testInfo) => {
+    const prefix = testInfo.project.name; // fullhd or 4k
+    await page.goto(url);
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    // For the listening sub-tab, click it after the page loads.
+    if (name === 'analytics-listening') {
+      const inner = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+      await inner.getByRole('tab', { name: 'Listening', exact: true }).click();
+      await page.waitForResponse((r) => r.url().includes('/api/listening-history/by-source') && r.ok()).catch(() => undefined);
+    }
+    await page.waitForTimeout(1800);
+    await page.screenshot({
+      path: path.join('tests', 'screenshots', 'out', `${prefix}-${name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/tests/screenshots/msl-reference.spec.ts
+++ b/tests/screenshots/msl-reference.spec.ts
@@ -1,0 +1,18 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test.use({
+  storageState: { cookies: [], origins: [] },
+  baseURL: 'https://msl.appahouse.com',
+  viewport: { width: 1440, height: 900 },
+});
+
+test('msl.appahouse.com home — style reference', async ({ page }) => {
+  await page.goto('/');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(800);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'ref-msl-home.png'),
+    fullPage: true,
+  });
+});

--- a/tests/screenshots/route-sweep.spec.ts
+++ b/tests/screenshots/route-sweep.spec.ts
@@ -1,0 +1,38 @@
+/**
+ * Sweep candidate routes to triage the styling-polish backlog.
+ * Generates desktop+mobile screenshots per route so I can identify
+ * the worst offenders before touching code.
+ */
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+const ROUTES: Array<{ name: string; url: string }> = [
+  { name: 'dashboard-home', url: '/dashboard' },
+  { name: 'dashboard-discover', url: '/dashboard/discover' },
+  { name: 'dashboard-history', url: '/dashboard/history' },
+  { name: 'dashboard-discovery-analytics', url: '/dashboard/discovery-analytics' },
+  { name: 'dashboard-library-growth', url: '/dashboard/library-growth' },
+  { name: 'dashboard-mood-timeline', url: '/dashboard/mood-timeline' },
+  { name: 'dashboard-generate', url: '/dashboard/generate' },
+  { name: 'music-identity', url: '/music-identity' },
+  { name: 'library-search', url: '/library/search' },
+  { name: 'library-artists', url: '/library/artists' },
+  { name: 'playlists', url: '/playlists' },
+  { name: 'settings-general', url: '/settings/general' },
+  { name: 'settings-recommendations', url: '/settings/recommendations' },
+  { name: 'dj', url: '/dj' },
+];
+
+for (const { name, url } of ROUTES) {
+  test(name, async ({ page }, testInfo) => {
+    const prefix = testInfo.project.name === 'mobile' ? 'route-mobile' : 'route-desktop';
+    await page.goto(url);
+    // Don't wait too long on routes that may have animations / streaming data.
+    await page.waitForLoadState('networkidle').catch(() => undefined);
+    await page.waitForTimeout(1500);
+    await page.screenshot({
+      path: path.join('tests', 'screenshots', 'out', `${prefix}-${name}.png`),
+      fullPage: true,
+    });
+  });
+}

--- a/tests/screenshots/source-breakdown.spec.ts
+++ b/tests/screenshots/source-breakdown.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Manual screenshot harness for PR 3 (source-breakdown pie chart).
+ * Not run in CI — invoked ad-hoc via `npx playwright test tests/screenshots/...`.
+ *
+ * Auth: reuses `tests/.auth/juan.json` saved via `playwright open --save-storage`.
+ */
+
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+
+const BASE = process.env.SCREENSHOT_BASE_URL ?? 'https://aidj.appahouse.com';
+const OUT_DIR = path.join('tests', 'screenshots', 'out');
+
+test.use({
+  storageState: 'tests/.auth/juan.json',
+  baseURL: BASE,
+  viewport: { width: 1440, height: 900 },
+});
+
+test('Analytics → Listening tab — full page', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle');
+
+  // Click the Listening tab.
+  await page.getByRole('tab', { name: /listening/i }).click();
+  // Wait for chart to render (recharts paints async after data arrives).
+  await page.waitForResponse((r) => r.url().includes('/api/listening-history/by-source') && r.ok());
+  await page.waitForTimeout(500); // recharts animation settle
+
+  await page.screenshot({
+    path: path.join(OUT_DIR, '01-listening-full.png'),
+    fullPage: true,
+  });
+});
+
+test('Source breakdown card — zoomed', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle');
+  await page.getByRole('tab', { name: /listening/i }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/listening-history/by-source') && r.ok());
+  await page.waitForTimeout(500);
+
+  const card = page.locator('text=Plays by Source').locator('xpath=ancestor::*[contains(@class,"rounded")][1]');
+  await expect(card).toBeVisible();
+  await card.screenshot({ path: path.join(OUT_DIR, '02-source-card.png') });
+});
+
+test('Analytics → Overview tab — for regression diff', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle');
+  await page.waitForTimeout(500);
+
+  await page.screenshot({
+    path: path.join(OUT_DIR, '03-overview.png'),
+    fullPage: true,
+  });
+});

--- a/tests/screenshots/tier2-verify.spec.ts
+++ b/tests/screenshots/tier2-verify.spec.ts
@@ -1,0 +1,57 @@
+/**
+ * Verify tier 1 + 2 DS changes landed on prod:
+ * - Sidebar Disc3 spins when audio plays
+ * - Queue panel "Now Playing" uses magenta accent
+ * - Player bar song title uses font-display
+ */
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test('player bar + sidebar (zoomed)', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+
+  // Sidebar header zoom.
+  const sidebar = page.locator('aside').first();
+  await sidebar.locator('a').first().screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'tier2-sidebar.png'),
+  }).catch(() => undefined);
+
+  // Player bar zoom (bottom of the page).
+  const playerBar = page.locator('[class*="audio-player"], [class*="PlayerBar"]').first();
+  await playerBar.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'tier2-player.png'),
+  }).catch(() => undefined);
+
+  // Verify spin class is on the sidebar Disc3 when something is playing.
+  // Land in the DOM regardless to capture state.
+  const sidebarDiscClass = await sidebar.locator('a').first().locator('svg').first().getAttribute('class');
+  console.log('Sidebar Disc3 class:', sidebarDiscClass);
+});
+
+test('queue panel now-playing magenta accent', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1000);
+
+  // Open the queue panel — usually a floating button at the bottom right.
+  const queueBtn = page.locator('button[aria-label*="queue" i], button[title*="queue" i]').first();
+  await queueBtn.click().catch(() => undefined);
+  await page.waitForTimeout(800);
+
+  // Snap the now-playing block if present.
+  const nowPlaying = page.locator('text=Now Playing').first();
+  if (await nowPlaying.isVisible().catch(() => false)) {
+    const block = nowPlaying.locator('xpath=ancestor::div[contains(@class,"border-b")][1]');
+    await block.screenshot({
+      path: path.join('tests', 'screenshots', 'out', 'tier2-now-playing.png'),
+    }).catch(() => undefined);
+  } else {
+    // Full screenshot for context if we can't isolate.
+    await page.screenshot({
+      path: path.join('tests', 'screenshots', 'out', 'tier2-queue-fallback.png'),
+      fullPage: false,
+    });
+  }
+});

--- a/tests/screenshots/zoom-source-card.spec.ts
+++ b/tests/screenshots/zoom-source-card.spec.ts
@@ -1,0 +1,22 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test('Zoom on Plays-by-Source card', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle');
+
+  const tabs = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+  await tabs.getByRole('tab', { name: 'Listening', exact: true }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/listening-history/by-source') && r.ok());
+  await page.waitForTimeout(1500); // give recharts plenty of animation time
+
+  const card = page.locator('text=Plays by Source').locator('xpath=ancestor::*[contains(@class,"rounded")][1]');
+  await expect(card).toBeVisible();
+  await card.screenshot({ path: path.join('tests', 'screenshots', 'out', 'zoom-source-card.png') });
+
+  // Dump the SVG so we can inspect path data if visuals are off.
+  const svg = await card.locator('svg').first().innerHTML();
+  console.log('SVG snippet:', svg.slice(0, 2000));
+});


### PR DESCRIPTION
## Summary
Brings the visual language from the Discovery tab (\`AdvancedDiscoveryAnalytics\`) back to the rest of the Analytics page so the whole \`/dashboard/analytics\` route feels consistent.

- New shared **StatCard** primitive: icon-prefixed header, tight mobile padding (\`p-3\` / \`p-6 sm:\`), value with optional inline trend chip or progress bar.
- **Overview tab**: 4-up stat grid — Feedback / Accept Rate / New Artists / Diversity (with progress bar) — replaces the 3-up uppercase-label cards.
- **Quality + Discovery tabs**: MetricCards swapped for StatCards with matching icon headers; 2-col on mobile, 3-col on desktop.
- Old \`MetricCard\` primitive removed.

This is step (b) of the polish sweep. Step (a) — targeted polish on \`dashboard/history\` and \`library/artists\` — will be a separate PR.

## Test plan
- [ ] Desktop: Overview tab shows 4 cards in a row at lg+
- [ ] Mobile: Overview cards stack 2x2
- [ ] Diversity card shows the progress bar
- [ ] Accept Rate card shows the trend arrow when quality trend is set
- [ ] Quality / Discovery tabs match the same compact card style