### PR TITLE
feat: Single setSongLiked() write-through — removals stick, no more drift (plan PR A)

### DIFF
--- a/src/lib/services/__tests__/liked-songs-set.test.ts
+++ b/src/lib/services/__tests__/liked-songs-set.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as navidrome from '../navidrome';
+
+// Configurable resolve value for any awaited/`.then`ed db chain.
+let resolveValue: unknown[] = [];
+
+// Chainable, thenable db mock: every builder method returns the same proxy,
+// and awaiting the proxy (or calling `.then`) resolves to `resolveValue`.
+function makeDb() {
+  const p: Record<string, unknown> = {};
+  const methods = [
+    'select', 'from', 'where', 'orderBy', 'limit',
+    'insert', 'values', 'onConflictDoUpdate', 'returning',
+    'update', 'set', 'delete',
+  ];
+  for (const m of methods) p[m] = vi.fn(() => p);
+  (p as { then: unknown }).then = (onFulfilled: (v: unknown) => unknown) =>
+    Promise.resolve(resolveValue).then(onFulfilled);
+  return p;
+}
+
+vi.mock('@/lib/db', () => ({ db: makeDb() }));
+
+vi.mock('../navidrome', () => ({
+  starSong: vi.fn().mockResolvedValue(undefined),
+  unstarSong: vi.fn().mockResolvedValue(undefined),
+  getSongsByIds: vi.fn().mockResolvedValue([]),
+  getStarredSongs: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock('../navidrome-users', () => ({
+  getNavidromeUserCreds: vi.fn().mockResolvedValue(null),
+}));
+
+import { setSongLiked, isCanonicalLikedPlaylist } from '../liked-songs-sync';
+
+const CREDS = { username: 'u', token: 't', salt: 's' } as unknown as Parameters<typeof setSongLiked>[3];
+
+describe('setSongLiked write-through', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveValue = [];
+  });
+
+  it('liking a song stars it in Navidrome (source of truth)', async () => {
+    // findLikedPlaylist resolves to an existing mirror playlist so no create path.
+    resolveValue = [{ id: 'pl1', name: '❤️ Liked Songs', navidromeId: null }];
+    await setSongLiked('user-1', 'song-1', true, CREDS, { artist: 'A', title: 'T' });
+
+    expect(navidrome.starSong).toHaveBeenCalledWith('song-1', CREDS);
+    expect(navidrome.unstarSong).not.toHaveBeenCalled();
+  });
+
+  it('unliking a song unstars it in Navidrome (the "remove = unstar" fix)', async () => {
+    resolveValue = [];
+    await setSongLiked('user-1', 'song-1', false, CREDS);
+
+    expect(navidrome.unstarSong).toHaveBeenCalledWith('song-1', CREDS);
+    expect(navidrome.starSong).not.toHaveBeenCalled();
+  });
+});
+
+describe('isCanonicalLikedPlaylist', () => {
+  it('matches the app-managed ❤️ Liked Songs playlist', () => {
+    expect(isCanonicalLikedPlaylist({ name: '❤️ Liked Songs', navidromeId: null })).toBe(true);
+  });
+
+  it('rejects Navidrome-backed playlists (e.g. "Loved Songs")', () => {
+    expect(isCanonicalLikedPlaylist({ name: 'Loved Songs', navidromeId: '99x5' })).toBe(false);
+  });
+
+  it('rejects unrelated playlists', () => {
+    expect(isCanonicalLikedPlaylist({ name: 'Road Trip', navidromeId: null })).toBe(false);
+  });
+});

--- a/src/lib/services/liked-songs-sync.ts
+++ b/src/lib/services/liked-songs-sync.ts
@@ -21,9 +21,10 @@ import {
   type LikedSongsSyncInsert,
 } from '../db/schema';
 import { eq, and, inArray, sql, desc } from 'drizzle-orm';
-import { getStarredSongs } from './navidrome';
+import { getStarredSongs, starSong, unstarSong, getSongsByIds } from './navidrome';
 import type { SubsonicSong } from './navidrome';
 import { getNavidromeUserCreds } from './navidrome-users';
+import type { SubsonicCreds } from './navidrome-users';
 
 // ============================================================================
 // Types
@@ -344,22 +345,200 @@ export async function getLikedSongsCount(userId: string): Promise<number> {
 
 const LIKED_SONGS_NAME = '❤️ Liked Songs';
 
-export async function rebuildLikedSongsPlaylist(
-  userId: string,
-  starredSongs: SubsonicSong[]
-): Promise<{ playlistId: string; songCount: number }> {
-  let likedPlaylist = await db
+type LikedPlaylistRow = typeof userPlaylists.$inferSelect;
+
+/**
+ * Resolve the canonical app-managed "Liked Songs" playlist for a user.
+ *
+ * NOTE: selection is still by `name ILIKE '%liked%'` (most-recently-updated),
+ * which is fragile — a follow-up (plan PR B) replaces this with a stable marker
+ * column. It is centralised here so there is exactly one place to change.
+ * Navidrome-backed playlists (e.g. "Loved Songs", which has a navidromeId) are
+ * intentionally excluded so we never treat a real Navidrome playlist as the
+ * auto-synced star mirror.
+ */
+export async function findLikedPlaylist(userId: string): Promise<LikedPlaylistRow | undefined> {
+  return db
     .select()
     .from(userPlaylists)
     .where(
       and(
         eq(userPlaylists.userId, userId),
+        sql`${userPlaylists.navidromeId} IS NULL`,
         sql`${userPlaylists.name} ILIKE '%liked%'`
       )
     )
     .orderBy(desc(userPlaylists.updatedAt))
     .limit(1)
     .then(rows => rows[0]);
+}
+
+/** True if a playlist row is the canonical app-managed Liked Songs mirror. */
+export function isCanonicalLikedPlaylist(p: Pick<LikedPlaylistRow, 'name' | 'navidromeId'>): boolean {
+  return p.navidromeId == null && /liked/i.test(p.name);
+}
+
+/**
+ * Single source of truth for toggling a song's "liked" (starred) state.
+ *
+ * Keeps every derived store in lockstep in ONE place:
+ *   Navidrome star  ↔  recommendation_feedback (source='library')
+ *                   ↔  liked_songs_sync.is_active
+ *                   ↔  playlist_songs (the ❤️ Liked Songs mirror)
+ *
+ * Use this everywhere a like is set/cleared (heart button, feedback endpoint,
+ * "remove from Liked Songs") so the playlist can never drift from the stars.
+ */
+export async function setSongLiked(
+  userId: string,
+  songId: string,
+  liked: boolean,
+  creds?: SubsonicCreds,
+  meta?: { artist?: string; title?: string }
+): Promise<void> {
+  // 1. Navidrome is the source of truth — (un)star first.
+  if (liked) {
+    await starSong(songId, creds);
+  } else {
+    await unstarSong(songId, creds);
+  }
+
+  // 2. Resolve metadata (needed for inserts). Best-effort; never fatal.
+  let artist = meta?.artist;
+  let title = meta?.title;
+  if (liked && (!artist || !title)) {
+    try {
+      const [song] = await getSongsByIds([songId]);
+      if (song) {
+        artist = artist || song.artist || 'Unknown';
+        title = title || song.title || song.name || songId;
+      }
+    } catch {
+      // metadata lookup failed — fall through to placeholders
+    }
+  }
+  artist = artist || 'Unknown';
+  title = title || songId;
+  const songArtistTitle = `${artist} - ${title}`;
+
+  // 3. recommendation_feedback (source='library' — mirrors the star)
+  if (liked) {
+    const temporal = getTemporalMetadata();
+    await db
+      .insert(recommendationFeedback)
+      .values({
+        userId,
+        songId,
+        songArtistTitle,
+        feedbackType: 'thumbs_up',
+        source: 'library',
+        month: temporal.month,
+        season: temporal.season,
+        dayOfWeek: temporal.dayOfWeek,
+        hourOfDay: temporal.hourOfDay,
+      })
+      .onConflictDoUpdate({
+        target: [recommendationFeedback.userId, recommendationFeedback.songId],
+        set: { feedbackType: 'thumbs_up', timestamp: new Date() },
+      });
+  } else {
+    await db
+      .delete(recommendationFeedback)
+      .where(
+        and(
+          eq(recommendationFeedback.userId, userId),
+          eq(recommendationFeedback.songId, songId),
+          eq(recommendationFeedback.source, 'library')
+        )
+      );
+  }
+
+  // 4. liked_songs_sync ledger
+  if (liked) {
+    await db
+      .insert(likedSongsSync)
+      .values({ userId, songId, artist, title, isActive: 1 })
+      .onConflictDoUpdate({
+        target: [likedSongsSync.userId, likedSongsSync.songId],
+        set: { isActive: 1, syncedAt: new Date() },
+      });
+  } else {
+    await db
+      .update(likedSongsSync)
+      .set({ isActive: 0 })
+      .where(and(eq(likedSongsSync.userId, userId), eq(likedSongsSync.songId, songId)));
+  }
+
+  // 5. playlist_songs — surgical single-row add/remove in the ❤️ mirror.
+  if (liked) {
+    // Create the mirror playlist on first like if it doesn't exist yet.
+    let likedPlaylist = await findLikedPlaylist(userId);
+    if (!likedPlaylist) {
+      const [created] = await db
+        .insert(userPlaylists)
+        .values({
+          id: crypto.randomUUID(),
+          userId,
+          name: LIKED_SONGS_NAME,
+          description: 'Auto-synced from your starred songs in Navidrome',
+          navidromeId: null,
+          lastSynced: new Date(),
+          songCount: 0,
+          totalDuration: 0,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        })
+        .returning();
+      likedPlaylist = created;
+    }
+
+    const existing = await db
+      .select({ id: playlistSongs.id })
+      .from(playlistSongs)
+      .where(and(eq(playlistSongs.playlistId, likedPlaylist.id), eq(playlistSongs.songId, songId)))
+      .limit(1);
+
+    if (existing.length === 0) {
+      const rows = await db
+        .select({ songId: playlistSongs.songId })
+        .from(playlistSongs)
+        .where(eq(playlistSongs.playlistId, likedPlaylist.id));
+      await db.insert(playlistSongs).values({
+        id: crypto.randomUUID(),
+        playlistId: likedPlaylist.id,
+        songId,
+        songArtistTitle,
+        position: rows.length + 1,
+        addedAt: new Date(),
+      });
+      await db
+        .update(userPlaylists)
+        .set({ songCount: rows.length + 1, updatedAt: new Date() })
+        .where(eq(userPlaylists.id, likedPlaylist.id));
+    }
+  } else {
+    const likedPlaylist = await findLikedPlaylist(userId);
+    if (likedPlaylist) {
+      await db
+        .delete(playlistSongs)
+        .where(and(eq(playlistSongs.playlistId, likedPlaylist.id), eq(playlistSongs.songId, songId)));
+      const remaining = await db
+        .select({ songId: playlistSongs.songId })
+        .from(playlistSongs)
+        .where(eq(playlistSongs.playlistId, likedPlaylist.id));
+      await db
+        .update(userPlaylists)
+        .set({ songCount: remaining.length, updatedAt: new Date() })
+        .where(eq(userPlaylists.id, likedPlaylist.id));
+    }
+  }
+}
+
+export async function rebuildLikedSongsPlaylist(
+  userId: string,
+  starredSongs: SubsonicSong[]
+): Promise<{ playlistId: string; songCount: number }> {
+  let likedPlaylist = await findLikedPlaylist(userId);
 
   if (!likedPlaylist) {
     const [newPlaylist] = await db

--- a/src/routes/api/navidrome/star.ts
+++ b/src/routes/api/navidrome/star.ts
@@ -9,12 +9,8 @@
  */
 
 import { createFileRoute } from '@tanstack/react-router';
-import { starSong, unstarSong, getSongsByIds } from '../../../lib/services/navidrome';
 import { ensureNavidromeUser } from '../../../lib/services/navidrome-users';
-import { db } from '../../../lib/db';
-import { recommendationFeedback, likedSongsSync, userPlaylists, playlistSongs } from '../../../lib/db/schema';
-import { eq, and, sql, desc } from 'drizzle-orm';
-import { extractTemporalMetadata } from '../../../lib/utils/temporal';
+import { setSongLiked } from '../../../lib/services/liked-songs-sync';
 import {
   withAuthAndErrorHandling,
   successResponse,
@@ -31,53 +27,8 @@ const POST = withAuthAndErrorHandling(
     }
 
     const creds = await ensureNavidromeUser(session.user.id, session.user.name, session.user.email);
-    await starSong(songId, creds);
-
-    // Sync star to feedback + liked_songs_sync tables (non-blocking)
-    try {
-      const songs = await getSongsByIds([songId]);
-      const song = songs[0];
-      const artistTitle = song
-        ? `${song.artist || 'Unknown'} - ${song.title || song.name}`
-        : `Unknown - ${songId}`;
-      const temporal = extractTemporalMetadata(new Date());
-
-      await db
-        .insert(recommendationFeedback)
-        .values({
-          id: crypto.randomUUID(),
-          userId: session.user.id,
-          songId,
-          songArtistTitle: artistTitle,
-          feedbackType: 'thumbs_up',
-          source: 'library',
-          timestamp: new Date(),
-          month: temporal.month,
-          season: temporal.season,
-          dayOfWeek: temporal.dayOfWeek,
-          hourOfDay: temporal.hourOfDay,
-        })
-        .onConflictDoUpdate({
-          target: [recommendationFeedback.userId, recommendationFeedback.songId],
-          set: { feedbackType: 'thumbs_up', timestamp: new Date() },
-        });
-
-      await db
-        .insert(likedSongsSync)
-        .values({
-          userId: session.user.id,
-          songId,
-          artist: song?.artist || 'Unknown',
-          title: song?.title || song?.name || songId,
-          isActive: 1,
-        })
-        .onConflictDoUpdate({
-          target: [likedSongsSync.userId, likedSongsSync.songId],
-          set: { isActive: 1, syncedAt: new Date() },
-        });
-    } catch (syncError) {
-      console.error('Failed to sync star to feedback tables (non-blocking):', syncError);
-    }
+    // Single write-through: Navidrome star + feedback + ledger + playlist mirror.
+    await setSongLiked(session.user.id, songId, true, creds);
 
     return successResponse({ starred: true, songId });
   },
@@ -99,70 +50,8 @@ const DELETE = withAuthAndErrorHandling(
     }
 
     const creds = await ensureNavidromeUser(session.user.id, session.user.name, session.user.email);
-    await unstarSong(songId, creds);
-
-    // Sync unstar to feedback + liked_songs_sync + playlist_songs (non-blocking)
-    try {
-      // Remove thumbs_up feedback for this song (regardless of source)
-      await db
-        .delete(recommendationFeedback)
-        .where(
-          and(
-            eq(recommendationFeedback.userId, session.user.id),
-            eq(recommendationFeedback.songId, songId),
-            eq(recommendationFeedback.feedbackType, 'thumbs_up')
-          )
-        );
-
-      // Mark as inactive in liked_songs_sync
-      await db
-        .update(likedSongsSync)
-        .set({ isActive: 0 })
-        .where(
-          and(
-            eq(likedSongsSync.userId, session.user.id),
-            eq(likedSongsSync.songId, songId)
-          )
-        );
-
-      // Remove from the Liked Songs playlist so it disappears on refresh
-      const likedPlaylist = await db
-        .select({ id: userPlaylists.id })
-        .from(userPlaylists)
-        .where(
-          and(
-            eq(userPlaylists.userId, session.user.id),
-            sql`${userPlaylists.name} ILIKE '%liked%'`
-          )
-        )
-        .orderBy(desc(userPlaylists.updatedAt))
-        .limit(1)
-        .then(rows => rows[0]);
-
-      if (likedPlaylist) {
-        await db
-          .delete(playlistSongs)
-          .where(
-            and(
-              eq(playlistSongs.playlistId, likedPlaylist.id),
-              eq(playlistSongs.songId, songId)
-            )
-          );
-
-        // Update the playlist song count
-        const remaining = await db
-          .select({ songId: playlistSongs.songId })
-          .from(playlistSongs)
-          .where(eq(playlistSongs.playlistId, likedPlaylist.id));
-
-        await db
-          .update(userPlaylists)
-          .set({ songCount: remaining.length, updatedAt: new Date() })
-          .where(eq(userPlaylists.id, likedPlaylist.id));
-      }
-    } catch (syncError) {
-      console.error('Failed to sync unstar to feedback tables (non-blocking):', syncError);
-    }
+    // Single write-through: Navidrome unstar + feedback + ledger + playlist mirror.
+    await setSongLiked(session.user.id, songId, false, creds);
 
     return successResponse({ starred: false, songId });
   },

--- a/src/routes/api/playlists/$id/songs/$songId.ts
+++ b/src/routes/api/playlists/$id/songs/$songId.ts
@@ -4,6 +4,8 @@ import { db } from '../../../../../lib/db';
 import { userPlaylists, playlistSongs } from '../../../../../lib/db/schema/playlists.schema';
 import { eq, and, gt } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
+import { ensureNavidromeUser } from '../../../../../lib/services/navidrome-users';
+import { setSongLiked, isCanonicalLikedPlaylist } from '../../../../../lib/services/liked-songs-sync';
 
 export const Route = createFileRoute("/api/playlists/$id/songs/$songId")({
   server: {
@@ -44,6 +46,20 @@ export const Route = createFileRoute("/api/playlists/$id/songs/$songId")({
           code: 'PLAYLIST_NOT_FOUND'
         }), {
           status: 404,
+          headers: { 'Content-Type': 'application/json' }
+        });
+      }
+
+      // The ❤️ Liked Songs playlist is a mirror of Navidrome stars, not a
+      // free-standing list. "Removing" a song from it must UNSTAR it — otherwise
+      // the song stays starred and the next rebuild re-adds it. Delegate to the
+      // single write-through so Navidrome + feedback + ledger + playlist stay
+      // in lockstep.
+      if (isCanonicalLikedPlaylist(playlist)) {
+        const creds = await ensureNavidromeUser(session.user.id, session.user.name, session.user.email);
+        await setSongLiked(session.user.id, songId, false, creds);
+        return new Response(JSON.stringify({ data: { success: true, unstarred: true } }), {
+          status: 200,
           headers: { 'Content-Type': 'application/json' }
         });
       }

--- a/src/routes/api/recommendations/feedback.ts
+++ b/src/routes/api/recommendations/feedback.ts
@@ -1,14 +1,13 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { db } from '../../../lib/db';
 import { recommendationFeedback, recommendationsCache, userPreferences, likedSongsSync } from '../../../lib/db/schema';
-import { eq, and, inArray, sql, desc } from 'drizzle-orm';
+import { eq, and, inArray } from 'drizzle-orm';
 import { z } from 'zod';
-import { starSong, unstarSong, getStarredSongs } from '../../../lib/services/navidrome';
+import { setSongLiked } from '../../../lib/services/liked-songs-sync';
 import { ensureNavidromeUser } from '../../../lib/services/navidrome-users';
 import { clearPreferenceCache } from '../../../lib/services/preferences';
 import { clearAnalyticsCache } from '../../../lib/services/recommendation-analytics';
 import { extractTemporalMetadata } from '../../../lib/utils/temporal';
-import { userPlaylists, playlistSongs } from '../../../lib/db/schema';
 import {
   withAuthAndErrorHandling,
   errorResponse,
@@ -195,113 +194,24 @@ export const POST = withAuthAndErrorHandling(
         if (syncEnabled) {
           const creds = await ensureNavidromeUser(session.user.id, session.user.name, session.user.email);
 
-          if (validatedData.feedbackType === 'thumbs_up') {
-            await starSong(validatedData.songId, creds);
-            console.log(`✅ Starred song ${validatedData.songId} in Navidrome`);
-
-            // Sync to likedSongsSync so heart icon shows in playlist views
-            const parts = validatedData.songArtistTitle.split(' - ');
-            const artist = parts[0] || 'Unknown';
-            const title = parts.slice(1).join(' - ') || validatedData.songArtistTitle;
-            await db
-              .insert(likedSongsSync)
-              .values({
-                userId: session.user.id,
-                songId: validatedData.songId,
-                artist,
-                title,
-                isActive: 1,
-              })
-              .onConflictDoUpdate({
-                target: [likedSongsSync.userId, likedSongsSync.songId],
-                set: { isActive: 1, syncedAt: new Date() },
-              });
-          } else if (validatedData.feedbackType === 'thumbs_down') {
-            await unstarSong(validatedData.songId, creds);
-            console.log(`❌ Unstarred song ${validatedData.songId} in Navidrome`);
-
-            // Mark as inactive in likedSongsSync
-            await db
-              .update(likedSongsSync)
-              .set({ isActive: 0 })
-              .where(
-                and(
-                  eq(likedSongsSync.userId, session.user.id),
-                  eq(likedSongsSync.songId, validatedData.songId)
-                )
-              );
-          }
-
-          // Auto-sync Liked Songs playlist after starring/unstarring
-          try {
-            const LIKED_SONGS_NAME = '❤️ Liked Songs';
-            const starredSongs = await getStarredSongs(creds);
-
-            // Find or create Liked Songs playlist
-            let likedPlaylist = await db
-              .select()
-              .from(userPlaylists)
-              .where(
-                and(
-                  eq(userPlaylists.userId, session.user.id),
-                  sql`${userPlaylists.name} ILIKE '%liked%'`
-                )
-              )
-              .orderBy(desc(userPlaylists.updatedAt))
-              .limit(1)
-              .then(rows => rows[0]);
-
-            if (!likedPlaylist) {
-              const [newPlaylist] = await db
-                .insert(userPlaylists)
-                .values({
-                  id: crypto.randomUUID(),
-                  userId: session.user.id,
-                  name: LIKED_SONGS_NAME,
-                  description: 'Auto-synced from your starred songs in Navidrome',
-                  navidromeId: null,
-                  lastSynced: new Date(),
-                  songCount: starredSongs.length,
-                  totalDuration: starredSongs.reduce((sum, s) => sum + parseInt(s.duration || '0'), 0),
-                  createdAt: new Date(),
-                  updatedAt: new Date(),
-                })
-                .returning();
-              likedPlaylist = newPlaylist;
-            }
-
-            // Update playlist metadata
-            await db
-              .update(userPlaylists)
-              .set({
-                name: LIKED_SONGS_NAME,
-                lastSynced: new Date(),
-                songCount: starredSongs.length,
-                totalDuration: starredSongs.reduce((sum, s) => sum + parseInt(s.duration || '0'), 0),
-                updatedAt: new Date(),
-              })
-              .where(eq(userPlaylists.id, likedPlaylist.id));
-
-            // Clear and re-insert songs
-            await db.delete(playlistSongs).where(eq(playlistSongs.playlistId, likedPlaylist.id));
-
-            if (starredSongs.length > 0) {
-              await db.insert(playlistSongs).values(
-                starredSongs.map((song, index) => ({
-                  id: crypto.randomUUID(),
-                  playlistId: likedPlaylist.id,
-                  songId: song.id,
-                  songArtistTitle: `${song.artist} - ${song.title}`,
-                  position: index + 1,
-                  addedAt: new Date(),
-                }))
-              );
-            }
-
-            console.log(`💖 Auto-synced Liked Songs playlist: ${starredSongs.length} songs`);
-          } catch (syncError) {
-            console.error('Failed to auto-sync Liked Songs playlist (non-blocking):', syncError);
-          }
+          // Mirror the feedback to the library "like" (star) through the single
+          // write-through, which keeps Navidrome + feedback + liked_songs_sync +
+          // the ❤️ Liked Songs playlist in lockstep (surgical single-row update,
+          // no full rebuild).
+          //
+          // NOTE: thumbs feedback is still COUPLED to stars here — a thumbs_up
+          // stars/likes the song, thumbs_down unstars it. Plan PR C decouples
+          // these two signals; this PR only centralises the write.
+          const parts = validatedData.songArtistTitle.split(' - ');
+          const artist = parts[0] || 'Unknown';
+          const title = parts.slice(1).join(' - ') || validatedData.songArtistTitle;
+          await setSongLiked(
+            session.user.id,
+            validatedData.songId,
+            validatedData.feedbackType === 'thumbs_up',
+            creds,
+            { artist, title }
+          );
         } else {
           console.log(`🔒 Navidrome sync disabled by user preference`);
         }


### PR DESCRIPTION
First slice of the Liked Songs refactor (`docs/design/liked-songs-refactor-plan.md`, PR A). Follows #133.

## Why

Investigated live on 2026-08-13: songs "removed" from Liked Songs kept coming back. Root cause — the ❤️ Liked Songs playlist is a **clear-and-reinsert mirror of Navidrome stars**, rebuilt from 4+ places, while the "remove" button only deleted a `playlist_songs` row without unstarring. So the song stayed starred and the next rebuild (playlist sync, a thumbs-up, the AI-DJ profile trigger) re-added it. Reproduced deterministically: removed 6 → hit Sync → `Rebuilt Liked Songs playlist: 369 songs` → all 6 back.

## What

- **`setSongLiked(userId, songId, liked, creds?, meta?)`** — one source of truth that keeps **Navidrome star + `recommendation_feedback`(source='library') + `liked_songs_sync.is_active` + the `playlist_songs` mirror** in lockstep with a surgical single-row update (no full rebuild).
- **`findLikedPlaylist()` / `isCanonicalLikedPlaylist()`** — centralised playlist selection; still `name ILIKE` but now excludes Navidrome-backed playlists (e.g. `Loved Songs`). A stable marker column is **deferred to PR B**.
- **`/api/navidrome/star`** POST/DELETE → thin delegates to `setSongLiked` (removes ~120 lines of inline write-through).
- **`/api/recommendations/feedback`** → thumbs_up/down call `setSongLiked` instead of a **copy-pasted full playlist rebuild** (dead code deleted, ~90 lines). Thumbs stay coupled to stars here; **PR C decouples** them.
- **`DELETE /api/playlists/$id/songs/$songId`** → when the target is the canonical Liked Songs playlist, **unstar (write-through)** instead of only deleting the row. This is the fix that makes removals actually stick.

## Testing

- New unit test: `setSongLiked` stars on like / unstars on unlike; `isCanonicalLikedPlaylist` matching (5 tests).
- Existing playlists + SongFeedbackButtons suites pass (27).
- `npm run build` passes; ESLint clean on changed files.
- Manual: the 6 test songs were unstarred via the same write-through path today and stayed gone through a rebuild.

## Not in this PR (tracked in the plan doc)

- PR B: stable liked-playlist marker + resolve ❤️/Loved duplication
- PR C: decouple thumbs feedback from stars
- PR D: reconcile-on-refresh backstop
- separate: why `library-reconciliation` never initializes on prod

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dm39VGE1neEGBUyfyaj9S6