### PR TITLE
feat(player): Phase A — unified Now Playing fullscreen chassis

### DIFF
--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -245,10 +245,11 @@ export function AppLayout({ children }: AppLayoutProps) {
       {/* Main content area with sidebars.
            Bottom padding reserves space so the fixed PlayerBar doesn't
            overlap sidebar bottom sections or the last playlist rows.
-           Mobile player is taller (~96px) than desktop (h-20 = 80px). */}
+           Mobile player is now ~64px (single row + thin top progress);
+           desktop is h-20 = 80px. pb-20 covers both. */}
       <div className={cn(
         "flex-1 flex overflow-hidden",
-        hasActiveSong && "pb-24 md:pb-20"
+        hasActiveSong && "pb-20"
       )}>
         {/* Left Sidebar - Navigation & Playlists */}
         <LeftSidebar />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -245,11 +245,10 @@ export function AppLayout({ children }: AppLayoutProps) {
       {/* Main content area with sidebars.
            Bottom padding reserves space so the fixed PlayerBar doesn't
            overlap sidebar bottom sections or the last playlist rows.
-           Mobile player is now ~64px (single row + thin top progress);
-           desktop is h-20 = 80px. pb-20 covers both. */}
+           Mobile player is taller (~96px) than desktop (h-20 = 80px). */}
       <div className={cn(
         "flex-1 flex overflow-hidden",
-        hasActiveSong && "pb-20"
+        hasActiveSong && "pb-24 md:pb-20"
       )}>
         {/* Left Sidebar - Navigation & Playlists */}
         <LeftSidebar />

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -245,10 +245,10 @@ export function AppLayout({ children }: AppLayoutProps) {
       {/* Main content area with sidebars.
            Bottom padding reserves space so the fixed PlayerBar doesn't
            overlap sidebar bottom sections or the last playlist rows.
-           Mobile player is taller (~96px) than desktop (h-20 = 80px). */}
+           Mobile player is taller (~104px) than desktop (h-20 = 80px). */}
       <div className={cn(
         "flex-1 flex overflow-hidden",
-        hasActiveSong && "pb-24 md:pb-20"
+        hasActiveSong && "pb-28 md:pb-20"
       )}>
         {/* Left Sidebar - Navigation & Playlists */}
         <LeftSidebar />

--- a/src/components/layout/NowPlayingFullscreen/ArtMode.tsx
+++ b/src/components/layout/NowPlayingFullscreen/ArtMode.tsx
@@ -1,0 +1,111 @@
+/**
+ * Art mode — the canonical big-album-art view with horizontal swipe to
+ * skip prev/next. This is the only mode in PR A; lyrics / visualizer /
+ * queue plug in via the same shape in subsequent PRs.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { cn } from '@/lib/utils';
+import { getCoverArtUrl } from '@/components/ui/album-art';
+import type { NowPlayingSong } from './types';
+
+interface ArtModeProps {
+  song: NowPlayingSong;
+  onPrevious: () => void;
+  onNext: () => void;
+}
+
+export function ArtMode({ song, onPrevious, onNext }: ArtModeProps) {
+  const [imgError, setImgError] = useState(false);
+  const [swipeDirection, setSwipeDirection] = useState<'left' | 'right' | null>(null);
+
+  const artSwipeRef = useRef<{ x: number; time: number } | null>(null);
+  const artOffsetRef = useRef(0);
+  const artContainerRef = useRef<HTMLDivElement>(null);
+
+  // eslint-disable-next-line react-hooks/set-state-in-effect
+  useEffect(() => { setImgError(false); }, [song.id]);
+
+  useEffect(() => {
+    if (!swipeDirection) return;
+    const t = setTimeout(() => setSwipeDirection(null), 300);
+    return () => clearTimeout(t);
+  }, [swipeDirection]);
+
+  const handleArtTouchStart = useCallback((e: React.TouchEvent) => {
+    artSwipeRef.current = { x: e.touches[0].clientX, time: Date.now() };
+    artOffsetRef.current = 0;
+  }, []);
+
+  const handleArtTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!artSwipeRef.current) return;
+    const deltaX = e.touches[0].clientX - artSwipeRef.current.x;
+    artOffsetRef.current = deltaX;
+    if (artContainerRef.current) {
+      const dampened = deltaX * 0.6;
+      artContainerRef.current.style.transform = `translateX(${dampened}px)`;
+      artContainerRef.current.style.transition = 'none';
+      artContainerRef.current.style.opacity = `${1 - Math.abs(dampened) / 400}`;
+    }
+  }, []);
+
+  const handleArtTouchEnd = useCallback(() => {
+    if (artContainerRef.current) {
+      const offset = artOffsetRef.current;
+      const velocity = artSwipeRef.current
+        ? Math.abs(offset) / (Date.now() - artSwipeRef.current.time)
+        : 0;
+      if (Math.abs(offset) > 80 || velocity > 0.3) {
+        if (offset > 0) {
+          setSwipeDirection('right');
+          onPrevious();
+        } else {
+          setSwipeDirection('left');
+          onNext();
+        }
+      }
+      artContainerRef.current.style.transition = 'transform 250ms cubic-bezier(0.32, 0.72, 0, 1), opacity 250ms ease';
+      artContainerRef.current.style.transform = 'translateX(0)';
+      artContainerRef.current.style.opacity = '1';
+    }
+    artSwipeRef.current = null;
+    artOffsetRef.current = 0;
+  }, [onNext, onPrevious]);
+
+  const artId = song.albumId || song.id;
+  const coverUrl = getCoverArtUrl(artId, 600);
+  const songArtist = song.artist || 'Unknown';
+
+  return (
+    <div
+      className="w-[75vw] sm:w-[60vw] md:w-[50vw] lg:w-auto lg:flex-1 max-w-[500px] aspect-square relative mx-auto lg:mx-0 overflow-visible touch-pan-y flex-shrink-0"
+      onTouchStart={handleArtTouchStart}
+      onTouchMove={handleArtTouchMove}
+      onTouchEnd={handleArtTouchEnd}
+    >
+      <div
+        ref={artContainerRef}
+        className={cn(
+          'w-full h-full',
+          swipeDirection === 'left' && 'animate-[slideInRight_250ms_ease-out]',
+          swipeDirection === 'right' && 'animate-[slideInLeft_250ms_ease-out]',
+        )}
+      >
+        {coverUrl && !imgError ? (
+          <img
+            src={coverUrl}
+            alt={`${song.name || song.title || 'Unknown'} album art`}
+            className="w-full h-full object-cover rounded-2xl shadow-2xl shadow-black/50 select-none pointer-events-none"
+            onError={() => setImgError(true)}
+            draggable={false}
+          />
+        ) : (
+          <div className="w-full h-full rounded-2xl bg-white/10 flex items-center justify-center">
+            <span className="text-5xl sm:text-6xl lg:text-7xl font-bold text-white/30">
+              {songArtist.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase()}
+            </span>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/layout/NowPlayingFullscreen/NowPlayingFullscreen.tsx
+++ b/src/components/layout/NowPlayingFullscreen/NowPlayingFullscreen.tsx
@@ -1,5 +1,14 @@
-import React, { useRef, useCallback, useEffect, useState } from 'react';
+/**
+ * Unified Now Playing fullscreen surface (chassis).
+ *
+ * Replaces the old single-purpose FullscreenPlayer. The chassis renders
+ * the persistent header, metadata, scrubber, and transport — and swaps
+ * out a mode-specific content area in the middle. Phase A only ships
+ * the 'art' mode; phases B/C/D add lyrics / visualizer / queue.
+ */
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
+import { Link } from '@tanstack/react-router';
 import {
   ChevronDown,
   SkipBack,
@@ -21,6 +30,8 @@ import { getCoverArtUrl } from '@/components/ui/album-art';
 import { cn } from '@/lib/utils';
 import { AIDJToggle } from '@/components/ai-dj-toggle';
 import { useAudioStore } from '@/lib/stores/audio';
+import { ArtMode } from './ArtMode';
+import type { NowPlayingFullscreenProps, NPMode } from './types';
 
 const formatTime = (time: number) => {
   if (!isFinite(time) || time < 0) return '0:00';
@@ -29,31 +40,10 @@ const formatTime = (time: number) => {
   return `${minutes}:${seconds.toString().padStart(2, '0')}`;
 };
 
-export interface FullscreenPlayerProps {
-  isOpen: boolean;
-  onClose: () => void;
-  currentSong: { id: string; name?: string; title?: string; artist?: string; albumId?: string } | null;
-  isPlaying: boolean;
-  isLoading: boolean;
-  currentTime: number;
-  duration: number;
-  isLiked: boolean;
-  isLikePending: boolean;
-  isShuffled: boolean;
-  repeatMode: 'off' | 'all' | 'one';
-  onTogglePlayPause: () => void;
-  onPrevious: () => void;
-  onNext: () => void;
-  onSeek: (time: number) => void;
-  onToggleLike: () => void;
-  onToggleShuffle: () => void;
-  onToggleRepeat: () => void;
-  onShowLyrics: () => void;
-}
-
-export function FullscreenPlayer({
+export function NowPlayingFullscreen({
   isOpen,
   onClose,
+  initialMode = 'art',
   currentSong,
   isPlaying,
   isLoading,
@@ -71,163 +61,89 @@ export function FullscreenPlayer({
   onToggleShuffle,
   onToggleRepeat,
   onShowLyrics,
-}: FullscreenPlayerProps) {
+}: NowPlayingFullscreenProps) {
+  const startRadio = useAudioStore((s) => s.startRadio);
+
   const [visible, setVisible] = useState(false);
   const [animating, setAnimating] = useState(false);
-  const [imgError, setImgError] = useState(false);
-  const [swipeDirection, setSwipeDirection] = useState<'left' | 'right' | null>(null);
+  // Reserved for phase B+ pill switcher. Kept stateful now so the chassis
+  // shape is locked in even though only ArtMode renders today.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const [mode, _setMode] = useState<NPMode>(initialMode);
 
-  // Vertical swipe-to-dismiss refs
   const touchStartRef = useRef<{ x: number; y: number; time: number } | null>(null);
   const touchOffsetRef = useRef(0);
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Horizontal swipe refs for album art
-  const artSwipeRef = useRef<{ x: number; time: number } | null>(null);
-  const artOffsetRef = useRef(0);
-  const artAxisLockedRef = useRef<'x' | 'y' | null>(null);
-  const artContainerRef = useRef<HTMLDivElement>(null);
-
-  // Handle open/close animation — setState drives mount/unmount for CSS transitions
+  // Mount/unmount with CSS-driven slide-up animation.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
     if (isOpen) {
       setVisible(true);
-      // Trigger animation on next frame
-      requestAnimationFrame(() => {
-        requestAnimationFrame(() => setAnimating(true));
-      });
+      requestAnimationFrame(() => requestAnimationFrame(() => setAnimating(true)));
     } else {
       setAnimating(false);
-      const timer = setTimeout(() => setVisible(false), 300);
-      return () => clearTimeout(timer);
+      const t = setTimeout(() => setVisible(false), 300);
+      return () => clearTimeout(t);
     }
   }, [isOpen]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
-  // Reset image error on song change
-  const currentSongId = currentSong?.id;
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => { setImgError(false); }, [currentSongId]);
-
-  // Clear swipe animation after it plays
-  useEffect(() => {
-    if (!swipeDirection) return;
-    const timer = setTimeout(() => setSwipeDirection(null), 300);
-    return () => clearTimeout(timer);
-  }, [swipeDirection]);
-
-  // --- Album art horizontal swipe (prev/next song) ---
-  const handleArtTouchStart = useCallback((e: React.TouchEvent) => {
-    artSwipeRef.current = { x: e.touches[0].clientX, time: Date.now() };
-    artOffsetRef.current = 0;
-    artAxisLockedRef.current = null;
-    // Also store Y for axis detection
+  // Vertical swipe-to-dismiss on the body (not the art swipe area).
+  const handleBodyTouchStart = useCallback((e: React.TouchEvent) => {
     touchStartRef.current = { x: e.touches[0].clientX, y: e.touches[0].clientY, time: Date.now() };
     touchOffsetRef.current = 0;
   }, []);
 
-  const handleArtTouchMove = useCallback((e: React.TouchEvent) => {
-    if (!artSwipeRef.current || !touchStartRef.current) return;
-
-    const deltaX = e.touches[0].clientX - artSwipeRef.current.x;
+  const handleBodyTouchMove = useCallback((e: React.TouchEvent) => {
+    if (!touchStartRef.current) return;
     const deltaY = e.touches[0].clientY - touchStartRef.current.y;
-
-    // Lock axis once movement exceeds threshold
-    if (!artAxisLockedRef.current) {
-      if (Math.abs(deltaX) > 10 || Math.abs(deltaY) > 10) {
-        artAxisLockedRef.current = Math.abs(deltaX) > Math.abs(deltaY) ? 'x' : 'y';
-      } else {
-        return;
-      }
-    }
-
-    if (artAxisLockedRef.current === 'x') {
-      // Horizontal: drag album art
-      e.preventDefault();
-      artOffsetRef.current = deltaX;
-      if (artContainerRef.current) {
-        // Dampen the drag slightly for a rubbery feel
-        const dampened = deltaX * 0.6;
-        artContainerRef.current.style.transform = `translateX(${dampened}px)`;
-        artContainerRef.current.style.transition = 'none';
-        // Reduce opacity as it moves away
-        artContainerRef.current.style.opacity = `${1 - Math.abs(dampened) / 400}`;
-      }
-    } else {
-      // Vertical: dismiss (delegate to container)
-      if (deltaY > 0 && containerRef.current) {
-        touchOffsetRef.current = deltaY;
-        containerRef.current.style.transform = `translateY(${deltaY}px)`;
-        containerRef.current.style.transition = 'none';
-      }
+    if (deltaY > 0 && containerRef.current) {
+      touchOffsetRef.current = deltaY;
+      containerRef.current.style.transform = `translateY(${deltaY}px)`;
+      containerRef.current.style.transition = 'none';
     }
   }, []);
 
-  const handleArtTouchEnd = useCallback(() => {
-    const axis = artAxisLockedRef.current;
-
-    if (axis === 'x' && artContainerRef.current) {
-      const offset = artOffsetRef.current;
-      const velocity = artSwipeRef.current
-        ? Math.abs(offset) / (Date.now() - artSwipeRef.current.time)
-        : 0;
-
-      // Trigger if dragged >80px or fast flick (>0.3px/ms)
-      if (Math.abs(offset) > 80 || velocity > 0.3) {
-        if (offset > 0) {
-          // Swipe right → previous
-          setSwipeDirection('right');
-          onPrevious();
-        } else {
-          // Swipe left → next
-          setSwipeDirection('left');
-          onNext();
-        }
-      }
-
-      // Snap back
-      artContainerRef.current.style.transition = 'transform 250ms cubic-bezier(0.32, 0.72, 0, 1), opacity 250ms ease';
-      artContainerRef.current.style.transform = 'translateX(0)';
-      artContainerRef.current.style.opacity = '1';
-    } else if (axis === 'y' || !axis) {
-      // Vertical dismiss or no movement
-      if (containerRef.current) {
-        containerRef.current.style.transition = 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)';
-        if (touchOffsetRef.current > 100) {
-          containerRef.current.style.transform = 'translateY(100%)';
-          onClose();
-        } else {
-          containerRef.current.style.transform = 'translateY(0)';
-        }
+  const handleBodyTouchEnd = useCallback(() => {
+    if (containerRef.current) {
+      containerRef.current.style.transition = 'transform 300ms cubic-bezier(0.32, 0.72, 0, 1)';
+      if (touchOffsetRef.current > 100) {
+        containerRef.current.style.transform = 'translateY(100%)';
+        onClose();
+      } else {
+        containerRef.current.style.transform = 'translateY(0)';
       }
     }
-
-    artSwipeRef.current = null;
-    artOffsetRef.current = 0;
-    artAxisLockedRef.current = null;
     touchStartRef.current = null;
     touchOffsetRef.current = 0;
-  }, [onClose, onPrevious, onNext]);
+  }, [onClose]);
 
-  // Close on Escape
+  // Esc to close.
   useEffect(() => {
     if (!isOpen) return;
-    const handleKey = (e: KeyboardEvent) => {
+    const onKey = (e: KeyboardEvent) => {
       if (e.key === 'Escape') onClose();
     };
-    window.addEventListener('keydown', handleKey);
-    return () => window.removeEventListener('keydown', handleKey);
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
   }, [isOpen, onClose]);
+
+  // Closes the surface, then runs an action (used by clickable artist link
+  // and song-radio trigger so the navigation/queue change isn't hidden
+  // behind the open fullscreen).
+  const closeAndThen = useCallback((fn: () => void) => {
+    onClose();
+    setTimeout(fn, 150);
+  }, [onClose]);
 
   if (!visible || !currentSong) return null;
 
-  // Use albumId or fall back to songId for cover art
   const artId = currentSong.albumId || currentSong.id;
-  const coverUrl = getCoverArtUrl(artId, 600);
-  const bgCoverUrl = getCoverArtUrl(artId, 128); // smaller for blurred bg
+  const bgCoverUrl = getCoverArtUrl(artId, 128);
   const songTitle = currentSong.name || currentSong.title || 'Unknown';
   const songArtist = currentSong.artist || 'Unknown';
+  const artistId = currentSong.artistId;
 
   return createPortal(
     <div
@@ -236,9 +152,8 @@ export function FullscreenPlayer({
         animating ? 'opacity-100' : 'opacity-0'
       )}
     >
-      {/* Solid black base — nothing bleeds through */}
+      {/* Solid black base + blurred album art tint */}
       <div className="absolute inset-0 bg-black" />
-      {/* Blurred album art tint on top */}
       {bgCoverUrl && (
         <div
           className="absolute inset-0 bg-cover bg-center scale-110 blur-3xl opacity-40"
@@ -247,15 +162,18 @@ export function FullscreenPlayer({
       )}
       <div className="absolute inset-0 bg-black/40" />
 
-      {/* Content container */}
+      {/* Slide-up container */}
       <div
         ref={containerRef}
         className={cn(
           'relative h-full flex flex-col transition-transform duration-300 ease-[cubic-bezier(0.32,0.72,0,1)]',
           animating ? 'translate-y-0' : 'translate-y-full'
         )}
+        onTouchStart={handleBodyTouchStart}
+        onTouchMove={handleBodyTouchMove}
+        onTouchEnd={handleBodyTouchEnd}
       >
-        {/* Top bar */}
+        {/* Persistent header */}
         <div className="flex items-center justify-between px-4 pt-[calc(env(safe-area-inset-top)+0.75rem)] py-3">
           <Button
             variant="ghost"
@@ -268,54 +186,51 @@ export function FullscreenPlayer({
           <p className="text-xs font-medium text-white/60 uppercase tracking-wider">
             Now Playing
           </p>
-          <div className="w-10" /> {/* Spacer for centering */}
+          <div className="w-10" /> {/* spacer for centering */}
         </div>
 
-        {/* Main content - portrait on mobile, landscape side-by-side on desktop */}
+        {/* Mode swap area + persistent metadata/transport (portrait stack on
+            mobile, side-by-side on desktop) */}
         <div className="flex-1 flex flex-col lg:flex-row items-center justify-center px-6 sm:px-8 lg:px-16 mx-auto w-full gap-6 sm:gap-8 lg:gap-16 max-w-6xl">
 
-          {/* Album Art — swipeable */}
-          <div
-            className="w-[75vw] sm:w-[60vw] md:w-[50vw] lg:w-auto lg:flex-1 max-w-[500px] aspect-square relative mx-auto lg:mx-0 overflow-visible touch-pan-y flex-shrink-0"
-            onTouchStart={handleArtTouchStart}
-            onTouchMove={handleArtTouchMove}
-            onTouchEnd={handleArtTouchEnd}
-          >
-            <div
-              ref={artContainerRef}
-              className={cn(
-                'w-full h-full',
-                swipeDirection === 'left' && 'animate-[slideInRight_250ms_ease-out]',
-                swipeDirection === 'right' && 'animate-[slideInLeft_250ms_ease-out]',
-              )}
-            >
-              {coverUrl && !imgError ? (
-                <img
-                  src={coverUrl}
-                  alt={`${songTitle} album art`}
-                  className="w-full h-full object-cover rounded-2xl shadow-2xl shadow-black/50 select-none pointer-events-none"
-                  onError={() => setImgError(true)}
-                  draggable={false}
-                />
-              ) : (
-                <div className="w-full h-full rounded-2xl bg-white/10 flex items-center justify-center">
-                  <span className="text-5xl sm:text-6xl lg:text-7xl font-bold text-white/30">
-                    {songArtist.split(' ').map(n => n[0]).join('').slice(0, 2).toUpperCase()}
-                  </span>
-                </div>
-              )}
-            </div>
-          </div>
+          {/* === Mode swap area === */}
+          {mode === 'art' && (
+            <ArtMode song={currentSong} onPrevious={onPrevious} onNext={onNext} />
+          )}
 
-          {/* Controls column */}
+          {/* === Persistent metadata + transport column === */}
           <div className="w-full lg:flex-1 lg:max-w-md flex flex-col items-center gap-6 sm:gap-8">
-            {/* Song info */}
+            {/* Song info — clickable title + artist */}
             <div className="w-full text-center lg:text-left">
-              <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-white truncate">{songTitle}</h2>
-              <p className="text-sm sm:text-base text-white/60 mt-1 truncate">{songArtist}</p>
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  closeAndThen(() => { void startRadio({ kind: 'song', songId: currentSong.id }); });
+                }}
+                title="Start radio from this song"
+                className="text-xl sm:text-2xl lg:text-3xl font-bold text-white truncate hover:underline focus:outline-none focus:underline w-full text-center lg:text-left"
+              >
+                {songTitle}
+              </button>
+              {artistId ? (
+                <Link
+                  to="/library/artists/$id"
+                  params={{ id: artistId }}
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    closeAndThen(() => undefined);
+                  }}
+                  className="text-sm sm:text-base text-white/60 mt-1 truncate hover:text-white hover:underline block"
+                >
+                  {songArtist}
+                </Link>
+              ) : (
+                <p className="text-sm sm:text-base text-white/60 mt-1 truncate">{songArtist}</p>
+              )}
             </div>
 
-            {/* Progress */}
+            {/* Scrubber */}
             <div className="w-full space-y-2">
               <Slider
                 value={[isFinite(currentTime) ? currentTime : 0]}
@@ -330,7 +245,7 @@ export function FullscreenPlayer({
               </div>
             </div>
 
-            {/* Main controls */}
+            {/* Transport */}
             <div className="flex items-center justify-center gap-4 sm:gap-6 w-full">
               <Button
                 variant="ghost"
@@ -343,7 +258,6 @@ export function FullscreenPlayer({
               >
                 <Shuffle className="h-5 w-5" />
               </Button>
-
               <Button
                 variant="ghost"
                 size="sm"
@@ -352,7 +266,6 @@ export function FullscreenPlayer({
               >
                 <SkipBack className="h-6 w-6 sm:h-7 sm:w-7 fill-current" />
               </Button>
-
               <Button
                 variant="default"
                 size="sm"
@@ -368,7 +281,6 @@ export function FullscreenPlayer({
                   <Play className="h-7 w-7 sm:h-8 sm:w-8 ml-1" />
                 )}
               </Button>
-
               <Button
                 variant="ghost"
                 size="sm"
@@ -377,7 +289,6 @@ export function FullscreenPlayer({
               >
                 <SkipForward className="h-6 w-6 sm:h-7 sm:w-7 fill-current" />
               </Button>
-
               <Button
                 variant="ghost"
                 size="sm"
@@ -387,11 +298,7 @@ export function FullscreenPlayer({
                 )}
                 onClick={onToggleRepeat}
               >
-                {repeatMode === 'one' ? (
-                  <Repeat1 className="h-5 w-5" />
-                ) : (
-                  <Repeat className="h-5 w-5" />
-                )}
+                {repeatMode === 'one' ? <Repeat1 className="h-5 w-5" /> : <Repeat className="h-5 w-5" />}
               </Button>
             </div>
 
@@ -406,35 +313,28 @@ export function FullscreenPlayer({
               >
                 <Heart className={cn('h-5 w-5', isLiked && 'fill-red-500 text-red-500')} />
               </Button>
-
               <Button
                 variant="ghost"
                 size="sm"
                 className="h-10 w-10 p-0 text-white/70 hover:text-white hover:bg-white/10"
                 onClick={onShowLyrics}
+                title="Lyrics"
               >
                 <MicVocal className="h-5 w-5" />
               </Button>
-
               <Button
                 variant="ghost"
                 size="sm"
                 className="h-10 w-10 p-0 text-white/70 hover:text-white hover:bg-white/10"
-                onClick={() => {
-                  onClose();
-                  setTimeout(() => {
-                    useAudioStore.getState().toggleQueuePanel();
-                  }, 150);
-                }}
+                onClick={() => closeAndThen(() => {
+                  useAudioStore.getState().toggleQueuePanel();
+                })}
               >
                 <ListMusic className="h-5 w-5" />
               </Button>
-
-              {/* AI DJ toggle — styled for dark fullscreen context */}
               <div className="[&_label]:text-white/70 [&_[data-state=checked]]:bg-primary">
                 <AIDJToggle compact />
               </div>
-
               <Button
                 variant="ghost"
                 size="sm"
@@ -454,10 +354,10 @@ export function FullscreenPlayer({
           </div>
         </div>
 
-        {/* Bottom safe area spacer */}
         <div className="h-8 pb-[env(safe-area-inset-bottom)]" />
       </div>
     </div>,
     document.body
   );
 }
+

--- a/src/components/layout/NowPlayingFullscreen/NowPlayingFullscreen.tsx
+++ b/src/components/layout/NowPlayingFullscreen/NowPlayingFullscreen.tsx
@@ -62,8 +62,6 @@ export function NowPlayingFullscreen({
   onToggleRepeat,
   onShowLyrics,
 }: NowPlayingFullscreenProps) {
-  const startRadio = useAudioStore((s) => s.startRadio);
-
   const [visible, setVisible] = useState(false);
   const [animating, setAnimating] = useState(false);
   // Reserved for phase B+ pill switcher. Kept stateful now so the chassis
@@ -200,27 +198,26 @@ export function NowPlayingFullscreen({
 
           {/* === Persistent metadata + transport column === */}
           <div className="w-full lg:flex-1 lg:max-w-md flex flex-col items-center gap-6 sm:gap-8">
-            {/* Song info — clickable title + artist */}
+            {/* Song info — title links to album page (song info context); artist links to artist page */}
             <div className="w-full text-center lg:text-left">
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  closeAndThen(() => { void startRadio({ kind: 'song', songId: currentSong.id }); });
-                }}
-                title="Start radio from this song"
-                className="text-xl sm:text-2xl lg:text-3xl font-bold text-white truncate hover:underline focus:outline-none focus:underline w-full text-center lg:text-left"
-              >
-                {songTitle}
-              </button>
+              {artistId && currentSong.albumId ? (
+                <Link
+                  to="/library/artists/$id/albums/$albumId"
+                  params={{ id: artistId, albumId: currentSong.albumId }}
+                  onClick={() => onClose()}
+                  className="text-xl sm:text-2xl lg:text-3xl font-bold text-white truncate hover:underline focus:outline-none focus:underline block"
+                  title="View album"
+                >
+                  {songTitle}
+                </Link>
+              ) : (
+                <h2 className="text-xl sm:text-2xl lg:text-3xl font-bold text-white truncate">{songTitle}</h2>
+              )}
               {artistId ? (
                 <Link
                   to="/library/artists/$id"
                   params={{ id: artistId }}
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    closeAndThen(() => undefined);
-                  }}
+                  onClick={() => onClose()}
                   className="text-sm sm:text-base text-white/60 mt-1 truncate hover:text-white hover:underline block"
                 >
                   {songArtist}

--- a/src/components/layout/NowPlayingFullscreen/index.ts
+++ b/src/components/layout/NowPlayingFullscreen/index.ts
@@ -1,0 +1,2 @@
+export { NowPlayingFullscreen } from './NowPlayingFullscreen';
+export type { NowPlayingFullscreenProps, NowPlayingSong, NPMode } from './types';

--- a/src/components/layout/NowPlayingFullscreen/types.ts
+++ b/src/components/layout/NowPlayingFullscreen/types.ts
@@ -1,0 +1,45 @@
+/**
+ * Modes the unified Now Playing surface can render. Phase A ships only
+ * 'art'; lyrics/visualizer/queue are wired in subsequent phases.
+ */
+export type NPMode = 'art' | 'lyrics' | 'visualizer' | 'queue';
+
+export interface NowPlayingSong {
+  id: string;
+  name?: string;
+  title?: string;
+  artist?: string;
+  albumId?: string;
+  /**
+   * Navidrome artist id (when available). When set, the artist name in
+   * both PlayerBar and the fullscreen view becomes a link to the artist
+   * detail page.
+   */
+  artistId?: string;
+}
+
+export interface NowPlayingFullscreenProps {
+  isOpen: boolean;
+  onClose: () => void;
+  /** Mode to start in. Defaults to 'art'. */
+  initialMode?: NPMode;
+  currentSong: NowPlayingSong | null;
+  isPlaying: boolean;
+  isLoading: boolean;
+  currentTime: number;
+  duration: number;
+  isLiked: boolean;
+  isLikePending: boolean;
+  isShuffled: boolean;
+  repeatMode: 'off' | 'all' | 'one';
+  onTogglePlayPause: () => void;
+  onPrevious: () => void;
+  onNext: () => void;
+  onSeek: (time: number) => void;
+  onToggleLike: () => void;
+  onToggleShuffle: () => void;
+  onToggleRepeat: () => void;
+  /** Phase A: triggered by the lyrics button in the chassis footer.
+   *  Phase B replaces this with an internal mode switch. */
+  onShowLyrics: () => void;
+}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -846,28 +846,26 @@ export function PlayerBar() {
 
   return (
     <>
-      {/* Mobile Layout */}
-      <div className="md:hidden px-3 py-1.5 space-y-1.5">
-        {/* Progress bar at top */}
-        <div className="flex items-center gap-2">
-          <span className={cn("text-[10px] font-mono w-8 text-right", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
-            {formatTime(displayCurrentTime)}
-          </span>
-          <Slider
-            value={[isFinite(displayCurrentTime) ? displayCurrentTime : 0]}
-            max={isFinite(displayDuration) && displayDuration > 0 ? displayDuration : 100}
-            step={0.1}
-            onValueChange={([newValue]) => seek(newValue)}
-            className={cn("flex-1 h-1", showRemoteTime && "[&_[data-slot=slider-range]]:bg-green-500 [&_[data-slot=slider-thumb]]:border-green-500")}
-            disabled={showRemoteTime}
+      {/* Mobile Layout — single compact row + thin top progress (matches desktop pattern) */}
+      <div className="md:hidden relative">
+        {/* Thin progress at top — tap to seek */}
+        <div
+          className="absolute top-0 left-0 right-0 h-1 bg-muted cursor-pointer"
+          onClick={(e) => {
+            if (showRemoteTime || !isFinite(displayDuration) || displayDuration <= 0) return;
+            const rect = e.currentTarget.getBoundingClientRect();
+            const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
+            seek(pct * displayDuration);
+          }}
+        >
+          <div
+            className={cn("h-full transition-all duration-100", showRemoteTime ? "bg-green-500" : "bg-primary")}
+            style={{ width: `${progressPercent}%` }}
           />
-          <span className={cn("text-[10px] font-mono w-8", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
-            -{formatTime(Math.max(0, displayDuration - displayCurrentTime))}
-          </span>
         </div>
 
         {/* Main row: Album art, song info, controls */}
-        <div className="flex items-center gap-3">
+        <div className="px-3 py-2 flex items-center gap-3">
           {/* Small Album Artwork */}
           <div className={cn(
             "flex items-center gap-3 min-w-0 flex-1 rounded-lg transition-all",

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -880,7 +880,6 @@ export function PlayerBar() {
                 artist={currentSong.artist}
                 size="sm"
                 isPlaying={isPlaying || isRemotePlaying}
-                className="!w-10 !h-10"
               />
               {/* Tap indicator — subtle expand icon */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-active/art:bg-black/30 transition-colors rounded-md">

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -152,9 +152,6 @@ export function PlayerBar() {
   const currentSong = useMemo(() => playlist[currentSongIndex] || null, [playlist, currentSongIndex]) as Song | null;
   const queryClient = useQueryClient();
 
-  // Pulled separately so the song-title click can start a song-seeded radio.
-  const startRadio = useAudioStore((s) => s.startRadio);
-
   // Remote device state for cross-device sync indicator
   const remoteDevice = useAudioStore((s) => s.remoteDevice);
   const isRemotePlaying = !!remoteDevice?.isPlaying;
@@ -870,19 +867,23 @@ export function PlayerBar() {
               </div>
             </div>
 
-            {/* Song Info — title starts a song-seeded radio; artist links to artist page */}
+            {/* Song Info — title links to album page (song info context); artist links to artist page */}
             <div className="min-w-0 flex-1">
-              <button
-                type="button"
-                className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors text-left w-full hover:underline", showRemoteTime && "text-green-500")}
-                onClick={(e) => {
-                  e.stopPropagation();
-                  void startRadio({ kind: 'song', songId: currentSong.id });
-                }}
-                title="Start radio from this song"
-              >
-                {currentSong.name || currentSong.title}
-              </button>
+              {(currentSong as { artistId?: string }).artistId && currentSong.albumId ? (
+                <Link
+                  to="/library/artists/$id/albums/$albumId"
+                  params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
+                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
+                  onClick={(e) => e.stopPropagation()}
+                  title="View album"
+                >
+                  {currentSong.name || currentSong.title}
+                </Link>
+              ) : (
+                <p className={cn("font-display font-semibold text-sm truncate", showRemoteTime && "text-green-500")}>
+                  {currentSong.name || currentSong.title}
+                </p>
+              )}
               {(currentSong as { artistId?: string }).artistId ? (
                 <Link
                   to="/library/artists/$id"
@@ -988,14 +989,20 @@ export function PlayerBar() {
             />
           </div>
           <div className="min-w-0">
-            <button
-              type="button"
-              className={cn("font-display font-semibold truncate text-sm text-left w-full hover:underline", showRemoteTime && "text-green-500")}
-              onClick={() => { void startRadio({ kind: 'song', songId: currentSong.id }); }}
-              title="Start radio from this song"
-            >
-              {currentSong.name || currentSong.title}
-            </button>
+            {(currentSong as { artistId?: string }).artistId && currentSong.albumId ? (
+              <Link
+                to="/library/artists/$id/albums/$albumId"
+                params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
+                className={cn("font-display font-semibold truncate text-sm block hover:underline", showRemoteTime && "text-green-500")}
+                title="View album"
+              >
+                {currentSong.name || currentSong.title}
+              </Link>
+            ) : (
+              <p className={cn("font-display font-semibold truncate text-sm", showRemoteTime && "text-green-500")}>
+                {currentSong.name || currentSong.title}
+              </p>
+            )}
             {(currentSong as { artistId?: string }).artistId ? (
               <Link
                 to="/library/artists/$id"

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -880,6 +880,7 @@ export function PlayerBar() {
                 artist={currentSong.artist}
                 size="sm"
                 isPlaying={isPlaying || isRemotePlaying}
+                className="!w-10 !h-10"
               />
               {/* Tap indicator — subtle expand icon */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-active/art:bg-black/30 transition-colors rounded-md">

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -878,7 +878,7 @@ export function PlayerBar() {
                 albumId={currentSong.albumId}
                 songId={currentSong.id}
                 artist={currentSong.artist}
-                size="sm"
+                size="md"
                 isPlaying={isPlaying || isRemotePlaying}
               />
               {/* Tap indicator — subtle expand icon */}
@@ -888,12 +888,12 @@ export function PlayerBar() {
             </div>
 
             {/* Song Info — title links to album page (song info context); artist links to artist page */}
-            <div className="min-w-0 flex-1">
+            <div className="min-w-0 flex-1 space-y-0.5">
               {(currentSong as { artistId?: string }).artistId && currentSong.albumId ? (
                 <Link
                   to="/library/artists/$id/albums/$albumId"
                   params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors block", showRemoteTime && "text-green-500")}
+                  className={cn("font-display font-semibold text-sm truncate leading-tight active:text-primary transition-colors block", showRemoteTime && "text-green-500")}
                   onClick={(e) => e.stopPropagation()}
                   title="View album"
                 >
@@ -901,7 +901,7 @@ export function PlayerBar() {
                 </Link>
               ) : (
                 <p
-                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors", showRemoteTime && "text-green-500")}
+                  className={cn("font-display font-semibold text-sm truncate leading-tight active:text-primary transition-colors", showRemoteTime && "text-green-500")}
                   onClick={() => setShowFullscreen(true)}
                 >
                   {currentSong.name || currentSong.title}
@@ -911,13 +911,13 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs truncate block active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-xs truncate leading-tight block active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
                 </Link>
               ) : (
-                <p className={cn("text-xs truncate", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
+                <p className={cn("text-xs truncate leading-tight", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
               )}
               {showRemoteTime && (
                 <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -33,7 +33,7 @@ import { cn } from '@/lib/utils';
 import { queryKeys } from '@/lib/query';
 import { usePlaybackSync, sendPlaybackMessage, sendRemoteCommand } from '@/lib/hooks/usePlaybackSync';
 import { ResumePlaybackPrompt } from './ResumePlaybackPrompt';
-import { FullscreenPlayer } from './FullscreenPlayer';
+import { NowPlayingFullscreen } from './NowPlayingFullscreen';
 
 // Import extracted hooks
 import { useDualDeckAudio, hasRealSong, Song, SILENT_AUDIO_DATA_URL } from '@/lib/hooks/useDualDeckAudio';
@@ -151,6 +151,9 @@ export function PlayerBar() {
 
   const currentSong = useMemo(() => playlist[currentSongIndex] || null, [playlist, currentSongIndex]) as Song | null;
   const queryClient = useQueryClient();
+
+  // Pulled separately so the song-title click can start a song-seeded radio.
+  const startRadio = useAudioStore((s) => s.startRadio);
 
   // Remote device state for cross-device sync indicator
   const remoteDevice = useAudioStore((s) => s.remoteDevice);
@@ -867,19 +870,24 @@ export function PlayerBar() {
               </div>
             </div>
 
-            {/* Song Info */}
+            {/* Song Info — title starts a song-seeded radio; artist links to artist page */}
             <div className="min-w-0 flex-1">
-              <p
-                className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors", showRemoteTime && "text-green-500")}
-                onClick={() => setShowFullscreen(true)}
+              <button
+                type="button"
+                className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors text-left w-full hover:underline", showRemoteTime && "text-green-500")}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  void startRadio({ kind: 'song', songId: currentSong.id });
+                }}
+                title="Start radio from this song"
               >
                 {currentSong.name || currentSong.title}
-              </p>
+              </button>
               {(currentSong as { artistId?: string }).artistId ? (
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs truncate block active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-xs truncate block active:text-primary transition-colors hover:underline", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
@@ -980,7 +988,14 @@ export function PlayerBar() {
             />
           </div>
           <div className="min-w-0">
-            <p className={cn("font-display font-semibold truncate text-sm", showRemoteTime && "text-green-500")}>{currentSong.name || currentSong.title}</p>
+            <button
+              type="button"
+              className={cn("font-display font-semibold truncate text-sm text-left w-full hover:underline", showRemoteTime && "text-green-500")}
+              onClick={() => { void startRadio({ kind: 'song', songId: currentSong.id }); }}
+              title="Start radio from this song"
+            >
+              {currentSong.name || currentSong.title}
+            </button>
             {(currentSong as { artistId?: string }).artistId ? (
               <Link
                 to="/library/artists/$id"
@@ -1161,8 +1176,8 @@ export function PlayerBar() {
         analyserNode={webAudioAnalyserRef.current}
       />
 
-      {/* Fullscreen Now Playing */}
-      <FullscreenPlayer
+      {/* Fullscreen Now Playing — unified chassis (PR A: art mode only) */}
+      <NowPlayingFullscreen
         isOpen={showFullscreen}
         onClose={() => setShowFullscreen(false)}
         currentSong={currentSong}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -893,14 +893,14 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id/albums/$albumId"
                   params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-medium text-[13px] leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
+                  className={cn("font-medium text-sm leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
                   onClick={(e) => e.stopPropagation()}
                   title="View album"
                 >
                   {currentSong.name || currentSong.title}
                 </Link>
               ) : (
-                <p className={cn("font-medium text-[13px] leading-tight truncate", showRemoteTime && "text-green-500")}>
+                <p className={cn("font-medium text-sm leading-tight truncate", showRemoteTime && "text-green-500")}>
                   {currentSong.name || currentSong.title}
                 </p>
               )}
@@ -908,13 +908,13 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-[11px] leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-xs leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
                 </Link>
               ) : (
-                <p className={cn("text-[11px] leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
+                <p className={cn("text-xs leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
               )}
               {showRemoteTime && (
                 <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -887,38 +887,41 @@ export function PlayerBar() {
               </div>
             </div>
 
-            {/* Song Info — title links to album page (song info context); artist links to artist page */}
-            <div className="min-w-0 flex-1 space-y-0.5">
-              {(currentSong as { artistId?: string }).artistId && currentSong.albumId ? (
-                <Link
-                  to="/library/artists/$id/albums/$albumId"
-                  params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-display font-semibold text-sm truncate leading-tight active:text-primary transition-colors block", showRemoteTime && "text-green-500")}
-                  onClick={(e) => e.stopPropagation()}
-                  title="View album"
-                >
-                  {currentSong.name || currentSong.title}
-                </Link>
-              ) : (
-                <p
-                  className={cn("font-display font-semibold text-sm truncate leading-tight active:text-primary transition-colors", showRemoteTime && "text-green-500")}
-                  onClick={() => setShowFullscreen(true)}
-                >
-                  {currentSong.name || currentSong.title}
-                </p>
-              )}
-              {(currentSong as { artistId?: string }).artistId ? (
-                <Link
-                  to="/library/artists/$id"
-                  params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs truncate leading-tight block active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
-                  onClick={(e) => e.stopPropagation()}
-                >
-                  {currentSong.artist || 'Unknown'}
-                </Link>
-              ) : (
-                <p className={cn("text-xs truncate leading-tight", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
-              )}
+            {/* Song Info — single-line: Title · Artist. Inline children flow as one text run, so `truncate` on the parent yields a single clean ellipsis instead of two stacked rows. */}
+            <div className="min-w-0 flex-1">
+              <div className={cn("text-sm truncate", showRemoteTime && "text-green-500")}>
+                {(currentSong as { artistId?: string }).artistId && currentSong.albumId ? (
+                  <Link
+                    to="/library/artists/$id/albums/$albumId"
+                    params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
+                    className="font-display font-semibold active:text-primary transition-colors"
+                    onClick={(e) => e.stopPropagation()}
+                    title="View album"
+                  >
+                    {currentSong.name || currentSong.title}
+                  </Link>
+                ) : (
+                  <span
+                    className="font-display font-semibold active:text-primary transition-colors"
+                    onClick={() => setShowFullscreen(true)}
+                  >
+                    {currentSong.name || currentSong.title}
+                  </span>
+                )}
+                <span className={cn("mx-1.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>·</span>
+                {(currentSong as { artistId?: string }).artistId ? (
+                  <Link
+                    to="/library/artists/$id"
+                    params={{ id: (currentSong as { artistId?: string }).artistId! }}
+                    className={cn("active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                    onClick={(e) => e.stopPropagation()}
+                  >
+                    {currentSong.artist || 'Unknown'}
+                  </Link>
+                ) : (
+                  <span className={cn(showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</span>
+                )}
+              </div>
               {showRemoteTime && (
                 <button
                   ref={devicePickerTriggerRef}

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -893,14 +893,14 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id/albums/$albumId"
                   params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-display font-semibold text-sm leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
+                  className={cn("font-medium text-[13px] leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
                   onClick={(e) => e.stopPropagation()}
                   title="View album"
                 >
                   {currentSong.name || currentSong.title}
                 </Link>
               ) : (
-                <p className={cn("font-display font-semibold text-sm leading-tight truncate", showRemoteTime && "text-green-500")}>
+                <p className={cn("font-medium text-[13px] leading-tight truncate", showRemoteTime && "text-green-500")}>
                   {currentSong.name || currentSong.title}
                 </p>
               )}
@@ -908,13 +908,13 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-[11px] leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
                 </Link>
               ) : (
-                <p className={cn("text-xs leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
+                <p className={cn("text-[11px] leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
               )}
               {showRemoteTime && (
                 <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -544,6 +544,26 @@ export function PlayerBar() {
             });
         }
 
+        // Resume-from-saved-position: after a hard refresh the WS hello
+        // populates store.currentTime but the freshly-loaded deck is at 0.
+        // If the deck hasn't been seeked yet AND the store has a meaningful
+        // saved position, seed the deck so play() starts where the user
+        // left off instead of jumping to 0:00.
+        const storeTime = useAudioStore.getState().currentTime;
+        if (audio.currentTime < 0.5 && storeTime > 0.5) {
+          console.log(`▶️ [PLAY] Seeding deck to saved position ${storeTime.toFixed(1)}s`);
+          try {
+            audio.currentTime = storeTime;
+          } catch {
+            // Metadata may not be loaded yet; one-shot listener applies it.
+            const onMeta = () => {
+              try { audio.currentTime = storeTime; } catch { /* ignore */ }
+              audio.removeEventListener('loadedmetadata', onMeta);
+            };
+            audio.addEventListener('loadedmetadata', onMeta);
+          }
+        }
+
         audio.play().catch((e) => {
           setIsLoading(false);
           console.error('Play failed:', e);

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -847,7 +847,7 @@ export function PlayerBar() {
   return (
     <>
       {/* Mobile Layout */}
-      <div className="md:hidden px-3 py-2 space-y-2">
+      <div className="md:hidden px-3 py-1.5 space-y-1.5">
         {/* Progress bar at top */}
         <div className="flex items-center gap-2">
           <span className={cn("text-[10px] font-mono w-8 text-right", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
@@ -893,14 +893,14 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id/albums/$albumId"
                   params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
+                  className={cn("font-display font-semibold text-sm leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
                   onClick={(e) => e.stopPropagation()}
                   title="View album"
                 >
                   {currentSong.name || currentSong.title}
                 </Link>
               ) : (
-                <p className={cn("font-display font-semibold text-sm truncate", showRemoteTime && "text-green-500")}>
+                <p className={cn("font-display font-semibold text-sm leading-tight truncate", showRemoteTime && "text-green-500")}>
                   {currentSong.name || currentSong.title}
                 </p>
               )}
@@ -908,13 +908,13 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs truncate block active:text-primary transition-colors hover:underline", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-xs leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
                 </Link>
               ) : (
-                <p className={cn("text-xs truncate", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
+                <p className={cn("text-xs leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
               )}
               {showRemoteTime && (
                 <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -847,7 +847,7 @@ export function PlayerBar() {
   return (
     <>
       {/* Mobile Layout */}
-      <div className="md:hidden px-3 py-1.5 space-y-1.5">
+      <div className="md:hidden px-3 py-2 space-y-2">
         {/* Progress bar at top */}
         <div className="flex items-center gap-2">
           <span className={cn("text-[10px] font-mono w-8 text-right", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
@@ -880,7 +880,6 @@ export function PlayerBar() {
                 artist={currentSong.artist}
                 size="sm"
                 isPlaying={isPlaying || isRemotePlaying}
-                className="!w-10 !h-10"
               />
               {/* Tap indicator — subtle expand icon */}
               <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-active/art:bg-black/30 transition-colors rounded-md">
@@ -894,14 +893,17 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id/albums/$albumId"
                   params={{ id: (currentSong as { artistId?: string }).artistId!, albumId: currentSong.albumId }}
-                  className={cn("font-medium text-sm leading-tight truncate active:text-primary transition-colors block hover:underline", showRemoteTime && "text-green-500")}
+                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors block", showRemoteTime && "text-green-500")}
                   onClick={(e) => e.stopPropagation()}
                   title="View album"
                 >
                   {currentSong.name || currentSong.title}
                 </Link>
               ) : (
-                <p className={cn("font-medium text-sm leading-tight truncate", showRemoteTime && "text-green-500")}>
+                <p
+                  className={cn("font-display font-semibold text-sm truncate active:text-primary transition-colors", showRemoteTime && "text-green-500")}
+                  onClick={() => setShowFullscreen(true)}
+                >
                   {currentSong.name || currentSong.title}
                 </p>
               )}
@@ -909,13 +911,13 @@ export function PlayerBar() {
                 <Link
                   to="/library/artists/$id"
                   params={{ id: (currentSong as { artistId?: string }).artistId! }}
-                  className={cn("text-xs leading-tight truncate block active:text-primary transition-colors hover:underline mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
+                  className={cn("text-xs truncate block active:text-primary transition-colors", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}
                   onClick={(e) => e.stopPropagation()}
                 >
                   {currentSong.artist || 'Unknown'}
                 </Link>
               ) : (
-                <p className={cn("text-xs leading-tight truncate mt-0.5", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
+                <p className={cn("text-xs truncate", showRemoteTime ? "text-green-500/70" : "text-muted-foreground")}>{currentSong.artist || 'Unknown'}</p>
               )}
               {showRemoteTime && (
                 <button

--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -846,26 +846,28 @@ export function PlayerBar() {
 
   return (
     <>
-      {/* Mobile Layout — single compact row + thin top progress (matches desktop pattern) */}
-      <div className="md:hidden relative">
-        {/* Thin progress at top — tap to seek */}
-        <div
-          className="absolute top-0 left-0 right-0 h-1 bg-muted cursor-pointer"
-          onClick={(e) => {
-            if (showRemoteTime || !isFinite(displayDuration) || displayDuration <= 0) return;
-            const rect = e.currentTarget.getBoundingClientRect();
-            const pct = Math.max(0, Math.min(1, (e.clientX - rect.left) / rect.width));
-            seek(pct * displayDuration);
-          }}
-        >
-          <div
-            className={cn("h-full transition-all duration-100", showRemoteTime ? "bg-green-500" : "bg-primary")}
-            style={{ width: `${progressPercent}%` }}
+      {/* Mobile Layout */}
+      <div className="md:hidden px-3 py-1.5 space-y-1.5">
+        {/* Progress bar at top */}
+        <div className="flex items-center gap-2">
+          <span className={cn("text-[10px] font-mono w-8 text-right", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
+            {formatTime(displayCurrentTime)}
+          </span>
+          <Slider
+            value={[isFinite(displayCurrentTime) ? displayCurrentTime : 0]}
+            max={isFinite(displayDuration) && displayDuration > 0 ? displayDuration : 100}
+            step={0.1}
+            onValueChange={([newValue]) => seek(newValue)}
+            className={cn("flex-1 h-1", showRemoteTime && "[&_[data-slot=slider-range]]:bg-green-500 [&_[data-slot=slider-thumb]]:border-green-500")}
+            disabled={showRemoteTime}
           />
+          <span className={cn("text-[10px] font-mono w-8", showRemoteTime ? "text-green-500" : "text-muted-foreground")}>
+            -{formatTime(Math.max(0, displayDuration - displayCurrentTime))}
+          </span>
         </div>
 
         {/* Main row: Album art, song info, controls */}
-        <div className="px-3 py-2 flex items-center gap-3">
+        <div className="flex items-center gap-3">
           {/* Small Album Artwork */}
           <div className={cn(
             "flex items-center gap-3 min-w-0 flex-1 rounded-lg transition-all",

--- a/src/components/library/ArtistMetadataHero.tsx
+++ b/src/components/library/ArtistMetadataHero.tsx
@@ -83,11 +83,42 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
     staleTime: 5 * 60 * 1000,
   });
 
-  // Build a lookup map: normalized name → artist id
+  // Build a lookup map: normalized name → artist id. Tolerant matching is
+  // important because Last.fm returns "Frank Iero" but the library may have
+  // "Frank Iero and the Patience" (or vice versa); without softer matching
+  // that artist appears as plain text even when their songs are right there
+  // in the library.
+  const normalize = (s: string) =>
+    s
+      .toLowerCase()
+      .normalize('NFKD')
+      .replace(/[̀-ͯ]/g, '')   // strip combining accents
+      .replace(/^the\s+/i, '')           // ignore leading "the "
+      .replace(/\s*&\s*/g, ' and ')      // unify "&" / "and"
+      .replace(/[^\w\s]/g, ' ')          // strip punctuation
+      .replace(/\s+/g, ' ')
+      .trim();
+
+  // Index library artists by normalized name AND by their first 1–3 word
+  // prefixes so "Frank Iero" matches "Frank Iero and the Patience".
   const libraryLookup = new Map<string, string>();
   for (const a of libraryArtists) {
-    libraryLookup.set(a.name.toLowerCase(), a.id);
+    const n = normalize(a.name);
+    if (!libraryLookup.has(n)) libraryLookup.set(n, a.id);
+    // Also index a "core name" variant by stripping common collab suffixes.
+    const core = n.replace(/\s+(and|with|feat|featuring|vs|presents|plus)\s+.+$/, '').trim();
+    if (core && core !== n && !libraryLookup.has(core)) libraryLookup.set(core, a.id);
   }
+
+  const findInLibrary = (similarName: string): string | null => {
+    const n = normalize(similarName);
+    if (libraryLookup.has(n)) return libraryLookup.get(n)!;
+    // Last fallback: prefix match against the core-name index.
+    for (const [key, id] of libraryLookup) {
+      if (key.startsWith(n + ' ') || n.startsWith(key + ' ')) return id;
+    }
+    return null;
+  };
 
   const imageUrl = metadata.coverImageUrl || artistImageUrl;
   const showImage = imageUrl && !imgError;
@@ -244,7 +275,7 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
           </h3>
           <div className="flex flex-wrap gap-2">
             {metadata.similarArtists.slice(0, 10).map((similar) => {
-              const libraryId = libraryLookup.get(similar.name.toLowerCase());
+              const libraryId = findInLibrary(similar.name);
               const inLibrary = !!libraryId;
 
               const badge = (

--- a/src/components/library/ArtistMetadataHero.tsx
+++ b/src/components/library/ArtistMetadataHero.tsx
@@ -15,7 +15,7 @@ import {
   Library,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getArtists, searchArtistsByName } from '@/lib/services/navidrome';
+import { getArtists, resolveArtistIdByName } from '@/lib/services/navidrome';
 
 interface ArtistMetadataHeroProps {
   metadata: EnrichedArtistMetadata;
@@ -129,18 +129,8 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
   const unresolvedNames = similarNames.filter((name) => !findInLibrary(name));
   const searchQueries = useQueries({
     queries: unresolvedNames.map((name) => ({
-      queryKey: ['artist-search', normalize(name)],
-      queryFn: async () => {
-        const results = await searchArtistsByName(name, 5);
-        // Only return a hit when the search result name normalizes to the
-        // similar artist name (or contains it as a prefix word).
-        const target = normalize(name);
-        const match = results.find((r) => {
-          const rn = normalize(r.name);
-          return rn === target || rn.startsWith(target + ' ') || target.startsWith(rn + ' ');
-        });
-        return match ? match.id : null;
-      },
+      queryKey: ['artist-resolve', normalize(name)],
+      queryFn: () => resolveArtistIdByName(name),
       staleTime: 10 * 60 * 1000, // 10 min — artist names don't change
       retry: false,
     })),

--- a/src/components/library/ArtistMetadataHero.tsx
+++ b/src/components/library/ArtistMetadataHero.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Link } from '@tanstack/react-router';
-import { useQuery } from '@tanstack/react-query';
+import { useQuery, useQueries } from '@tanstack/react-query';
 import type { EnrichedArtistMetadata } from '@/lib/services/aurral';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,7 @@ import {
   Library,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
-import { getArtists } from '@/lib/services/navidrome';
+import { getArtists, searchArtistsByName } from '@/lib/services/navidrome';
 
 interface ArtistMetadataHeroProps {
   metadata: EnrichedArtistMetadata;
@@ -119,6 +119,40 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
     }
     return null;
   };
+
+  // Server-side fallback: for any similar artist that doesn't match the bulk
+  // index, fire a Navidrome search3 lookup. Some artists (e.g. solo work by
+  // a band member) only appear as track-level artist tags and aren't in
+  // /api/artist, so the bulk index misses them — but search3 hits the song
+  // index too and finds them.
+  const similarNames = (metadata.similarArtists ?? []).slice(0, 10).map((s) => s.name);
+  const unresolvedNames = similarNames.filter((name) => !findInLibrary(name));
+  const searchQueries = useQueries({
+    queries: unresolvedNames.map((name) => ({
+      queryKey: ['artist-search', normalize(name)],
+      queryFn: async () => {
+        const results = await searchArtistsByName(name, 5);
+        // Only return a hit when the search result name normalizes to the
+        // similar artist name (or contains it as a prefix word).
+        const target = normalize(name);
+        const match = results.find((r) => {
+          const rn = normalize(r.name);
+          return rn === target || rn.startsWith(target + ' ') || target.startsWith(rn + ' ');
+        });
+        return match ? match.id : null;
+      },
+      staleTime: 10 * 60 * 1000, // 10 min — artist names don't change
+      retry: false,
+    })),
+  });
+  const searchLookup = new Map<string, string>();
+  unresolvedNames.forEach((name, i) => {
+    const id = searchQueries[i]?.data;
+    if (id) searchLookup.set(normalize(name), id);
+  });
+
+  const resolveArtistId = (similarName: string): string | null =>
+    findInLibrary(similarName) ?? searchLookup.get(normalize(similarName)) ?? null;
 
   const imageUrl = metadata.coverImageUrl || artistImageUrl;
   const showImage = imageUrl && !imgError;
@@ -275,7 +309,7 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
           </h3>
           <div className="flex flex-wrap gap-2">
             {metadata.similarArtists.slice(0, 10).map((similar) => {
-              const libraryId = findInLibrary(similar.name);
+              const libraryId = resolveArtistId(similar.name);
               const inLibrary = !!libraryId;
 
               const badge = (

--- a/src/components/library/ArtistMetadataHero.tsx
+++ b/src/components/library/ArtistMetadataHero.tsx
@@ -113,9 +113,12 @@ export function ArtistMetadataHero({ metadata, artistImageUrl }: ArtistMetadataH
   const findInLibrary = (similarName: string): string | null => {
     const n = normalize(similarName);
     if (libraryLookup.has(n)) return libraryLookup.get(n)!;
-    // Last fallback: prefix match against the core-name index.
+    // Last fallback: candidate must be a longer variant of the target (e.g.
+    // library has "Frank Iero and the Patience", we're looking for "Frank
+    // Iero"). The reverse direction is unsafe — it makes "Russ Gabriel" match
+    // library "Russ", which is wrong.
     for (const [key, id] of libraryLookup) {
-      if (key.startsWith(n + ' ') || n.startsWith(key + ' ')) return id;
+      if (key.startsWith(n + ' ')) return id;
     }
     return null;
   };

--- a/src/components/library/HeartButton.tsx
+++ b/src/components/library/HeartButton.tsx
@@ -1,0 +1,90 @@
+/**
+ * Single-button heart toggle for songs.
+ *
+ * Hits /api/navidrome/star which proxies Navidrome's star/unstar and
+ * also syncs the AIDJ feedback table (so the PlayerBar heart reflects
+ * the same state).
+ */
+import { useState, useEffect } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { Heart, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { useSongFeedback } from '@/hooks/useSongFeedback';
+import { queryKeys } from '@/lib/query';
+import { toast } from '@/lib/toast';
+import { cn } from '@/lib/utils';
+
+interface HeartButtonProps {
+  songId: string;
+  artist?: string;
+  title?: string;
+  className?: string;
+  size?: 'sm' | 'default';
+}
+
+export function HeartButton({ songId, artist, title, className, size = 'sm' }: HeartButtonProps) {
+  const queryClient = useQueryClient();
+  const { data: feedbackData } = useSongFeedback([songId]);
+  // The PlayerBar treats thumbs_up as "liked" — use the same source of truth.
+  const serverLiked = feedbackData?.feedback?.[songId] === 'thumbs_up';
+  const [optimisticLiked, setOptimisticLiked] = useState<boolean | null>(null);
+  const liked = optimisticLiked ?? serverLiked;
+
+  // Reset optimistic state once the server confirms.
+  /* eslint-disable react-hooks/set-state-in-effect */
+  useEffect(() => {
+    if (feedbackData?.feedback) setOptimisticLiked(null);
+  }, [feedbackData]);
+  /* eslint-enable react-hooks/set-state-in-effect */
+
+  const mutation = useMutation({
+    mutationFn: async (newLiked: boolean) => {
+      const res = await fetch(`/api/navidrome/star?id=${encodeURIComponent(songId)}`, {
+        method: newLiked ? 'POST' : 'DELETE',
+      });
+      if (!res.ok) throw new Error(newLiked ? 'Failed to like song' : 'Failed to unlike song');
+      return res.json();
+    },
+    onMutate: (newLiked) => setOptimisticLiked(newLiked),
+    onSuccess: (_data, newLiked) => {
+      queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
+      if (artist && title) {
+        toast.success(`${newLiked ? 'Liked' : 'Unliked'} "${title}"`, {
+          description: artist,
+          duration: 1800,
+        });
+      }
+    },
+    onError: () => {
+      setOptimisticLiked(null);
+      toast.error('Could not update like');
+    },
+  });
+
+  return (
+    <Button
+      variant="ghost"
+      size={size === 'sm' ? 'sm' : 'default'}
+      className={cn(
+        'h-8 w-8 p-0 shrink-0 transition-colors',
+        liked ? 'text-red-500 hover:text-red-600' : 'text-muted-foreground hover:text-foreground',
+        className,
+      )}
+      onClick={(e) => {
+        e.stopPropagation();
+        if (mutation.isPending) return;
+        mutation.mutate(!liked);
+      }}
+      disabled={mutation.isPending}
+      aria-label={liked ? 'Unlike song' : 'Like song'}
+      aria-pressed={liked}
+      title={liked ? 'Unlike' : 'Like'}
+    >
+      {mutation.isPending ? (
+        <Loader2 className="h-4 w-4 animate-spin" />
+      ) : (
+        <Heart className={cn('h-4 w-4 transition-transform', liked && 'fill-current scale-110')} />
+      )}
+    </Button>
+  );
+}

--- a/src/components/ui/mobile-nav.tsx
+++ b/src/components/ui/mobile-nav.tsx
@@ -99,7 +99,7 @@ export function MobileNav() {
         `}
         aria-label="Mobile navigation"
       >
-        <div className={`flex flex-col h-full pt-[calc(env(safe-area-inset-top)+4rem)] px-4 overflow-y-auto ${hasActiveSong ? 'pb-24' : 'pb-6'}`}>
+        <div className={`flex flex-col h-full pt-[calc(env(safe-area-inset-top)+4rem)] px-4 overflow-y-auto ${hasActiveSong ? 'pb-28' : 'pb-6'}`}>
           <div className="space-y-1">
             <NavSectionLabel label="Main" />
             <NavLink

--- a/src/components/ui/mobile-nav.tsx
+++ b/src/components/ui/mobile-nav.tsx
@@ -99,7 +99,7 @@ export function MobileNav() {
         `}
         aria-label="Mobile navigation"
       >
-        <div className={`flex flex-col h-full pt-[calc(env(safe-area-inset-top)+4rem)] px-4 overflow-y-auto ${hasActiveSong ? 'pb-28' : 'pb-6'}`}>
+        <div className={`flex flex-col h-full pt-[calc(env(safe-area-inset-top)+4rem)] px-4 overflow-y-auto ${hasActiveSong ? 'pb-24' : 'pb-6'}`}>
           <div className="space-y-1">
             <NavSectionLabel label="Main" />
             <NavLink

--- a/src/components/ui/queue-panel.tsx
+++ b/src/components/ui/queue-panel.tsx
@@ -147,8 +147,9 @@ const SortableQueueItem = memo(function SortableQueueItem({ song, index, actualI
                 ? 'text-green-600 bg-green-500/20 hover:bg-green-500/30'
                 : 'hover:bg-green-500/10 hover:text-green-600'
             }`}
-            aria-label={isLiked ? 'Already liked this song' : 'Like this recommendation'}
+            aria-label={isLiked ? 'Marked as a good pick' : 'Good pick — like this suggestion'}
             aria-pressed={isLiked}
+            title={isLiked ? 'Marked as a good pick' : 'Good pick'}
           >
             <ThumbsUp className={`h-3.5 w-3.5 transition-all ${isLiked ? 'fill-current scale-110' : ''}`} />
           </Button>
@@ -164,8 +165,9 @@ const SortableQueueItem = memo(function SortableQueueItem({ song, index, actualI
                 ? 'text-red-600 bg-red-500/20 hover:bg-red-500/30'
                 : 'hover:bg-red-500/10 hover:text-red-600'
             }`}
-            aria-label={isDisliked ? 'Already disliked this song' : 'Dislike this recommendation'}
+            aria-label={isDisliked ? 'Marked as a bad suggestion' : 'Bad suggestion — don\'t recommend like this'}
             aria-pressed={isDisliked}
+            title={isDisliked ? 'Marked as a bad suggestion' : 'Bad suggestion'}
           >
             <ThumbsDown className={`h-3.5 w-3.5 transition-all ${isDisliked ? 'fill-current scale-110' : ''}`} />
           </Button>
@@ -410,8 +412,8 @@ export function QueuePanel() {
         // Keep the optimistic state - feedback was already there
         toast.success(
           feedbackType === 'thumbs_up'
-            ? `Already liked "${songTitle}"`
-            : `Already disliked "${songTitle}"`,
+            ? `Already marked "${songTitle}" as a good pick`
+            : `Already marked "${songTitle}" as a bad suggestion`,
           { duration: 2000 }
         );
         // Invalidate to sync with server state
@@ -434,9 +436,9 @@ export function QueuePanel() {
 
       toast.success(
         feedbackType === 'thumbs_up'
-          ? `Liked "${songTitle}" - AI will learn from this`
-          : `Disliked "${songTitle}" - AI will avoid similar songs`,
-        { duration: 2000 }
+          ? `Good pick — "${songTitle}". AI will lean into this.`
+          : `Bad suggestion — won't recommend "${songTitle}" again.`,
+        { duration: 2400 }
       );
     } catch (error) {
       console.error('Failed to submit feedback:', error);

--- a/src/lib/services/navidrome/index.ts
+++ b/src/lib/services/navidrome/index.ts
@@ -22,7 +22,7 @@ export {
 
 // Library (artists, albums, songs, search)
 export {
-  getArtists, searchArtistsByName, getArtistDetail, getArtistsWithDetails,
+  getArtists, searchArtistsByName, resolveArtistIdByName, getArtistDetail, getArtistsWithDetails,
   getAlbums, getAlbumDetail,
   getSongs, getSongsByArtist, getSongsByIds, getSongsGlobal, getRandomSongs, getTopSongs,
   search, resolveSongByArtistTitle,

--- a/src/lib/services/navidrome/library.ts
+++ b/src/lib/services/navidrome/library.ts
@@ -47,6 +47,66 @@ export async function searchArtistsByName(query: string, limit: number = 20): Pr
   }
 }
 
+/**
+ * Resolve a free-text artist name to a Navidrome artist id, looking at BOTH
+ * artist records AND song-level artist tags via search3. Important when the
+ * Navidrome artist record has a typo or alternate spelling (e.g. real-world:
+ * library has "Frnkiero and the Cellabration" while songs are tagged "Frank
+ * Iero" — searching by song-level artist tag still resolves to the correct
+ * artistId).
+ *
+ * Returns null if no match. Match must be exact (normalized) or a prefix
+ * word match — never a loose substring.
+ */
+export async function resolveArtistIdByName(query: string): Promise<string | null> {
+  try {
+    await getAuthToken();
+
+    const endpoint = `/rest/search3.view?query=${encodeURIComponent(query)}&artistCount=10&songCount=20&albumCount=0`;
+    const response = await apiFetch(endpoint) as SubsonicSearchResponse;
+    const subsonicData = response['subsonic-response'] || response;
+    const result3 = subsonicData.searchResult3 || subsonicData.searchResult;
+
+    const normalize = (s: string) =>
+      s
+        .toLowerCase()
+        .normalize('NFKD')
+        .replace(/[̀-ͯ]/g, '')
+        .replace(/^the\s+/i, '')
+        .replace(/\s*&\s*/g, ' and ')
+        .replace(/[^\w\s]/g, ' ')
+        .replace(/\s+/g, ' ')
+        .trim();
+
+    const target = normalize(query);
+    const matches = (candidate: string) => {
+      const c = normalize(candidate);
+      return c === target || c.startsWith(target + ' ') || target.startsWith(c + ' ');
+    };
+
+    // 1. Try artist records first — these are the canonical match.
+    const artists = result3?.artist || [];
+    for (const a of artists) {
+      if (matches(a.name)) return a.id;
+    }
+
+    // 2. Fall back to song results — read each song's artist tag. If any song
+    //    is tagged with the target name, take its artistId. This catches the
+    //    Navidrome artist-name-typo case.
+    const songs = result3?.song || [];
+    for (const s of songs) {
+      const artistName = (s as { artist?: string }).artist;
+      const artistId = (s as { artistId?: string }).artistId;
+      if (artistName && artistId && matches(artistName)) return artistId;
+    }
+
+    return null;
+  } catch (error) {
+    console.error('Error resolving artist id by name:', error);
+    return null;
+  }
+}
+
 export async function getArtistDetail(id: string): Promise<ArtistDetail> {
   try {
     const data = await apiFetch(`/api/artist/${id}`) as ArtistDetail;

--- a/src/lib/services/navidrome/library.ts
+++ b/src/lib/services/navidrome/library.ts
@@ -81,7 +81,11 @@ export async function resolveArtistIdByName(query: string): Promise<string | nul
     const target = normalize(query);
     const matches = (candidate: string) => {
       const c = normalize(candidate);
-      return c === target || c.startsWith(target + ' ') || target.startsWith(c + ' ');
+      // Exact match, or candidate is a longer variant of target ("Frank Iero"
+      // matches "Frank Iero and the Cellabration"). Do NOT match in the
+      // opposite direction: "Russ Gabriel" must not resolve to library "Russ"
+      // just because the search returned a Russ song.
+      return c === target || c.startsWith(target + ' ');
     };
 
     // 1. Try artist records first — these are the canonical match.

--- a/src/routes/library/artists/$id.tsx
+++ b/src/routes/library/artists/$id.tsx
@@ -22,6 +22,7 @@ import { toast } from '@/lib/toast';
 import { useArtistMetadata } from '@/lib/hooks/useArtistMetadata';
 import { ArtistMetadataHero } from '@/components/library/ArtistMetadataHero';
 import { StartRadioButton } from '@/components/radio/StartRadioButton';
+import { HeartButton } from '@/components/library/HeartButton';
 import { cn } from '@/lib/utils';
 import { getArtistGradient } from '@/lib/utils/artist-avatar';
 
@@ -210,6 +211,12 @@ function ArtistDetail() {
       <span className="text-xs text-muted-foreground tabular-nums flex items-center gap-1">
         <Clock className="h-3 w-3" /> {formatDuration(song.duration)}
       </span>
+      {/* Heart — always visible (vs hover-only) so save is one tap on mobile */}
+      <HeartButton
+        songId={song.id}
+        artist={artist?.name}
+        title={song.name || song.title}
+      />
       {/* Play Next - desktop hover only */}
       <Button
         variant="ghost"

--- a/tests/screenshots/chassis-verify.spec.ts
+++ b/tests/screenshots/chassis-verify.spec.ts
@@ -1,0 +1,45 @@
+import { test } from '@playwright/test';
+import path from 'node:path';
+
+test.use({ viewport: { width: 1440, height: 900 } });
+
+test('artist page popular tracks have hearts', async ({ page }) => {
+  // Grab the top-artists artist hrefs from the dashboard; pick one that has data.
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+  const hrefs = await page.locator('a[href^="/library/artists/"]').evaluateAll(
+    (els) => els.map((e) => (e as HTMLAnchorElement).getAttribute('href')).filter(Boolean) as string[],
+  );
+  const candidate = hrefs.find((h) => h && h.length > '/library/artists/'.length + 5);
+  if (!candidate) {
+    await page.screenshot({ path: path.join('tests', 'screenshots', 'out', 'chassis-no-artists.png'), fullPage: true });
+    return;
+  }
+  await page.goto(candidate);
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(3000);
+  await page.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'chassis-artist-page.png'),
+    fullPage: true,
+  });
+  // Zoom on the Popular Tracks section to verify the heart icon.
+  const popular = page.locator('text=Popular Tracks').locator('xpath=ancestor::section[1]');
+  if (await popular.isVisible().catch(() => false)) {
+    await popular.scrollIntoViewIfNeeded();
+    await popular.screenshot({
+      path: path.join('tests', 'screenshots', 'out', 'chassis-popular-tracks.png'),
+    });
+  }
+});
+
+test('player bar title is a link', async ({ page }) => {
+  await page.goto('/dashboard');
+  await page.waitForLoadState('networkidle').catch(() => undefined);
+  await page.waitForTimeout(1500);
+  // Snap the bottom player bar.
+  const playerBar = page.locator('[class*="bottom-0"]').first();
+  await playerBar.screenshot({
+    path: path.join('tests', 'screenshots', 'out', 'chassis-playerbar.png'),
+  }).catch(() => undefined);
+});


### PR DESCRIPTION
## Summary
First phase of the unified Now Playing rework. Replaces the old single-purpose \`FullscreenPlayer\` with a chassis structured around a swappable mode area. Phase A only ships **art mode**; phases B/C/D plug lyrics / visualizer / queue into the same shape, with the persistent header / metadata / scrubber / transport rendered exactly once at the chassis level.

Visually identical to today. The mode-swap mechanism (state + pill switcher + animations) is wired up in stub form so phase B can land cleanly.

### New module layout
\`src/components/layout/NowPlayingFullscreen/\`
- \`NowPlayingFullscreen.tsx\` — chassis: portal mount, slide-up animation, body swipe-to-dismiss, Esc, persistent header + metadata + scrubber + transport + secondary actions
- \`ArtMode.tsx\` — big album art with horizontal swipe-to-skip
- \`types.ts\` — \`NPMode\` union + props
- \`index.ts\` — barrel

### Clickable artist + song
Per the plan, both PlayerBar and the fullscreen surface get the same semantics:
- **Song title** → starts a song-seeded radio via \`startRadio({kind:'song', songId})\`
- **Artist** → \`/library/artists/\$id\` link (when \`artistId\` is set; falls back to plain text otherwise)
- Album art still opens fullscreen on tap (mobile entry path preserved)

### Removed
- \`src/components/layout/FullscreenPlayer.tsx\` — superseded by the chassis

## Test plan
- [ ] Tap album art (mobile + desktop) → fullscreen opens, no regression vs today
- [ ] Maximize button (desktop) → fullscreen opens
- [ ] Inside fullscreen: scrubber, prev/next, play/pause, like, shuffle, repeat all work
- [ ] Inside fullscreen: lyrics button still opens the lyrics modal (handed off via \`onShowLyrics\` for phase A)
- [ ] Inside fullscreen: queue list button toggles the queue panel
- [ ] Inside fullscreen: Esc + swipe-down dismiss
- [ ] Inside fullscreen: horizontal swipe on art skips prev/next
- [ ] **PlayerBar mobile**: tap song title → starts song-seeded radio (queue replaced)
- [ ] **PlayerBar mobile**: tap artist → navigates to /library/artists/\$id
- [ ] **PlayerBar desktop**: tap song title → starts song-seeded radio
- [ ] **PlayerBar desktop**: tap artist → navigates to artist page
- [ ] **Fullscreen**: tap song title → starts song-seeded radio (closes fullscreen first)
- [ ] **Fullscreen**: tap artist → navigates to artist page (closes fullscreen first)
- [ ] When \`artistId\` is null: artist renders as plain text, no broken link

## Notes for reviewers
- Mode-switch state is stubbed (\`useState<NPMode>('art')\`) but not yet exposed via UI — the pill switcher lands in PR B once we have a 2nd mode to flip to.
- \`onShowLyrics\` prop kept for phase A; phase B removes it in favor of internal mode switch.