### PR TITLE
fix: Give playlist import its own rate limit bucket

### DIFF
--- a/src/lib/services/navidrome/library.ts
+++ b/src/lib/services/navidrome/library.ts
@@ -278,14 +278,14 @@ export async function getTopSongs(artistId: string, count: number = 10): Promise
  * 5. If no artists, fallback to Subsonic song search
  * 6. If Subsonic fails, fallback to native song search
  */
-export async function search(query: string, start: number = 0, limit: number = 50): Promise<Song[]> {
+export async function search(query: string, start: number = 0, limit: number = 50, options?: { rateLimitKey?: string; rateLimitMaxWaitMs?: number }): Promise<Song[]> {
   try {
     const config = getConfig();
     if (!config.navidromeUrl) {
       return [];
     }
 
-    const waitTime = await waitForRateLimit('search', 10000);
+    const waitTime = await waitForRateLimit(options?.rateLimitKey ?? 'search', options?.rateLimitMaxWaitMs ?? 10000);
     if (waitTime > 0) {
       console.log(`⏳ Rate limit: waited ${waitTime}ms before search`);
     }

--- a/src/routes/api/playlists/import.ts
+++ b/src/routes/api/playlists/import.ts
@@ -115,19 +115,21 @@ function createNavidromeSearcher() {
         duration: song.duration,
       });
 
+      const rlOpts = { rateLimitKey: 'import-search', rateLimitMaxWaitMs: 60000 };
+
       // 1. Artist + full cleaned title
-      const r1 = await navidromeSearch(`${primaryArtist} ${cleanTitle}`);
+      const r1 = await navidromeSearch(`${primaryArtist} ${cleanTitle}`, 0, 50, rlOpts);
       addResults(r1.map(toCandidate));
 
       // 2. Artist-only search (catches title mismatches like "Overload 2K" vs "Overload")
       if (all.length < 3 && primaryArtist.length > 2) {
-        const r2 = await navidromeSearch(primaryArtist);
+        const r2 = await navidromeSearch(primaryArtist, 0, 50, rlOpts);
         addResults(r2.map(toCandidate));
       }
 
       // 3. Title-only search (catches artist name mismatches)
       if (all.length < 3 && cleanTitle.length > 3) {
-        const r3 = await navidromeSearch(cleanTitle);
+        const r3 = await navidromeSearch(cleanTitle, 0, 50, rlOpts);
         addResults(r3.map(toCandidate));
       }
 


### PR DESCRIPTION
## Summary
- Import searches were sharing the `search` rate limit key (120 req/min, 10s max wait) with normal browsing traffic (cover art, streaming, album lists)
- When importing a playlist with 99 songs (up to 3 searches each = 297 requests), the budget was exhausted and songs were falsely marked as "not found"
- Import now uses a dedicated `import-search` rate limit key with a 60s max wait, so it drains gracefully without competing with browsing

## Test plan
- [ ] Import a large Spotify playlist (50+ songs) and verify no `RATE_LIMIT_ERROR` in server logs
- [ ] Confirm normal browsing (cover art loading, search, streaming) is unaffected during import
- [ ] Compare match rate before/after — expect fewer false "unmatched" results

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011GVJKAp8mWtvC82b8wMHhk