### PR TITLE
feat: Library reconciliation — detect and remap ghost song IDs

### DIFF
--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -146,8 +146,6 @@ class LibraryReconciliationManager {
     }
 
     this.isRunning = true;
-    const startMs = Date.now();
-
     try {
       const result = await reconcileLibrary(this.userId);
       this.lastResult = result;
@@ -226,7 +224,7 @@ function parseRealArtistTitle(artist: string, title: string): {
   artist: string;
   title: string;
 } {
-  let clean = title
+  const clean = title
     .replace(/\s*\[Official (?:Audio|Video|Music Video)\]/gi, '')
     .replace(/\s*\(Official (?:Audio|Video)\)/gi, '')
     .replace(/\s*\(Lyrics?\)/gi, '')
@@ -542,8 +540,8 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
             )
           );
         tablesUpdated.push('liked_songs_sync');
-      } catch (err: any) {
-        if (err?.code === '23505') {
+      } catch (err: unknown) {
+        if (err instanceof Error && (err as Error & { code?: string }).code === '23505') {
           await db
             .delete(likedSongsSync)
             .where(
@@ -578,8 +576,8 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
             )
           );
         tablesUpdated.push('recommendation_feedback');
-      } catch (err: any) {
-        if (err?.code === '23505') {
+      } catch (err: unknown) {
+        if (err instanceof Error && (err as Error & { code?: string }).code === '23505') {
           await db
             .delete(recommendationFeedback)
             .where(
@@ -615,8 +613,8 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
                   eq(playlistSongs.songId, deadId)
                 )
               );
-          } catch (dupErr: any) {
-            if (dupErr?.code === '23505') {
+          } catch (dupErr: unknown) {
+            if (dupErr instanceof Error && (dupErr as Error & { code?: string }).code === '23505') {
               await db
                 .delete(playlistSongs)
                 .where(

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -220,6 +220,18 @@ function isTitleMatch(a: string, b: string): boolean {
   return false;
 }
 
+async function isStreamable(songId: string): Promise<boolean> {
+  try {
+    const streamUrl = buildSubsonicUrl('stream');
+    streamUrl.searchParams.set('id', songId);
+    const resp = await fetch(streamUrl.toString(), { method: 'HEAD' });
+    const ct = resp.headers.get('content-type') || '';
+    return ct.includes('audio');
+  } catch {
+    return true; // Assume streamable on network error
+  }
+}
+
 async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
   const startMs = Date.now();
   const details: RemapDetail[] = [];
@@ -334,7 +346,6 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
         }
       }
     } catch {
-      // If batch lookup fails, check individually
       for (const id of batch) {
         try {
           const songs = await getSongsByIds([id]);
@@ -348,6 +359,30 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
         }
       }
     }
+  }
+
+  // Navidrome keeps metadata for songs whose files were moved/deleted.
+  // getSong succeeds but the stream returns XML error instead of audio.
+  // HEAD-check the stream for IDs that passed the metadata check.
+  const liveIds = allIds.filter((id) => !deadIds.has(id));
+  for (let i = 0; i < liveIds.length; i += BATCH) {
+    const batch = liveIds.slice(i, i + BATCH);
+    await Promise.all(
+      batch.map(async (id) => {
+        try {
+          const streamUrl = buildSubsonicUrl('stream');
+          streamUrl.searchParams.set('id', id);
+          const resp = await fetch(streamUrl.toString(), { method: 'HEAD' });
+          const ct = resp.headers.get('content-type') || '';
+          if (!ct.includes('audio')) {
+            const meta = idMeta.get(id);
+            if (meta) deadIds.set(id, meta);
+          }
+        } catch {
+          // Network error — don't flag as dead, might be transient
+        }
+      })
+    );
   }
 
   console.log(
@@ -413,20 +448,29 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
       const results = await navidromeSearch(query, 0, 15);
       const nonDead = results.filter((r) => r.id !== deadId);
 
-      const found = nonDead.find(
-        (r) =>
+      for (const r of nonDead) {
+        if (
           isArtistMatch(r.artist || '', meta.artist) &&
-          isTitleMatch(r.title || r.name || '', meta.title)
-      );
-      if (found) match = toMatch(found);
+          isTitleMatch(r.title || r.name || '', meta.title) &&
+          (await isStreamable(r.id))
+        ) {
+          match = toMatch(r);
+          break;
+        }
+      }
 
       // Fallback: title-only search
       if (!match && meta.title) {
         const titleResults = await navidromeSearch(meta.title, 0, 15);
-        const titleFound = titleResults
-          .filter((r) => r.id !== deadId)
-          .find((r) => isArtistMatch(r.artist || '', meta.artist));
-        if (titleFound) match = toMatch(titleFound);
+        for (const r of titleResults.filter((r) => r.id !== deadId)) {
+          if (
+            isArtistMatch(r.artist || '', meta.artist) &&
+            (await isStreamable(r.id))
+          ) {
+            match = toMatch(r);
+            break;
+          }
+        }
       }
     } catch (err) {
       console.warn(
@@ -450,7 +494,7 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
 
     const tablesUpdated: string[] = [];
 
-    // Update liked_songs_sync
+    // Update liked_songs_sync (delete old if new ID already exists)
     if (meta.sources.has('liked_songs_sync')) {
       try {
         await db
@@ -468,11 +512,23 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
             )
           );
         tablesUpdated.push('liked_songs_sync');
-      } catch (err) {
-        console.warn(
-          `[LibraryReconciliation] Failed to update liked_songs_sync for ${deadId}:`,
-          err
-        );
+      } catch (err: any) {
+        if (err?.code === '23505') {
+          await db
+            .delete(likedSongsSync)
+            .where(
+              and(
+                eq(likedSongsSync.userId, userId),
+                eq(likedSongsSync.songId, deadId)
+              )
+            );
+          tablesUpdated.push('liked_songs_sync(dedup)');
+        } else {
+          console.warn(
+            `[LibraryReconciliation] Failed to update liked_songs_sync for ${deadId}:`,
+            err
+          );
+        }
       }
     }
 
@@ -492,31 +548,55 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
             )
           );
         tablesUpdated.push('recommendation_feedback');
-      } catch (err) {
-        console.warn(
-          `[LibraryReconciliation] Failed to update recommendation_feedback for ${deadId}:`,
-          err
-        );
+      } catch (err: any) {
+        if (err?.code === '23505') {
+          await db
+            .delete(recommendationFeedback)
+            .where(
+              and(
+                eq(recommendationFeedback.userId, userId),
+                eq(recommendationFeedback.songId, deadId)
+              )
+            );
+          tablesUpdated.push('recommendation_feedback(dedup)');
+        } else {
+          console.warn(
+            `[LibraryReconciliation] Failed to update recommendation_feedback for ${deadId}:`,
+            err
+          );
+        }
       }
     }
 
     // Update playlist_songs
     if (meta.sources.has('playlist_songs')) {
       try {
-        // Get playlist IDs containing this song for this user
         const affectedPlaylists = playlistRows.filter(
           (r) => r.songId === deadId
         );
         for (const pl of affectedPlaylists) {
-          await db
-            .update(playlistSongs)
-            .set({ songId: match.id })
-            .where(
-              and(
-                eq(playlistSongs.playlistId, pl.playlistId),
-                eq(playlistSongs.songId, deadId)
-              )
-            );
+          try {
+            await db
+              .update(playlistSongs)
+              .set({ songId: match.id })
+              .where(
+                and(
+                  eq(playlistSongs.playlistId, pl.playlistId),
+                  eq(playlistSongs.songId, deadId)
+                )
+              );
+          } catch (dupErr: any) {
+            if (dupErr?.code === '23505') {
+              await db
+                .delete(playlistSongs)
+                .where(
+                  and(
+                    eq(playlistSongs.playlistId, pl.playlistId),
+                    eq(playlistSongs.songId, deadId)
+                  )
+                );
+            } else throw dupErr;
+          }
         }
         tablesUpdated.push('playlist_songs');
       } catch (err) {

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -220,6 +220,25 @@ function isTitleMatch(a: string, b: string): boolean {
   return false;
 }
 
+// MeTube downloads often have "Channel Name" as the artist and
+// "Real Artist - Real Title [Official Audio]" as the title.
+function parseRealArtistTitle(artist: string, title: string): {
+  artist: string;
+  title: string;
+} {
+  let clean = title
+    .replace(/\s*\[Official (?:Audio|Video|Music Video)\]/gi, '')
+    .replace(/\s*\(Official (?:Audio|Video)\)/gi, '')
+    .replace(/\s*\(Lyrics?\)/gi, '')
+    .replace(/\s*\|.*$/g, '')
+    .trim();
+  const parts = clean.split(/\s+-\s+/);
+  if (parts.length >= 2) {
+    return { artist: parts[0].trim(), title: parts.slice(1).join(' - ').trim() };
+  }
+  return { artist, title: clean };
+}
+
 async function isStreamable(songId: string): Promise<boolean> {
   try {
     const streamUrl = buildSubsonicUrl('stream');
@@ -469,6 +488,25 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
           ) {
             match = toMatch(r);
             break;
+          }
+        }
+      }
+
+      // Fallback: MeTube titles often embed "Real Artist - Real Title"
+      if (!match && meta.title.includes(' - ')) {
+        const parsed = parseRealArtistTitle(meta.artist, meta.title);
+        if (parsed.artist !== meta.artist || parsed.title !== meta.title) {
+          const parsedQuery = `${parsed.artist} ${parsed.title}`;
+          const parsedResults = await navidromeSearch(parsedQuery, 0, 15);
+          for (const r of parsedResults.filter((r) => r.id !== deadId)) {
+            if (
+              isArtistMatch(r.artist || '', parsed.artist) &&
+              isTitleMatch(r.title || r.name || '', parsed.title) &&
+              (await isStreamable(r.id))
+            ) {
+              match = toMatch(r);
+              break;
+            }
           }
         }
       }

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -1,0 +1,604 @@
+/**
+ * Library Reconciliation Service
+ *
+ * After Picard retags or Lidarr reorganizes files, Navidrome assigns new song
+ * IDs.  Old IDs referenced by playlist_songs, liked_songs_sync, and
+ * recommendation_feedback become "ghosts" — the DB row points at a song that
+ * streams an error or a completely different track.
+ *
+ * This service:
+ * 1. Collects every song ID referenced in user-facing tables
+ * 2. Checks each against Navidrome (getSong + stream HEAD)
+ * 3. For dead IDs, searches by artist+title to find the retagged version
+ * 4. Remaps playlist_songs, liked_songs_sync, recommendation_feedback, and
+ *    stars in Navidrome to the new ID
+ * 5. Triggers a Navidrome startScan to purge ghost entries
+ *
+ * Runs as a singleton scheduled job (default: every 6 hours).
+ */
+
+import { db } from '@/lib/db';
+import {
+  likedSongsSync,
+  recommendationFeedback,
+  playlistSongs,
+  userPlaylists,
+} from '@/lib/db/schema';
+import { eq, and } from 'drizzle-orm';
+import {
+  getSongsByIds,
+  search as navidromeSearch,
+  starSong,
+  getStarredSongs,
+  buildSubsonicUrl,
+} from './navidrome';
+import { getNavidromeUserCreds } from './navidrome-users';
+import type { SubsonicCreds } from './navidrome-users';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface ReconciliationResult {
+  checkedIds: number;
+  deadIds: number;
+  remapped: number;
+  notFound: number;
+  scanTriggered: boolean;
+  details: RemapDetail[];
+  missingFromLibrary: MissingSong[];
+  durationMs: number;
+}
+
+interface RemapDetail {
+  oldId: string;
+  newId: string;
+  artist: string;
+  title: string;
+  tables: string[];
+}
+
+interface MissingSong {
+  oldId: string;
+  artist: string;
+  title: string;
+  source: string;
+}
+
+export interface ReconciliationStatus {
+  isRunning: boolean;
+  lastRunAt: Date | null;
+  nextRunAt: Date | null;
+  lastResult: ReconciliationResult | null;
+  lastError: string | null;
+  frequencyHours: number;
+}
+
+// ============================================================================
+// Singleton Manager
+// ============================================================================
+
+class LibraryReconciliationManager {
+  private static instance: LibraryReconciliationManager | null = null;
+
+  private userId: string | null = null;
+  private scheduledTimeoutId: NodeJS.Timeout | null = null;
+  private isRunning = false;
+  private lastRunAt: Date | null = null;
+  private nextRunAt: Date | null = null;
+  private lastResult: ReconciliationResult | null = null;
+  private lastError: string | null = null;
+  private frequencyHours = 6;
+  private enabled = true;
+
+  private constructor() {}
+
+  static getInstance(): LibraryReconciliationManager {
+    if (!LibraryReconciliationManager.instance) {
+      LibraryReconciliationManager.instance = new LibraryReconciliationManager();
+    }
+    return LibraryReconciliationManager.instance;
+  }
+
+  async initialize(userId: string, frequencyHours?: number): Promise<void> {
+    this.userId = userId;
+    if (frequencyHours !== undefined) this.frequencyHours = frequencyHours;
+    if (this.enabled) {
+      this.scheduleNextRun();
+    }
+    console.log(
+      `[LibraryReconciliation] Initialized for user ${userId}, every ${this.frequencyHours}h`
+    );
+  }
+
+  start(): void {
+    this.enabled = true;
+    this.scheduleNextRun();
+  }
+
+  stop(): void {
+    this.enabled = false;
+    if (this.scheduledTimeoutId) {
+      clearTimeout(this.scheduledTimeoutId);
+      this.scheduledTimeoutId = null;
+    }
+    this.nextRunAt = null;
+  }
+
+  getStatus(): ReconciliationStatus {
+    return {
+      isRunning: this.isRunning,
+      lastRunAt: this.lastRunAt,
+      nextRunAt: this.nextRunAt,
+      lastResult: this.lastResult,
+      lastError: this.lastError,
+      frequencyHours: this.frequencyHours,
+    };
+  }
+
+  async triggerNow(): Promise<ReconciliationResult> {
+    if (!this.userId) throw new Error('Not initialized');
+    if (this.isRunning) throw new Error('Already running');
+
+    if (this.scheduledTimeoutId) {
+      clearTimeout(this.scheduledTimeoutId);
+      this.scheduledTimeoutId = null;
+    }
+
+    this.isRunning = true;
+    const startMs = Date.now();
+
+    try {
+      const result = await reconcileLibrary(this.userId);
+      this.lastResult = result;
+      this.lastRunAt = new Date();
+      this.lastError = null;
+      console.log(
+        `[LibraryReconciliation] Done: ${result.checkedIds} checked, ` +
+          `${result.deadIds} dead, ${result.remapped} remapped, ` +
+          `${result.notFound} missing (${result.durationMs}ms)`
+      );
+      return result;
+    } catch (err) {
+      this.lastError = err instanceof Error ? err.message : String(err);
+      console.error('[LibraryReconciliation] Failed:', this.lastError);
+      throw err;
+    } finally {
+      this.isRunning = false;
+      if (this.enabled) this.scheduleNextRun();
+    }
+  }
+
+  private scheduleNextRun(delayMs?: number): void {
+    if (!this.enabled) return;
+    if (this.scheduledTimeoutId) clearTimeout(this.scheduledTimeoutId);
+
+    const delay = delayMs ?? this.frequencyHours * 60 * 60 * 1000;
+    this.nextRunAt = new Date(Date.now() + delay);
+    this.scheduledTimeoutId = setTimeout(() => {
+      this.triggerNow().catch(() => {});
+    }, delay);
+
+    console.log(
+      `[LibraryReconciliation] Next run at ${this.nextRunAt.toISOString()}`
+    );
+  }
+}
+
+// ============================================================================
+// Core Reconciliation Logic
+// ============================================================================
+
+function normalizeForMatch(s: string): string {
+  return s
+    .toLowerCase()
+    .replace(/\(feat\..*?\)/gi, '')
+    .replace(/\(ft\..*?\)/gi, '')
+    .replace(/\[.*?\]/g, '')
+    .replace(/[''`]/g, "'")
+    .replace(/[""]/g, '"')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function isArtistMatch(a: string, b: string): boolean {
+  const na = normalizeForMatch(a);
+  const nb = normalizeForMatch(b);
+  if (na === nb) return true;
+  const primaryA = na.split(/[,;&]/)[0].trim();
+  const primaryB = nb.split(/[,;&]/)[0].trim();
+  if (primaryA === primaryB) return true;
+  if (na.includes(primaryB) || nb.includes(primaryA)) return true;
+  return false;
+}
+
+function isTitleMatch(a: string, b: string): boolean {
+  const na = normalizeForMatch(a);
+  const nb = normalizeForMatch(b);
+  if (na === nb) return true;
+  if (na.includes(nb) || nb.includes(na)) return true;
+  return false;
+}
+
+async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
+  const startMs = Date.now();
+  const details: RemapDetail[] = [];
+  const missingFromLibrary: MissingSong[] = [];
+
+  // ── 1.  Collect all referenced song IDs ──────────────────────────────
+
+  const [likedRows, feedbackRows, playlistRows] = await Promise.all([
+    db
+      .select({
+        songId: likedSongsSync.songId,
+        artist: likedSongsSync.artist,
+        title: likedSongsSync.title,
+      })
+      .from(likedSongsSync)
+      .where(
+        and(eq(likedSongsSync.userId, userId), eq(likedSongsSync.isActive, 1))
+      ),
+
+    db
+      .select({
+        songId: recommendationFeedback.songId,
+        songArtistTitle: recommendationFeedback.songArtistTitle,
+      })
+      .from(recommendationFeedback)
+      .where(
+        and(
+          eq(recommendationFeedback.userId, userId),
+          eq(recommendationFeedback.feedbackType, 'thumbs_up')
+        )
+      ),
+
+    db
+      .select({
+        songId: playlistSongs.songId,
+        playlistId: playlistSongs.playlistId,
+      })
+      .from(playlistSongs)
+      .innerJoin(userPlaylists, eq(playlistSongs.playlistId, userPlaylists.id))
+      .where(eq(userPlaylists.userId, userId)),
+  ]);
+
+  // Build a unique set of IDs with their metadata
+  const idMeta = new Map<
+    string,
+    { artist: string; title: string; sources: Set<string> }
+  >();
+
+  for (const row of likedRows) {
+    const existing = idMeta.get(row.songId);
+    if (existing) {
+      existing.sources.add('liked_songs_sync');
+    } else {
+      idMeta.set(row.songId, {
+        artist: row.artist,
+        title: row.title,
+        sources: new Set(['liked_songs_sync']),
+      });
+    }
+  }
+
+  for (const row of feedbackRows) {
+    if (!row.songId) continue;
+    const existing = idMeta.get(row.songId);
+    if (existing) {
+      existing.sources.add('recommendation_feedback');
+    } else {
+      const parts = (row.songArtistTitle || '').split(' - ');
+      idMeta.set(row.songId, {
+        artist: parts[0] || 'Unknown',
+        title: parts.slice(1).join(' - ') || 'Unknown',
+        sources: new Set(['recommendation_feedback']),
+      });
+    }
+  }
+
+  for (const row of playlistRows) {
+    const existing = idMeta.get(row.songId);
+    if (existing) {
+      existing.sources.add('playlist_songs');
+    } else {
+      idMeta.set(row.songId, {
+        artist: '',
+        title: '',
+        sources: new Set(['playlist_songs']),
+      });
+    }
+  }
+
+  const allIds = [...idMeta.keys()];
+  console.log(
+    `[LibraryReconciliation] Checking ${allIds.length} unique song IDs`
+  );
+
+  // ── 2.  Check each ID against Navidrome ──────────────────────────────
+
+  const BATCH = 50;
+  const deadIds = new Map<
+    string,
+    { artist: string; title: string; sources: Set<string> }
+  >();
+
+  for (let i = 0; i < allIds.length; i += BATCH) {
+    const batch = allIds.slice(i, i + BATCH);
+    try {
+      const songs = await getSongsByIds(batch);
+      const foundIds = new Set(songs.map((s) => s.id));
+      for (const id of batch) {
+        if (!foundIds.has(id)) {
+          const meta = idMeta.get(id);
+          if (meta) deadIds.set(id, meta);
+        }
+      }
+    } catch {
+      // If batch lookup fails, check individually
+      for (const id of batch) {
+        try {
+          const songs = await getSongsByIds([id]);
+          if (songs.length === 0) {
+            const meta = idMeta.get(id);
+            if (meta) deadIds.set(id, meta);
+          }
+        } catch {
+          const meta = idMeta.get(id);
+          if (meta) deadIds.set(id, meta);
+        }
+      }
+    }
+  }
+
+  console.log(
+    `[LibraryReconciliation] Found ${deadIds.size} dead IDs out of ${allIds.length}`
+  );
+
+  if (deadIds.size === 0) {
+    return {
+      checkedIds: allIds.length,
+      deadIds: 0,
+      remapped: 0,
+      notFound: 0,
+      scanTriggered: false,
+      details: [],
+      missingFromLibrary: [],
+      durationMs: Date.now() - startMs,
+    };
+  }
+
+  // ── 3.  Search for replacements ──────────────────────────────────────
+
+  let remapped = 0;
+  let notFound = 0;
+
+  // Get per-user Navidrome creds for star operations
+  let userCreds: SubsonicCreds | null = null;
+  try {
+    userCreds = await getNavidromeUserCreds(userId);
+  } catch {
+    // Will fall back to admin creds for star operations
+  }
+
+  // Get currently starred songs to know if we need to re-star
+  const starredSongs = userCreds
+    ? await getStarredSongs(userCreds)
+    : await getStarredSongs();
+  const starredIds = new Set(starredSongs.map((s) => s.id));
+
+  for (const [deadId, meta] of deadIds) {
+    // Skip if we don't have artist+title to search with
+    if (!meta.artist && !meta.title) {
+      notFound++;
+      missingFromLibrary.push({
+        oldId: deadId,
+        artist: 'Unknown',
+        title: 'Unknown',
+        source: [...meta.sources].join(', '),
+      });
+      continue;
+    }
+
+    const query = `${meta.artist} ${meta.title}`;
+    let match: { id: string; artist: string; title: string } | null = null;
+
+    try {
+      const toMatch = (r: { id: string; artist?: string; title?: string; name: string }) => ({
+        id: r.id,
+        artist: r.artist || 'Unknown Artist',
+        title: r.title || r.name,
+      });
+
+      // Search by artist + title
+      const results = await navidromeSearch(query, 0, 15);
+      const nonDead = results.filter((r) => r.id !== deadId);
+
+      const found = nonDead.find(
+        (r) =>
+          isArtistMatch(r.artist || '', meta.artist) &&
+          isTitleMatch(r.title || r.name || '', meta.title)
+      );
+      if (found) match = toMatch(found);
+
+      // Fallback: title-only search
+      if (!match && meta.title) {
+        const titleResults = await navidromeSearch(meta.title, 0, 15);
+        const titleFound = titleResults
+          .filter((r) => r.id !== deadId)
+          .find((r) => isArtistMatch(r.artist || '', meta.artist));
+        if (titleFound) match = toMatch(titleFound);
+      }
+    } catch (err) {
+      console.warn(
+        `[LibraryReconciliation] Search failed for "${query}":`,
+        err
+      );
+    }
+
+    if (!match) {
+      notFound++;
+      missingFromLibrary.push({
+        oldId: deadId,
+        artist: meta.artist,
+        title: meta.title,
+        source: [...meta.sources].join(', '),
+      });
+      continue;
+    }
+
+    // ── 4.  Remap references ─────────────────────────────────────────
+
+    const tablesUpdated: string[] = [];
+
+    // Update liked_songs_sync
+    if (meta.sources.has('liked_songs_sync')) {
+      try {
+        await db
+          .update(likedSongsSync)
+          .set({
+            songId: match.id,
+            artist: match.artist,
+            title: match.title,
+            syncedAt: new Date(),
+          })
+          .where(
+            and(
+              eq(likedSongsSync.userId, userId),
+              eq(likedSongsSync.songId, deadId)
+            )
+          );
+        tablesUpdated.push('liked_songs_sync');
+      } catch (err) {
+        console.warn(
+          `[LibraryReconciliation] Failed to update liked_songs_sync for ${deadId}:`,
+          err
+        );
+      }
+    }
+
+    // Update recommendation_feedback
+    if (meta.sources.has('recommendation_feedback')) {
+      try {
+        await db
+          .update(recommendationFeedback)
+          .set({
+            songId: match.id,
+            songArtistTitle: `${match.artist} - ${match.title}`,
+          })
+          .where(
+            and(
+              eq(recommendationFeedback.userId, userId),
+              eq(recommendationFeedback.songId, deadId)
+            )
+          );
+        tablesUpdated.push('recommendation_feedback');
+      } catch (err) {
+        console.warn(
+          `[LibraryReconciliation] Failed to update recommendation_feedback for ${deadId}:`,
+          err
+        );
+      }
+    }
+
+    // Update playlist_songs
+    if (meta.sources.has('playlist_songs')) {
+      try {
+        // Get playlist IDs containing this song for this user
+        const affectedPlaylists = playlistRows.filter(
+          (r) => r.songId === deadId
+        );
+        for (const pl of affectedPlaylists) {
+          await db
+            .update(playlistSongs)
+            .set({ songId: match.id })
+            .where(
+              and(
+                eq(playlistSongs.playlistId, pl.playlistId),
+                eq(playlistSongs.songId, deadId)
+              )
+            );
+        }
+        tablesUpdated.push('playlist_songs');
+      } catch (err) {
+        console.warn(
+          `[LibraryReconciliation] Failed to update playlist_songs for ${deadId}:`,
+          err
+        );
+      }
+    }
+
+    // Re-star if the old ID was starred
+    if (starredIds.has(deadId) && !starredIds.has(match.id)) {
+      try {
+        await starSong(match.id, userCreds || undefined);
+        tablesUpdated.push('navidrome_star');
+      } catch (err) {
+        console.warn(
+          `[LibraryReconciliation] Failed to re-star ${match.id}:`,
+          err
+        );
+      }
+    }
+
+    details.push({
+      oldId: deadId,
+      newId: match.id,
+      artist: match.artist,
+      title: match.title,
+      tables: tablesUpdated,
+    });
+    remapped++;
+
+    console.log(
+      `[LibraryReconciliation] Remapped "${meta.artist} - ${meta.title}" ` +
+        `${deadId} → ${match.id} (${tablesUpdated.join(', ')})`
+    );
+  }
+
+  // ── 5.  Trigger Navidrome scan to clean ghost entries ────────────────
+
+  let scanTriggered = false;
+  if (deadIds.size > 0) {
+    try {
+      const url = buildSubsonicUrl('startScan');
+      await fetch(url.toString());
+      scanTriggered = true;
+      console.log(
+        '[LibraryReconciliation] Triggered Navidrome scan to purge ghost entries'
+      );
+    } catch (err) {
+      console.warn(
+        '[LibraryReconciliation] Failed to trigger Navidrome scan:',
+        err
+      );
+    }
+  }
+
+  return {
+    checkedIds: allIds.length,
+    deadIds: deadIds.size,
+    remapped,
+    notFound,
+    scanTriggered,
+    details,
+    missingFromLibrary,
+    durationMs: Date.now() - startMs,
+  };
+}
+
+// ============================================================================
+// Exports
+// ============================================================================
+
+export function getReconciliationManager(): LibraryReconciliationManager {
+  return LibraryReconciliationManager.getInstance();
+}
+
+export async function initializeReconciliation(
+  userId: string,
+  frequencyHours?: number
+): Promise<LibraryReconciliationManager> {
+  const manager = getReconciliationManager();
+  await manager.initialize(userId, frequencyHours);
+  return manager;
+}

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -247,7 +247,7 @@ async function isStreamable(songId: string): Promise<boolean> {
     const ct = resp.headers.get('content-type') || '';
     return ct.includes('audio');
   } catch {
-    return true; // Assume streamable on network error
+    return true;
   }
 }
 
@@ -388,17 +388,9 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
     const batch = liveIds.slice(i, i + BATCH);
     await Promise.all(
       batch.map(async (id) => {
-        try {
-          const streamUrl = buildSubsonicUrl('stream');
-          streamUrl.searchParams.set('id', id);
-          const resp = await fetch(streamUrl.toString(), { method: 'HEAD' });
-          const ct = resp.headers.get('content-type') || '';
-          if (!ct.includes('audio')) {
-            const meta = idMeta.get(id);
-            if (meta) deadIds.set(id, meta);
-          }
-        } catch {
-          // Network error — don't flag as dead, might be transient
+        if (!(await isStreamable(id))) {
+          const meta = idMeta.get(id);
+          if (meta) deadIds.set(id, meta);
         }
       })
     );

--- a/src/lib/services/task-aggregator.ts
+++ b/src/lib/services/task-aggregator.ts
@@ -9,12 +9,13 @@ import { getBackgroundSyncManager } from './library-sync/background-sync';
 import { getBackgroundDiscoveryManager } from './background-discovery';
 import { getActiveBackfill } from './lastfm-backfill';
 import { getAurralCacheWarmingManager, initializeAurralCacheWarming } from './aurral-cache-warming';
+import { getReconciliationManager } from './library-reconciliation';
 
 export interface UnifiedTask {
   id: string;
   name: string;
   description: string;
-  type: 'library-sync' | 'discovery' | 'lastfm-backfill' | 'aurral-warming';
+  type: 'library-sync' | 'discovery' | 'lastfm-backfill' | 'aurral-warming' | 'library-reconciliation';
   status: 'idle' | 'running' | 'completed' | 'error';
   progress?: {
     current: number;
@@ -256,6 +257,52 @@ export async function getAllTaskStatuses(userId: string): Promise<UnifiedTask[]>
       interval: '24 hours',
       lastDuration: null,
       canTrigger: false,
+      canCancel: false,
+    });
+  }
+
+  // 5. Library Reconciliation
+  try {
+    const reconManager = getReconciliationManager();
+    const reconStatus = reconManager.getStatus();
+
+    tasks.push({
+      id: 'library-reconciliation',
+      name: 'Library Reconciliation',
+      description: 'Detects and remaps ghost song IDs after Picard retags or Lidarr moves files',
+      type: 'library-reconciliation',
+      status: reconStatus.isRunning
+        ? 'running'
+        : reconStatus.lastError
+          ? 'error'
+          : 'idle',
+      lastRunAt: reconStatus.lastRunAt?.toISOString() ?? null,
+      nextRunAt: reconStatus.nextRunAt?.toISOString() ?? null,
+      interval: `${reconStatus.frequencyHours} hours`,
+      lastDuration: reconStatus.lastResult?.durationMs != null
+        ? formatDurationMs(reconStatus.lastResult.durationMs) : null,
+      error: reconStatus.lastError ?? undefined,
+      canTrigger: !reconStatus.isRunning,
+      canCancel: false,
+      stats: reconStatus.lastResult ? {
+        checked: reconStatus.lastResult.checkedIds,
+        dead: reconStatus.lastResult.deadIds,
+        remapped: reconStatus.lastResult.remapped,
+        notFound: reconStatus.lastResult.notFound,
+      } : undefined,
+    });
+  } catch {
+    tasks.push({
+      id: 'library-reconciliation',
+      name: 'Library Reconciliation',
+      description: 'Detects and remaps ghost song IDs after Picard retags or Lidarr moves files',
+      type: 'library-reconciliation',
+      status: 'idle',
+      lastRunAt: null,
+      nextRunAt: null,
+      interval: '6 hours',
+      lastDuration: null,
+      canTrigger: true,
       canCancel: false,
     });
   }

--- a/src/routes/api/library-reconciliation/status.ts
+++ b/src/routes/api/library-reconciliation/status.ts
@@ -1,0 +1,42 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+} from '@/lib/utils/api-response';
+import { getReconciliationManager, initializeReconciliation } from '@/lib/services/library-reconciliation';
+
+const GET = withAuthAndErrorHandling(
+  async ({ session }) => {
+    const userId = session.user.id;
+    const manager = getReconciliationManager();
+
+    if (!manager.getStatus().nextRunAt) {
+      await initializeReconciliation(userId);
+    }
+
+    const status = manager.getStatus();
+
+    return successResponse({
+      isRunning: status.isRunning,
+      lastRunAt: status.lastRunAt?.toISOString() ?? null,
+      nextRunAt: status.nextRunAt?.toISOString() ?? null,
+      frequencyHours: status.frequencyHours,
+      lastError: status.lastError,
+      lastResult: status.lastResult,
+    });
+  },
+  {
+    service: 'library-reconciliation',
+    operation: 'status',
+    defaultCode: 'STATUS_ERROR',
+    defaultMessage: 'Failed to get reconciliation status',
+  }
+);
+
+export const Route = createFileRoute("/api/library-reconciliation/status")({
+  server: {
+    handlers: {
+      GET,
+    },
+  },
+});

--- a/src/routes/api/library-reconciliation/trigger.ts
+++ b/src/routes/api/library-reconciliation/trigger.ts
@@ -14,12 +14,13 @@ const POST = withAuthAndErrorHandling(
       await initializeReconciliation(userId);
     }
 
-    const result = await manager.triggerNow();
+    if (manager.getStatus().isRunning) {
+      return successResponse({ message: 'Reconciliation already running', started: false });
+    }
 
-    return successResponse({
-      message: `Reconciliation complete: ${result.checkedIds} checked, ${result.remapped} remapped, ${result.notFound} not found`,
-      ...result,
-    });
+    manager.triggerNow().catch(() => {});
+
+    return successResponse({ message: 'Reconciliation started', started: true });
   },
   {
     service: 'library-reconciliation',

--- a/src/routes/api/library-reconciliation/trigger.ts
+++ b/src/routes/api/library-reconciliation/trigger.ts
@@ -1,0 +1,38 @@
+import { createFileRoute } from "@tanstack/react-router";
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+} from '@/lib/utils/api-response';
+import { getReconciliationManager, initializeReconciliation } from '@/lib/services/library-reconciliation';
+
+const POST = withAuthAndErrorHandling(
+  async ({ session }) => {
+    const userId = session.user.id;
+    const manager = getReconciliationManager();
+
+    if (!manager.getStatus().nextRunAt) {
+      await initializeReconciliation(userId);
+    }
+
+    const result = await manager.triggerNow();
+
+    return successResponse({
+      message: `Reconciliation complete: ${result.checkedIds} checked, ${result.remapped} remapped, ${result.notFound} not found`,
+      ...result,
+    });
+  },
+  {
+    service: 'library-reconciliation',
+    operation: 'trigger',
+    defaultCode: 'TRIGGER_ERROR',
+    defaultMessage: 'Failed to trigger library reconciliation',
+  }
+);
+
+export const Route = createFileRoute("/api/library-reconciliation/trigger")({
+  server: {
+    handlers: {
+      POST,
+    },
+  },
+});

--- a/src/routes/api/tasks/index.ts
+++ b/src/routes/api/tasks/index.ts
@@ -68,6 +68,16 @@ const POST = withAuthAndErrorHandling(
       }
     }
 
+    if (taskId === 'library-reconciliation') {
+      const { getReconciliationManager } = await import('../../../lib/services/library-reconciliation');
+      const manager = getReconciliationManager();
+
+      if (action === 'trigger') {
+        const result = await manager.triggerNow();
+        return successResponse({ triggered: true, taskId, result });
+      }
+    }
+
     return errorResponse('UNKNOWN_TASK', `Unknown task: ${taskId}`, { status: 400 });
   },
   {


### PR DESCRIPTION
## Summary
- Adds a scheduled job (every 6h) that detects "ghost" song IDs — references in playlists, liked songs, and recommendation feedback that point to songs Navidrome can no longer stream after Picard retags or Lidarr reorganizes files
- For each dead ID, searches Navidrome by artist+title to find the replacement, remaps all DB references, re-stars in Navidrome, and triggers a library scan
- Two-stage dead ID detection: batch `getSongsByIds` check + HEAD stream-verify (catches Navidrome's known issue where metadata persists after file deletion)
- MeTube fallback: parses "Real Artist - Real Title" from YouTube-style titles
- Duplicate-key safe: handles cases where the new ID already exists in a table
- Integrated into task-aggregator dashboard and tasks API for manual trigger/status
- Trigger endpoint is fire-and-forget (returns immediately, poll status separately)

## Files
| File | What |
|------|------|
| `src/lib/services/library-reconciliation.ts` | Core service: singleton manager + reconciliation logic |
| `src/lib/services/task-aggregator.ts` | Registers reconciliation in unified task dashboard |
| `src/routes/api/library-reconciliation/status.ts` | GET status endpoint |
| `src/routes/api/library-reconciliation/trigger.ts` | POST trigger endpoint (fire-and-forget) |
| `src/routes/api/tasks/index.ts` | Adds `library-reconciliation` to task actions |

## Test plan
- [ ] Trigger reconciliation via POST `/api/library-reconciliation/trigger` — should return immediately
- [ ] Poll GET `/api/library-reconciliation/status` — should show running then complete
- [ ] Verify remapped songs still play correctly in playlists
- [ ] Verify stars transfer to new song IDs
- [ ] Check task dashboard shows reconciliation status
- [ ] Confirm no regressions in existing autoplay/AI DJ flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GVJKAp8mWtvC82b8wMHhk