### PR TITLE
ci: Remove broken e2e job, leave restoration notes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,42 +32,13 @@ jobs:
       - name: Run unit tests
         run: npx vitest run
 
-  e2e:
-    runs-on: ubuntu-latest
-    needs: build
-    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
-    
-    steps:
-    - name: Checkout code
-      uses: actions/checkout@v6
-      
-    - name: Setup Node.js
-      uses: actions/setup-node@v6
-      with:
-        node-version: '20'
-        cache: 'npm'
-        
-    - name: Install dependencies
-      run: npm ci
-      
-    - name: Install Playwright browsers
-      run: npx playwright install --with-deps
-      
-    - name: Run E2E tests
-      run: npm run test:e2e
-      env:
-        PLAYWRIGHT_BROWSERS_PATH: 0
-        
-    - name: Upload E2E test artifacts
-      if: always()
-      uses: actions/upload-artifact@v7
-      with:
-        name: e2e-test-results
-        path: |
-          playwright-report/
-          test-results/
-          trace-*.zip
-        retention-days: 30
+  # TODO(e2e): The Playwright job was removed 2026-07-28 because it never
+  # actually ran tests — `npm run dev` (Playwright's webServer) crashloops on
+  # startup env validation since the job provides no env vars. Restoring it
+  # requires: dummy values for the nine required vars in src/env/server.ts,
+  # a PostgreSQL service container for DATABASE_URL (+ migrations), and
+  # making the e2e suite tolerant of unreachable Navidrome/Ollama/Lidarr.
+  # Until then, run e2e locally with `npm run test:e2e`.
 
   security:
     runs-on: ubuntu-latest


### PR DESCRIPTION
The e2e job only triggered on pushes to main and has never actually executed tests: Playwright's webServer (`npm run dev`) crashloops on startup env validation because the job sets no env vars, so the run times out and fails.

Removed the job and left a TODO comment in the workflow describing what a real restoration needs (dummy env vars, a PostgreSQL service container, and an e2e suite tolerant of unreachable Navidrome/Ollama/Lidarr). E2E still runs locally via `npm run test:e2e`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)