### PR TITLE
refactor: Decouple thumbs feedback from stars (plan PR C)

### DIFF
--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -397,8 +397,9 @@ export function PlayerBar() {
   // Determine if song is liked based on server state
   const isLiked = useMemo(() => {
     if (!currentSong?.id) return false;
-    return feedbackData?.feedback?.[currentSong.id] === 'thumbs_up';
-  }, [feedbackData?.feedback, currentSong?.id]);
+    // Heart reflects the library star signal (`liked`), not thumbs feedback.
+    return feedbackData?.liked?.includes(currentSong.id) ?? false;
+  }, [feedbackData?.liked, currentSong?.id]);
 
   // Like/unlike mutation with optimistic cache update
   const { mutate: likeMutate, isPending: isLikePending } = useMutation({
@@ -435,9 +436,11 @@ export function PlayerBar() {
       const feedbackQueryKey = queryKeys.feedback.songs([currentSong.id]);
       await queryClient.cancelQueries({ queryKey: feedbackQueryKey });
       const previous = queryClient.getQueryData(feedbackQueryKey);
-      queryClient.setQueryData(feedbackQueryKey, {
-        feedback: { [currentSong.id]: liked ? 'thumbs_up' : 'thumbs_down' },
-      });
+      // Optimistically update the `liked` (star) set so the heart fills immediately.
+      queryClient.setQueryData(feedbackQueryKey, (old: { feedback?: Record<string, string>; liked?: string[] } | undefined) => ({
+        feedback: old?.feedback ?? {},
+        liked: liked ? [currentSong.id] : [],
+      }));
       return { previous, feedbackQueryKey };
     },
     onSuccess: (liked) => {

--- a/src/components/library/HeartButton.tsx
+++ b/src/components/library/HeartButton.tsx
@@ -25,15 +25,15 @@ interface HeartButtonProps {
 export function HeartButton({ songId, artist, title, className, size = 'sm' }: HeartButtonProps) {
   const queryClient = useQueryClient();
   const { data: feedbackData } = useSongFeedback([songId]);
-  // The PlayerBar treats thumbs_up as "liked" — use the same source of truth.
-  const serverLiked = feedbackData?.feedback?.[songId] === 'thumbs_up';
+  // Liked = the library star signal, kept SEPARATE from thumbs feedback.
+  const serverLiked = feedbackData?.liked?.includes(songId) ?? false;
   const [optimisticLiked, setOptimisticLiked] = useState<boolean | null>(null);
   const liked = optimisticLiked ?? serverLiked;
 
   // Reset optimistic state once the server confirms.
   /* eslint-disable react-hooks/set-state-in-effect */
   useEffect(() => {
-    if (feedbackData?.feedback) setOptimisticLiked(null);
+    if (feedbackData) setOptimisticLiked(null);
   }, [feedbackData]);
   /* eslint-enable react-hooks/set-state-in-effect */
 
@@ -50,9 +50,11 @@ export function HeartButton({ songId, artist, title, className, size = 'sm' }: H
       const feedbackQueryKey = queryKeys.feedback.songs([songId]);
       await queryClient.cancelQueries({ queryKey: feedbackQueryKey });
       const previous = queryClient.getQueryData(feedbackQueryKey);
-      queryClient.setQueryData(feedbackQueryKey, {
-        feedback: { [songId]: newLiked ? 'thumbs_up' : 'thumbs_down' },
-      });
+      // Optimistically update the `liked` (star) set — the heart's source of truth.
+      queryClient.setQueryData(feedbackQueryKey, (old: { feedback?: Record<string, string>; liked?: string[] } | undefined) => ({
+        feedback: old?.feedback ?? {},
+        liked: newLiked ? [songId] : [],
+      }));
       return { previous, feedbackQueryKey };
     },
     onSuccess: (_data, newLiked) => {

--- a/src/hooks/useSongFeedback.ts
+++ b/src/hooks/useSongFeedback.ts
@@ -3,7 +3,10 @@ import authClient from '@/lib/auth/auth-client';
 import { queryKeys, queryPresets } from '@/lib/query';
 
 interface FeedbackResponse {
+  // Thumbs signal (recommendation quality).
   feedback: Record<string, 'thumbs_up' | 'thumbs_down'>;
+  // Library star state (the heart) — decoupled from thumbs. See the feedback route.
+  liked: string[];
 }
 
 /**
@@ -19,7 +22,7 @@ export function useSongFeedback(songIds: string[]) {
     queryKey: queryKeys.feedback.songs(songIds),
     queryFn: async (): Promise<FeedbackResponse> => {
       if (!session?.user?.id || songIds.length === 0) {
-        return { feedback: {} };
+        return { feedback: {}, liked: [] };
       }
 
       const response = await fetch(`/api/recommendations/feedback?songIds=${encodeURIComponent(songIds.join(','))}`);

--- a/src/lib/hooks/useSongFeedback.ts
+++ b/src/lib/hooks/useSongFeedback.ts
@@ -13,7 +13,7 @@ export function useSongFeedback(songIds: string[]) {
     queryKey: queryKeys.feedback.songs(songIds),
     queryFn: async () => {
       if (songIds.length === 0) {
-        return { feedback: {} };
+        return { feedback: {}, liked: [] };
       }
 
       const response = await fetch(`/api/recommendations/feedback?songIds=${songIds.join(',')}`);
@@ -26,7 +26,12 @@ export function useSongFeedback(songIds: string[]) {
       }
 
       const data = await response.json();
-      return data as { feedback: Record<string, 'thumbs_up' | 'thumbs_down'> };
+      // `feedback` = thumbs signal (recommendation quality); `liked` = library
+      // star state (the heart). These are decoupled — see /api/recommendations/feedback.
+      return data as {
+        feedback: Record<string, 'thumbs_up' | 'thumbs_down'>;
+        liked: string[];
+      };
     },
     enabled: songIds.length > 0,
     ...queryPresets.feedback,

--- a/src/routes/api/recommendations/__tests__/feedback-decouple.test.ts
+++ b/src/routes/api/recommendations/__tests__/feedback-decouple.test.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import * as likedSongsSync from '@/lib/services/liked-songs-sync';
+
+// Chainable, thenable db mock: every builder method returns the same proxy, and
+// awaiting the proxy (or `.then`) resolves to `resolveValue`. Both selects in the
+// POST path (existing feedback, user preferences) resolve to [] → insert branch,
+// sync enabled by default.
+let resolveValue: unknown[] = [];
+function makeDb() {
+  const p: Record<string, unknown> = {};
+  const methods = [
+    'select', 'from', 'where', 'orderBy', 'limit',
+    'insert', 'values', 'onConflictDoUpdate', 'returning',
+    'update', 'set', 'delete',
+  ];
+  for (const m of methods) p[m] = vi.fn(() => p);
+  (p as { then: unknown }).then = (onFulfilled: (v: unknown) => unknown) =>
+    Promise.resolve(resolveValue).then(onFulfilled);
+  return p;
+}
+
+vi.mock('@/lib/db', () => ({ db: makeDb() }));
+
+vi.mock('@/lib/services/liked-songs-sync', () => ({
+  setSongLiked: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('@/lib/services/navidrome-users', () => ({
+  ensureNavidromeUser: vi.fn().mockResolvedValue({ username: 'u', token: 't', salt: 's' }),
+}));
+
+vi.mock('@/lib/services/preferences', () => ({ clearPreferenceCache: vi.fn() }));
+vi.mock('@/lib/services/recommendation-analytics', () => ({ clearAnalyticsCache: vi.fn() }));
+
+// withAuthAndErrorHandling dynamically imports this and injects the session.
+vi.mock('@/lib/auth/auth', () => ({
+  auth: { api: { getSession: vi.fn().mockResolvedValue({ user: { id: 'user-1', name: 'U', email: 'u@e.com' } }) } },
+}));
+
+import { POST } from '../feedback';
+
+function postReq(body: Record<string, unknown>) {
+  return {
+    request: new Request('http://localhost/api/recommendations/feedback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    }),
+  };
+}
+
+describe('feedback POST — thumbs decoupled from stars', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resolveValue = [];
+  });
+
+  it('does NOT star recommendation-source thumbs_up (pure rec signal)', async () => {
+    const res = await POST(postReq({
+      songArtistTitle: 'Artist - Title',
+      feedbackType: 'thumbs_up',
+      source: 'recommendation',
+      songId: 'song-1',
+    }));
+
+    expect(res.status).toBe(200);
+    expect(likedSongsSync.setSongLiked).not.toHaveBeenCalled();
+  });
+
+  it('does NOT unstar on an ai_dj thumbs_down (must not clear a genuine like)', async () => {
+    await POST(postReq({
+      songArtistTitle: 'Artist - Title',
+      feedbackType: 'thumbs_down',
+      source: 'ai_dj',
+      songId: 'song-1',
+    }));
+
+    expect(likedSongsSync.setSongLiked).not.toHaveBeenCalled();
+  });
+
+  it('DOES star an explicit library like (the heart, source=library)', async () => {
+    await POST(postReq({
+      songArtistTitle: 'Artist - Title',
+      feedbackType: 'thumbs_up',
+      source: 'library',
+      songId: 'song-1',
+    }));
+
+    expect(likedSongsSync.setSongLiked).toHaveBeenCalledWith(
+      'user-1',
+      'song-1',
+      true,
+      expect.objectContaining({ username: 'u' }),
+      expect.objectContaining({ artist: 'Artist', title: 'Title' }),
+    );
+  });
+
+  it('DOES unstar an explicit library unlike (source=library, thumbs_down)', async () => {
+    await POST(postReq({
+      songArtistTitle: 'Artist - Title',
+      feedbackType: 'thumbs_down',
+      source: 'library',
+      songId: 'song-1',
+    }));
+
+    expect(likedSongsSync.setSongLiked).toHaveBeenCalledWith(
+      'user-1',
+      'song-1',
+      false,
+      expect.anything(),
+      expect.anything(),
+    );
+  });
+});

--- a/src/routes/api/recommendations/feedback.ts
+++ b/src/routes/api/recommendations/feedback.ts
@@ -69,26 +69,24 @@ export const GET = withAuthAndErrorHandling(
       }
     }
 
-    // Check liked_songs_sync for songs that are starred in Navidrome but don't
-    // have a feedback record yet (e.g. starred before AIDJ, or sync hasn't run)
-    const missingIds = songIds.filter(id => !(id in feedbackMap));
-    if (missingIds.length > 0) {
-      const likedRecords = await db
-        .select({ songId: likedSongsSync.songId })
-        .from(likedSongsSync)
-        .where(
-          and(
-            eq(likedSongsSync.userId, session.user.id),
-            eq(likedSongsSync.isActive, 1),
-            inArray(likedSongsSync.songId, missingIds)
-          )
-        );
-      for (const record of likedRecords) {
-        feedbackMap[record.songId] = 'thumbs_up';
-      }
-    }
+    // Library "liked" state (Navidrome stars, mirrored into liked_songs_sync) is
+    // a SEPARATE signal from thumbs feedback: the heart reads `liked`, the thumbs
+    // UI reads `feedback`. We deliberately do NOT fold stars into the thumbs map —
+    // being starred no longer implies you thumbs-up'd a recommendation, and a
+    // thumbs-down no longer clears the heart (Plan PR C: decouple thumbs/stars).
+    const likedRecords = await db
+      .select({ songId: likedSongsSync.songId })
+      .from(likedSongsSync)
+      .where(
+        and(
+          eq(likedSongsSync.userId, session.user.id),
+          eq(likedSongsSync.isActive, 1),
+          inArray(likedSongsSync.songId, songIds)
+        )
+      );
+    const liked = likedRecords.map(r => r.songId);
 
-    return jsonResponse({ feedback: feedbackMap });
+    return jsonResponse({ feedback: feedbackMap, liked });
   },
   {
     service: 'feedback',
@@ -177,8 +175,16 @@ export const POST = withAuthAndErrorHandling(
     clearPreferenceCache(session.user.id);
     clearAnalyticsCache(session.user.id);
 
-    // Sync to Navidrome (star/unstar) if enabled and songId provided
-    if (validatedData.songId) {
+    // Mirror to the library "like" (Navidrome star) ONLY for explicit library
+    // like actions — i.e. the heart button (source='library'), where thumbs_up
+    // means "add to Liked Songs" and thumbs_down means "unlike/remove".
+    //
+    // Recommendation / AI-DJ / autoplay / search thumbs are a pure
+    // recommendation-quality signal: they update recommendationFeedback (above)
+    // but must NOT star/unstar or touch the ❤️ Liked Songs playlist. Coupling
+    // them was silently repopulating Liked Songs and inflating thumbs_up vs the
+    // real star count (Plan PR C: decouple thumbs from stars).
+    if (validatedData.songId && validatedData.source === 'library') {
       try {
         // Check user preferences for Navidrome sync setting
         const prefs = await db
@@ -194,14 +200,9 @@ export const POST = withAuthAndErrorHandling(
         if (syncEnabled) {
           const creds = await ensureNavidromeUser(session.user.id, session.user.name, session.user.email);
 
-          // Mirror the feedback to the library "like" (star) through the single
-          // write-through, which keeps Navidrome + feedback + liked_songs_sync +
+          // Single write-through keeps Navidrome + feedback + liked_songs_sync +
           // the ❤️ Liked Songs playlist in lockstep (surgical single-row update,
           // no full rebuild).
-          //
-          // NOTE: thumbs feedback is still COUPLED to stars here — a thumbs_up
-          // stars/likes the song, thumbs_down unstars it. Plan PR C decouples
-          // these two signals; this PR only centralises the write.
           const parts = validatedData.songArtistTitle.split(' - ');
           const artist = parts[0] || 'Unknown';
           const title = parts.slice(1).join(' - ') || validatedData.songArtistTitle;


### PR DESCRIPTION
## What & why

Thumbs feedback and library "likes" (Navidrome stars) were a single conflated signal: **any `thumbs_up` starred the song and added it to ❤️ Liked Songs, any `thumbs_down` unstarred it.** That silently repopulated Liked Songs and inflated `thumbs_up` far above the real star count (part of the "songs come back" family of bugs). This is **PR C** of `docs/design/liked-songs-refactor-plan.md`.

## The two signals, now separated

- **Thumbs** (`recommendationFeedback`) = recommendation-quality signal.
- **Likes/stars** (`liked_songs_sync` ⇄ Navidrome stars) = the heart / ❤️ Liked Songs. Source of truth.

## Changes

- **`POST /api/recommendations/feedback`**: only mirrors to a star (`setSongLiked`) when `source === 'library'` — the explicit heart action. `recommendation` / `ai_dj` / `autoplay` / `search` thumbs now write **only** the feedback row; they never touch stars or Liked Songs.
- **`GET`**: returns a separate `liked: string[]` (real stars) instead of folding stars into the thumbs map. Being starred no longer implies a `thumbs_up`; a `thumbs_down` no longer clears the heart.
- **Heart UI** (`HeartButton`, `PlayerBar`) reads / optimistically updates `liked`; the **thumbs UI** keeps reading `feedback`. Both duplicate `useSongFeedback` hooks (`@/hooks` and `@/lib/hooks` — see the known duplicate-hooks issue) updated to expose `liked`.

## Tests

- New `feedback-decouple.test.ts` (4 tests): rec/ai_dj thumbs never call `setSongLiked`; `source=library` like/unlike still star/unstar.
- Existing `liked-songs-set` (6) and `SongFeedbackButtons` (18) suites still green.

## Verify live

- Thumbs-up a recommendation → song is **not** added to ❤️ Liked Songs, heart stays empty.
- Heart a song (PlayerBar / HeartButton) → still stars + appears in Liked Songs.
- `thumbs_up` count should stop drifting above the real star count over time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)