### PR TITLE
style(history,artists): Step (a) — DS treatments on listening history + artists

### DIFF
--- a/src/components/library/ArtistsList.tsx
+++ b/src/components/library/ArtistsList.tsx
@@ -244,6 +244,7 @@ export function ArtistsList() {
       icon={<Users className="h-5 w-5" />}
       backLink="/dashboard"
       backLabel="Dashboard"
+      wide
     >
       {/* Filters + Search link */}
       <PageSection>
@@ -277,7 +278,7 @@ export function ArtistsList() {
       {/* Artist Grid */}
       <PageSection>
         {isLoading ? (
-          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-5">
+          <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 3xl:grid-cols-8 gap-4 sm:gap-5">
             {Array.from({ length: 12 }).map((_, i) => (
               <ArtistCardSkeleton key={i} />
             ))}
@@ -290,7 +291,7 @@ export function ArtistsList() {
           />
         ) : (
           <>
-            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 gap-4 sm:gap-5">
+            <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5 xl:grid-cols-6 2xl:grid-cols-7 3xl:grid-cols-8 gap-4 sm:gap-5">
               {visible.map((artist) => {
                 const key = artist.name.toLowerCase();
                 return (

--- a/src/routes/dashboard/history.tsx
+++ b/src/routes/dashboard/history.tsx
@@ -10,7 +10,8 @@ import { PageLayout } from '@/components/ui/page-layout';
 import { Card, CardContent } from '@/components/ui/card';
 import { Button } from '@/components/ui/button';
 import { cn } from '@/lib/utils';
-import { Clock, Music, SkipForward, CheckCircle2, Repeat, Loader2 } from 'lucide-react';
+import { Clock, Music, SkipForward, CheckCircle2, Repeat, Loader2, Headphones, Disc, RotateCcw } from 'lucide-react';
+import { StatCard } from '@/components/recommendations/StatCard';
 import { useState, useCallback, useRef } from 'react';
 import { useQuery } from '@tanstack/react-query';
 
@@ -151,27 +152,27 @@ function HistoryPage() {
         </div>
       }
     >
-      {/* Summary Stats */}
+      {/* Summary Stats — canonical AIDJ StatCard treatment */}
       {summary && (
-        <div className="grid grid-cols-3 gap-3 sm:gap-4">
-          <Card>
-            <CardContent className="p-4 text-center">
-              <p className="text-2xl sm:text-3xl font-bold">{summary.totalPlays}</p>
-              <p className="text-xs sm:text-sm text-muted-foreground">Total Plays</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <p className="text-2xl sm:text-3xl font-bold">{summary.uniqueSongs}</p>
-              <p className="text-xs sm:text-sm text-muted-foreground">Unique Songs</p>
-            </CardContent>
-          </Card>
-          <Card>
-            <CardContent className="p-4 text-center">
-              <p className="text-2xl sm:text-3xl font-bold">{summary.repeatCount}</p>
-              <p className="text-xs sm:text-sm text-muted-foreground">Repeated Songs</p>
-            </CardContent>
-          </Card>
+        <div className="grid grid-cols-3 gap-2 sm:gap-4">
+          <StatCard
+            icon={Headphones}
+            label="Total Plays"
+            value={summary.totalPlays.toLocaleString()}
+            gradient
+            glow
+          />
+          <StatCard
+            icon={Disc}
+            label="Unique Songs"
+            value={summary.uniqueSongs.toLocaleString()}
+          />
+          <StatCard
+            icon={RotateCcw}
+            label="Repeated"
+            value={summary.repeatCount.toLocaleString()}
+            caption={summary.repeatCount > 0 ? 'Songs played 2+ times' : 'No repeats yet'}
+          />
         </div>
       )}
 

--- a/src/routes/dashboard/history.tsx
+++ b/src/routes/dashboard/history.tsx
@@ -152,9 +152,11 @@ function HistoryPage() {
         </div>
       }
     >
-      {/* Summary Stats — canonical AIDJ StatCard treatment */}
+      {/* Summary Stats — canonical AIDJ StatCard treatment.
+          1-up on mobile (each card has room for label + value + caption);
+          3-up on sm+ where there's enough horizontal room. */}
       {summary && (
-        <div className="grid grid-cols-3 gap-2 sm:gap-4">
+        <div className="grid grid-cols-1 gap-2 sm:grid-cols-3 sm:gap-4">
           <StatCard
             icon={Headphones}
             label="Total Plays"

--- a/tests/screenshots/history-verify.spec.ts
+++ b/tests/screenshots/history-verify.spec.ts
@@ -1,0 +1,22 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test('history page', async ({ page }) => {
+  await page.goto('/dashboard/history');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'history-deployed.png'),
+    fullPage: true,
+  });
+
+  // Zoom on the stat row.
+  const statRow = page.locator('text=Total Plays').locator('xpath=ancestor::*[contains(@class,"grid")][1]');
+  if (await statRow.isVisible().catch(() => false)) {
+    await statRow.screenshot({
+      path: path.join('tests', 'screenshots', 'out', 'history-stats.png'),
+    });
+  }
+});

--- a/tests/screenshots/tooltip-verify.spec.ts
+++ b/tests/screenshots/tooltip-verify.spec.ts
@@ -1,0 +1,77 @@
+/**
+ * Hover over chart elements to trigger tooltips, then snap.
+ * Verifies the popover-foreground / item-style fix landed.
+ */
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test('Listening tab donut tooltip', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  const tabs = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+  await tabs.getByRole('tab', { name: 'Listening', exact: true }).click();
+  await page.waitForResponse((r) => r.url().includes('/api/listening-history/by-source') && r.ok()).catch(() => undefined);
+  await page.waitForTimeout(1800);
+
+  // Hover over the largest pie slice. Recharts listens for synthetic React
+  // events, so dispatch mouseover via page.evaluate on the actual SVG path.
+  await page.evaluate(() => {
+    const path = document.querySelector('.recharts-pie-sector path');
+    if (!path) return;
+    const rect = path.getBoundingClientRect();
+    const event = new MouseEvent('mouseover', {
+      bubbles: true,
+      cancelable: true,
+      clientX: rect.x + rect.width / 2,
+      clientY: rect.y + rect.height / 2,
+    });
+    path.dispatchEvent(event);
+  });
+  await page.waitForTimeout(600);
+  // Snap the source card region for a close-up.
+  const card = page.locator('text=Plays by Source').locator('xpath=ancestor::*[contains(@class,"rounded")][1]');
+  await card.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'tooltip-donut.png'),
+  }).catch(async () => {
+    await page.screenshot({ path: path.join('tests', 'screenshots', 'out', 'tooltip-donut.png') });
+  });
+});
+
+test('Quality tab bar chart tooltip', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  const tabs = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+  await tabs.getByRole('tab', { name: 'Quality', exact: true }).click();
+  await page.waitForTimeout(2000);
+
+  const bar = page.locator('.recharts-bar-rectangle').first();
+  await bar.hover({ force: true });
+  await page.waitForTimeout(400);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'tooltip-bar.png'),
+  });
+});
+
+test('Activity hour line tooltip', async ({ page }) => {
+  await page.goto('/dashboard/analytics');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  const tabs = page.locator('[role="tablist"]').filter({ has: page.getByRole('tab', { name: 'Listening', exact: true }) });
+  await tabs.getByRole('tab', { name: 'Activity', exact: true }).click();
+  await page.waitForTimeout(2000);
+
+  // Hover roughly mid-chart on the line.
+  const lineChart = page.locator('text=Feedback Events by Hour').locator('xpath=ancestor::*[contains(@class,"rounded")][1]').locator('.recharts-surface').first();
+  const box = await lineChart.boundingBox();
+  if (box) {
+    // Two moves — first enters, second triggers tooltip update.
+    await page.mouse.move(box.x + box.width * 0.3, box.y + box.height * 0.5);
+    await page.waitForTimeout(150);
+    await page.mouse.move(box.x + box.width * 0.5, box.y + box.height * 0.5);
+    await page.waitForTimeout(400);
+  }
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'tooltip-line.png'),
+  });
+});


### PR DESCRIPTION
## Summary
Step (a) of the styling sweep — small, surgical applications of the canonical AIDJ design-system treatments to two high-traffic library pages.

### dashboard/history
- Summary stats row (Total Plays / Unique Songs / Repeated) routed through the shared StatCard primitive: font-display values, eyebrow labels, lucide icons (Headphones / Disc / RotateCcw).
- Total Plays gets the hero treatment (\`gradient\` + \`glow\` props).
- Repeated card surfaces a contextual caption ("Songs played 2+ times" / "No repeats yet").

### library/artists
- \`wide\` prop on PageLayout — page now uses the full content width on big monitors.
- Grid breakpoints extended to \`xl:6\` / \`2xl:7\` / \`3xl:8\` columns so 1080p+ displays pack more artists per row instead of just stretching cards.

## Test plan
- [ ] /dashboard/history — three stat cards render with new treatment, Total Plays has gradient + glow
- [ ] /library/artists — at 1080p+ packs 6+ artists per row
- [ ] Mobile: history cards stack 3-up, artists 2-up (unchanged)