### PR TITLE
fix: Hide missing-file ghost stars from liked-songs sync (#130)

### DIFF
--- a/docs/design/liked-songs-refactor-plan.md
+++ b/docs/design/liked-songs-refactor-plan.md
@@ -1,0 +1,128 @@
+# Liked Songs / Stars Reconciliation — Refactor Plan
+
+**Status:** proposed
+**Author:** investigation 2026-08-13 (Juan + Claude)
+**Related:** PR #133 (missing-file ghost stars), issue #130, #124 (dup liked playlists)
+
+## Problem
+
+Songs removed from Liked Songs reappear; unstars don't stick; feedback and likes
+are entangled. Root causes were reproduced live against prod on 2026-08-13.
+
+### Confirmed findings (evidence)
+
+1. **"Remove from playlist" ≠ unstar.**
+   `DELETE /api/playlists/$id/songs/$songId` (`src/routes/api/playlists/$id/songs/$songId.ts`)
+   deletes only the `playlist_songs` row. The song stays starred in Navidrome.
+   - *Test:* removed 6 from ❤️ Liked Songs (369→363), hit Sync →
+     `Rebuilt Liked Songs playlist: 369 songs` → all 6 returned.
+
+2. **The Liked Songs playlist is a full clear-and-reinsert MIRROR of Navidrome
+   stars, rebuilt from 4+ triggers with no single owner:**
+   - `rebuildLikedSongsPlaylist()` in `src/lib/services/liked-songs-sync.ts`
+   - an **inline duplicate** rebuild in `src/routes/api/recommendations/feedback.ts` (~L235)
+   - `POST /api/playlists/sync`
+   - `POST /api/playlists/liked-songs/sync`
+   - partial single-row delete in `DELETE /api/navidrome/star`
+   Any rebuild re-adds every currently-starred song, so removals can't win.
+
+3. **Feedback IS merged with stars/likes.**
+   `feedback.ts`: `thumbs_up → starSong`, `thumbs_down → unstarSong`, then rebuild.
+   A thumbs-up on a recommendation stars the song and adds it to Liked Songs.
+   *Data:* feedback `thumbs_up` = 470 vs real stars = 363.
+
+4. **Duplicate/fragile playlist selection.**
+   Two mirror playlists hold the identical star set:
+   - `❤️ Liked Songs` (app, `navidromeId=null`, id `8fbb6f16…`)
+   - `Loved Songs` (Navidrome-backed, `navidromeId=99x5…`, id `4c2fcfb1…`)
+   All selection uses `name ILIKE '%liked%' ORDER BY updatedAt DESC LIMIT 1` —
+   non-deterministic and name-dependent.
+
+5. **Missing-file ghost stars** (separate, PR #133): the pre-fix native starred
+   fetch returned deleted-file "ghosts" that got re-merged. Fixed by `missing=false`.
+
+### Design principle
+
+**Navidrome stars are the single source of truth.** `liked_songs_sync`,
+`recommendation_feedback (source='library')`, and the Liked Songs `playlist_songs`
+are all *derived caches* of the star set. Every mutation must keep them in lockstep,
+and there must be exactly one code path that rebuilds the cache.
+
+---
+
+## Plan (staged)
+
+### PR #133 — missing-file ghost stars (already open)
+Land first. `getStarredSongs` → native `missing=false`; reconciliation re-star/unstar.
+
+### PR A — "Remove from Liked Songs = unstar" + single rebuild owner (quick, high value)
+
+Goal: removals stick; kill the copy-pasted rebuild.
+
+1. **Remove = unstar for the Liked Songs playlist.**
+   In the playlist view (`src/routes/playlists/$id.tsx`), when `isLikedSongsPlaylist`,
+   route the row "remove" action through the star write-through
+   (`DELETE /api/navidrome/star?id=`) instead of `removeSongMutation`.
+   Alternatively (server-side, more robust): have
+   `DELETE /api/playlists/$id/songs/$songId` detect the Liked Songs playlist and
+   delegate to the unstar write-through.
+2. **One rebuild function.** Delete the inline rebuild in `feedback.ts` and call the
+   shared `rebuildLikedSongsPlaylist()` from `liked-songs-sync.ts`.
+3. **Extract a single `setSongLiked(userId, songId, liked, creds)` service** that does,
+   in one place: Navidrome (un)star → upsert/delete `recommendation_feedback`
+   (source='library') → set `liked_songs_sync.is_active` → add/remove `playlist_songs`
+   row → fix `song_count`. Point `star.ts` POST/DELETE and feedback's star path at it.
+
+**Acceptance:** unstar (heart) and remove (row) both drop the song from Navidrome +
+all caches; a subsequent Sync/rebuild does NOT bring it back.
+
+### PR B — deterministic playlist selection + de-dup (medium)
+
+Goal: exactly one canonical Liked Songs playlist, selected by a stable key.
+
+1. Add a stable marker to `user_playlists` — e.g. `kind` enum
+   (`'liked' | 'user' | 'smart' | 'navidrome'`) or a boolean `is_liked_songs`.
+   Backfill the canonical `❤️ Liked Songs` row.
+2. Replace every `name ILIKE '%liked%' ORDER BY updatedAt DESC LIMIT 1` with a lookup
+   by that marker (in `liked-songs-sync.ts`, `star.ts`, `feedback.ts`, `$id.ts`).
+3. Resolve the `Loved Songs` (Navidrome-backed) vs `❤️ Liked Songs` duplication:
+   decide the canonical one, stop double-mirroring, migrate/rename the other.
+4. Make the `'liked-songs'` route alias resolve to the marked row explicitly.
+
+**Acceptance:** all liked operations target the same row regardless of names; no
+second auto-mirrored playlist.
+
+### PR C — decouple feedback from stars (design decision needed)
+
+Options:
+- **(recommended) Decouple:** `thumbs_up/down` = recommendation signal only; star/like
+  = library action only. Stop `starSong`/`unstarSong` inside the feedback endpoint.
+  Liked Songs is driven purely by stars.
+- **Keep linked but explicit:** if a thumbs-up should still like the song, make it an
+  intentional, documented one-way effect through `setSongLiked()` (not a full rebuild),
+  and surface it in the UI.
+
+**Acceptance:** thumbs feedback no longer silently rebuilds/repopulates Liked Songs;
+`thumbs_up` count reconciles with real stars (modulo intentional manual thumbs).
+
+### PR D — reconcile-on-refresh backstop (small)
+
+Out-of-band changes (unstarring in the Navidrome client) still need a catch-up.
+On opening Liked Songs, trigger the single rebuild owner so the view self-heals from
+stars. Also fixes the "unstar in Navidrome client doesn't reflect" lag.
+
+### Also: library-reconciliation not running
+
+The 6-hourly reconciliation job has **zero logs** on prod — it never initializes.
+This is what remaps metube→Picard duplicate IDs (the "two rows per track" trap, e.g.
+"Odee"). Track separately: find why `initializeReconciliation` isn't called on boot.
+
+---
+
+## Risks / testing
+
+- Touches prod-facing star/like flows — cover `setSongLiked()` with unit tests
+  (star, unstar, idempotency, dup-id no-op) and one e2e (remove from Liked Songs → stays gone).
+- DB marker migration must re-export from `src/lib/db/schema/index.ts` and be applied
+  manually on deploy (migrations don't auto-run — see CLAUDE.md).
+- Verify cross-device sync unaffected (heart state flows through feedback cache).

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -191,6 +191,12 @@ class LibraryReconciliationManager {
 // Core Reconciliation Logic
 // ============================================================================
 
+/** Extract a Postgres error code from an unknown thrown value (direct or wrapped in `.cause`). */
+function pgErrorCode(err: unknown): string | undefined {
+  const e = err as { code?: string; cause?: { code?: string } } | null;
+  return e?.code ?? e?.cause?.code;
+}
+
 function normalizeForMatch(s: string): string {
   return s
     .toLowerCase()
@@ -622,7 +628,7 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
           );
         tablesUpdated.push('liked_songs_sync');
       } catch (err: unknown) {
-        const pgCode = (err as any)?.code || (err as any)?.cause?.code;
+        const pgCode = pgErrorCode(err);
         if (pgCode === '23505') {
           await db
             .delete(likedSongsSync)
@@ -659,7 +665,7 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
           );
         tablesUpdated.push('recommendation_feedback');
       } catch (err: unknown) {
-        const pgCode2 = (err as any)?.code || (err as any)?.cause?.code;
+        const pgCode2 = pgErrorCode(err);
         if (pgCode2 === '23505') {
           await db
             .delete(recommendationFeedback)
@@ -697,7 +703,7 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
                 )
               );
           } catch (dupErr: unknown) {
-            const pgCode3 = (dupErr as any)?.code || (dupErr as any)?.cause?.code;
+            const pgCode3 = pgErrorCode(dupErr);
             if (pgCode3 === '23505') {
               await db
                 .delete(playlistSongs)

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -29,12 +29,15 @@ import {
   getSongsByIds,
   search as navidromeSearch,
   starSong,
+  unstarSong,
   getStarredSongs,
+  getMissingStarredSongs,
   buildSubsonicUrl,
   apiFetch,
 } from './navidrome';
 import { getNavidromeUserCreds } from './navidrome-users';
 import type { SubsonicCreds } from './navidrome-users';
+import { getConfig } from '@/lib/config/config';
 
 // ============================================================================
 // Types
@@ -434,11 +437,22 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
     // Will fall back to admin creds for star operations
   }
 
-  // Get currently starred songs to know if we need to re-star
-  const starredSongs = userCreds
-    ? await getStarredSongs(userCreds)
-    : await getStarredSongs();
-  const starredIds = new Set(starredSongs.map((s) => s.id));
+  // Get currently starred songs to know if we need to re-star.
+  //
+  // getStarredSongs now filters out missing-file "ghost stars" (GH #130), but a
+  // starred song whose file was moved becomes exactly such a ghost — and it's
+  // precisely the dead ID we're remapping. If we only looked at the filtered
+  // list we'd fail to re-star the remapped (now-playable) song and silently
+  // drop the user's like. So union the filtered list with the unfiltered ghost
+  // list to recover those stars. Ghosts are admin-native only, so only fetch
+  // them when this user IS the admin account.
+  const isAdminUser = !userCreds || userCreds.username === getConfig().navidromeUsername;
+  const [liveStarred, ghostStarred] = await Promise.all([
+    userCreds ? getStarredSongs(userCreds) : getStarredSongs(),
+    isAdminUser ? getMissingStarredSongs().catch(() => []) : Promise.resolve([]),
+  ]);
+  const starredIds = new Set([...liveStarred, ...ghostStarred].map((s) => s.id));
+  const ghostStarredIds = new Set(ghostStarred.map((s) => s.id));
 
   for (const [deadId, meta] of deadIds) {
     // Skip if we don't have artist+title to search with
@@ -713,6 +727,22 @@ async function reconcileLibrary(userId: string): Promise<ReconciliationResult> {
       } catch (err) {
         console.warn(
           `[LibraryReconciliation] Failed to re-star ${match.id}:`,
+          err
+        );
+      }
+    }
+
+    // If the dead ID was a ghost star (missing file), unstar it now that the
+    // star has moved to the live match — otherwise it lingers in Navidrome as
+    // an unplayable star. Only ghosts are safe to unstar here: a live star on
+    // deadId would already be covered by the remap above (GH #130).
+    if (ghostStarredIds.has(deadId)) {
+      try {
+        await unstarSong(deadId, userCreds || undefined);
+        tablesUpdated.push('navidrome_unstar_ghost');
+      } catch (err) {
+        console.warn(
+          `[LibraryReconciliation] Failed to unstar ghost ${deadId}:`,
           err
         );
       }

--- a/src/lib/services/navidrome/index.ts
+++ b/src/lib/services/navidrome/index.ts
@@ -31,7 +31,7 @@ export {
 
 // User features (star, scrobble)
 export {
-  starSong, unstarSong, getStarredSongs, scrobbleSong,
+  starSong, unstarSong, getStarredSongs, getMissingStarredSongs, scrobbleSong,
 } from './user-features';
 
 // Playlists

--- a/src/lib/services/navidrome/user-features.ts
+++ b/src/lib/services/navidrome/user-features.ts
@@ -148,14 +148,30 @@ interface NativeSong {
   trackNumber?: number;
 }
 
-async function fetchStarredSongsNative(): Promise<SubsonicSong[]> {
+/**
+ * Fetch starred songs via Navidrome's native REST API (no result cap, unlike
+ * Subsonic getStarred2 which truncates at ~334).
+ *
+ * @param missing - Controls the `missing` file filter:
+ *   - `false` (default): exclude songs whose backing file is gone. This matches
+ *     Subsonic getStarred2's behavior — it silently hides missing-file songs.
+ *     Without this filter the native API returns "ghost stars" (DB rows for
+ *     files deleted/moved by a Lidarr/Picard reorg), which the liked-songs sync
+ *     would then re-merge into Liked Songs and queue for playback (dead IDs →
+ *     skips). See GH #130.
+ *   - `true`: return ONLY the ghost stars (missing files) — used by library
+ *     reconciliation to find and clean them up.
+ *   - `undefined`: no filter (both live and missing).
+ */
+async function fetchStarredSongsNative(missing: boolean | undefined = false): Promise<SubsonicSong[]> {
   const PAGE_SIZE = 500;
   const all: SubsonicSong[] = [];
   let start = 0;
+  const missingParam = missing === undefined ? '' : `&missing=${missing}`;
 
   while (true) {
     const songs = await apiFetch<NativeSong[]>(
-      `/api/song?_start=${start}&_end=${start + PAGE_SIZE}&_order=DESC&_sort=starred_at&starred=true`
+      `/api/song?_start=${start}&_end=${start + PAGE_SIZE}&_order=DESC&_sort=starred_at&starred=true${missingParam}`
     );
 
     for (const song of songs) {
@@ -174,8 +190,24 @@ async function fetchStarredSongsNative(): Promise<SubsonicSong[]> {
     start += PAGE_SIZE;
   }
 
-  console.log(`⭐ Fetched ${all.length} starred songs from Navidrome (native API)`);
+  const label = missing === true ? 'ghost/missing ' : '';
+  console.log(`⭐ Fetched ${all.length} ${label}starred songs from Navidrome (native API)`);
   return all;
+}
+
+/**
+ * Fetch "ghost stars" — starred songs whose backing file is missing (deleted or
+ * moved by a Lidarr/Picard reorg). These stream an XML error instead of audio
+ * and are hidden by Subsonic getStarred2, so the normal star fetch never sees
+ * them. Library reconciliation uses this to unstar/remap them. See GH #130.
+ *
+ * Server-side / admin only — the native API always authenticates as the admin
+ * account, so callers must ensure the target account IS the admin account.
+ * Returns [] in the browser.
+ */
+export async function getMissingStarredSongs(): Promise<SubsonicSong[]> {
+  if (isBrowser()) return [];
+  return fetchStarredSongsNative(true);
 }
 
 /**


### PR DESCRIPTION
Fixes #130.

## Problem

`getStarredSongs()` fetches the admin account's stars via Navidrome's **native** `/api/song?starred=true` (no result cap). That endpoint returns **ghost stars** — DB rows whose backing files were deleted/moved by a Lidarr/Picard reorg. Subsonic `getStarred2` silently *hides* missing-file songs; the native path did not, so `syncLikedSongsToFeedback()` re-activated the ghosts every run and merged them back into Liked Songs → unplayable IDs → playback skips. (Observed on prod: 436 active likes vs 383 real stars = 53 ghosts.)

## Fix

- **`fetchStarredSongsNative()`** now appends the native `&missing=false` filter, giving exact parity with `getStarred2`'s ghost-hiding — no per-song stream checks needed.
  - Verified the filter is honored against the live server: `23111` total = `21715` `missing=false` + `1396` `missing=true`.
- **`getMissingStarredSongs()`** (new, `missing=true`, admin/native only) exposes the ghost subset for reconciliation.

## Reconciliation blind spot (second-order fix)

Because `getStarredSongs` now hides ghosts, a starred song whose file *moved* (exactly the dead ID being remapped) would no longer appear in the starred set — so the remap would **silently drop the user's like**. Reconciliation now:
- unions the live starred list with the unfiltered ghost list so remapped ghosts still get **re-starred**, and
- **unstars the dead ghost id** after a successful remap, so Navidrome stops carrying the unplayable star.

The ghost fetch is admin-gated (native API always authenticates as admin), so non-admin users are unaffected.

## Deferred

Blanket unstarring of *notFound* ghosts (no live replacement) is intentionally left out — it's destructive and risks nuking a real like if a drive is temporarily unmounted mid-scan. The `missing=false` fix already stops the re-merge, so it's cosmetic. Can be added later behind a scan-confirmed guard.

## Testing

- Confirmed `&missing=false` filter behavior directly against the Navidrome server.
- Typecheck clean on all three changed files (pre-existing route-tree codegen errors are in unrelated route files).
- `seeded-radio` service test suite passes (34/34).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dm39VGE1neEGBUyfyaj9S6