### PR TITLE
fix(lidarr): Unmonitor other albums on single-song add, split semicolon artists

### DIFF
--- a/src/lib/services/lidarr.ts
+++ b/src/lib/services/lidarr.ts
@@ -552,9 +552,7 @@ export async function unmonitorOtherAlbums(artistId: number, targetAlbumId: numb
       });
     }
 
-    if (toUnmonitor.length > 0) {
-      console.log(`🎯 Unmonitored ${toUnmonitor.length} other albums for artist ${artistId}`);
-    }
+    console.log(`🎯 Unmonitor check: ${albums.length} albums, ${toUnmonitor.length} unmonitored for artist ${artistId}`);
   } catch (error) {
     console.error('Error unmonitoring other albums:', error);
   }

--- a/src/routes/api/downloads/queue.ts
+++ b/src/routes/api/downloads/queue.ts
@@ -250,10 +250,11 @@ async function queueToLidarr(songs: { title: string; artist: string; album?: str
     try {
       console.log(`[Lidarr Queue] Processing: ${song.artist} - ${song.title}${song.album ? ` (Album: ${song.album})` : ''}`);
 
-      // Step 1: Extract primary artist (handle collaborations like "Artist1, Artist2")
-      // Take the first artist from comma-separated list
-      const primaryArtist = song.artist.split(',')[0].trim();
-      console.log(`[Lidarr Queue] Primary artist: ${primaryArtist}`);
+      // Step 1: Extract primary artist (handle collaborations like "Artist1, Artist2" or "Artist1;Artist2")
+      const primaryArtist = song.artist.split(/[,;]/)[0].trim();
+      if (primaryArtist !== song.artist) {
+        console.log(`[Lidarr Queue] Primary artist: ${primaryArtist} (from "${song.artist}")`);
+      }
 
       // Search for the artist using artist lookup
       const artistSearchQuery = encodeURIComponent(primaryArtist);
@@ -631,9 +632,7 @@ async function unmonitorOtherAlbums(
       });
     }
 
-    if (toUnmonitor.length > 0) {
-      console.log(`[Lidarr Queue] Unmonitored ${toUnmonitor.length} other albums for artist ${artistId}`);
-    }
+    console.log(`[Lidarr Queue] Unmonitor check: ${albums.length} albums, ${toUnmonitor.length} unmonitored for artist ${artistId}`);
   } catch (error) {
     console.error('[Lidarr Queue] Error unmonitoring other albums:', error);
   }
@@ -655,7 +654,7 @@ function findBestAlbumMatch(
   const songTitle = song.title.toLowerCase();
   const songAlbum = song.album?.toLowerCase();
   // Extract primary artist from collaborations for better matching
-  const primaryArtist = song.artist.split(',')[0].trim().toLowerCase();
+  const primaryArtist = song.artist.split(/[,;]/)[0].trim().toLowerCase();
 
   // Score each album
   const scored = albums.map(album => {

--- a/src/routes/api/lidarr/add.ts
+++ b/src/routes/api/lidarr/add.ts
@@ -10,6 +10,7 @@ import {
   ensureArtistMonitored,
   searchForAlbum,
   searchAlbumByTitle,
+  unmonitorOtherAlbums,
   type LidarrAlbum,
 } from '../../../lib/services/lidarr';
 import { search as searchNavidrome } from '../../../lib/services/navidrome';
@@ -128,6 +129,7 @@ export const Route = createFileRoute("/api/lidarr/add")({
       }
 
       const artistName = match[1].trim();
+      const primaryArtist = artistName.split(/[,;]/)[0].trim();
       const songTitle = match[2].trim();
 
       // Check if the specific song is already available in Navidrome
@@ -139,7 +141,7 @@ export const Route = createFileRoute("/api/lidarr/add")({
         });
       }
 
-      const results = await searchArtistsFull(artistName);
+      const results = await searchArtistsFull(primaryArtist);
       if (results.length === 0) {
         return new Response(JSON.stringify({ error: `Artist "${artistName}" not found in Lidarr search` }), {
           status: 404,
@@ -218,6 +220,7 @@ export const Route = createFileRoute("/api/lidarr/add")({
             if (localAlbum && localAlbum.id) {
               console.log(`✅ Monitoring artist "${artist.artistName}" and album "${localAlbum.title}" for "${songTitle}"`);
               await monitorAlbum(localAlbum.id, true);
+              await unmonitorOtherAlbums(existingArtist.id, localAlbum.id);
               await searchForAlbum(localAlbum.id);
               return new Response(JSON.stringify({
                 success: true,
@@ -323,6 +326,9 @@ export const Route = createFileRoute("/api/lidarr/add")({
           if (localAlbum && localAlbum.id) {
             console.log(`✅ Found and monitoring album "${localAlbum.title}" for "${songTitle}"`);
             await monitorAlbum(localAlbum.id, true);
+            if (newArtist) {
+              await unmonitorOtherAlbums(newArtist.id, localAlbum.id);
+            }
             await searchForAlbum(localAlbum.id);
             return new Response(JSON.stringify({
               success: true,


### PR DESCRIPTION
## Summary
- **Bug**: `/api/lidarr/add` monitored the target album but never called `unmonitorOtherAlbums` — artists added before the `monitorAll:false` safeguard (or via Lidarr UI) had all albums monitored, causing Lidarr to download entire discographies (e.g. Jorge Ben Jor's 28 albums)
- **Fix**: Add `unmonitorOtherAlbums` to both existing-artist and new-artist paths in `lidarr/add.ts` (`downloads/queue.ts` and `playlist-download.ts` already had them)
- Split artist names on `;` in addition to `,` — Navidrome sends collaborations as `Artist1;Artist2` which caused 0-score artist matches in Lidarr lookups
- `unmonitorOtherAlbums` now always logs album counts instead of only when > 0

## Files changed
- `src/routes/api/lidarr/add.ts` — import + call `unmonitorOtherAlbums`, add `primaryArtist` semicolon split
- `src/routes/api/downloads/queue.ts` — semicolon split in artist extraction + `findBestAlbumMatch`, always-log unmonitor
- `src/lib/services/lidarr.ts` — always-log unmonitor

## Test plan
- [ ] Request a song by a semicolon-separated artist (e.g. `LONOWN;Asenssia - addiction`) — should match `LONOWN` cleanly
- [ ] Request a song for an artist with multiple monitored albums — only the target album should remain monitored after
- [ ] Check container logs for `Unmonitor check:` lines confirming the check runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GVJKAp8mWtvC82b8wMHhk