### PR TITLE
fix: Reconcile Liked Songs from stars on open (plan PR D)

### DIFF
--- a/src/routes/api/playlists/$id.ts
+++ b/src/routes/api/playlists/$id.ts
@@ -117,6 +117,10 @@ export const Route = createFileRoute("/api/playlists/$id")({
       return new Response(JSON.stringify({
         data: {
           ...playlist,
+          // Lets the client reliably detect the canonical Liked Songs playlist
+          // (its id is a UUID, so a literal id check can't) and trigger the
+          // reconcile-on-open backstop.
+          isLikedSongs: isLikedSongsPlaylist,
           songs: enrichedSongs,
         }
       }), {

--- a/src/routes/playlists/$id.tsx
+++ b/src/routes/playlists/$id.tsx
@@ -85,6 +85,8 @@ interface PlaylistDetail {
   songs: PlaylistSong[];
   createdAt: Date;
   updatedAt: Date;
+  // True when this is the canonical ❤️ Liked Songs playlist (server-computed).
+  isLikedSongs?: boolean;
 }
 
 interface SongRowProps {
@@ -665,6 +667,29 @@ function PlaylistDetailPage() {
       return json.data as PlaylistDetail;
     },
   });
+
+  // Reconcile-on-open backstop for Liked Songs: when the canonical Liked Songs
+  // playlist is opened, rebuild it once from Navidrome stars so the view
+  // self-heals from out-of-band changes (e.g. unstarring directly in the
+  // Navidrome client), which the app's own write-through can't observe.
+  // Fires once per playlist id; silent + non-blocking (the cached list renders
+  // immediately, then refreshes when the rebuild lands).
+  const reconciledIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!playlist?.isLikedSongs) return;
+    if (reconciledIdRef.current === id) return;
+    reconciledIdRef.current = id;
+    void (async () => {
+      try {
+        const res = await fetch('/api/playlists/liked-songs/sync', { method: 'POST' });
+        if (!res.ok) return;
+        queryClient.invalidateQueries({ queryKey: ['playlist', id] });
+        queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
+      } catch {
+        // Non-blocking: the cached view stays usable if the reconcile fails.
+      }
+    })();
+  }, [playlist?.isLikedSongs, id, queryClient]);
 
   const removeSongMutation = useMutation({
     mutationFn: async (songId: string) => {


### PR DESCRIPTION
## Summary
Final PR of the liked-songs refactor plan (PRs A–D). Opening the ❤️ Liked Songs playlist now **reconciles it from Navidrome stars in the background**, so the view self-heals from **out-of-band** changes the app can't observe — chiefly unstarring a track directly in the Navidrome client.

This closes the last drift path: the app's own star/unstar is already a clean write-through (PR A `setSongLiked`), thumbs no longer touch stars (PR C), and the playlist is deterministic (PR B marker column). But a client-side unstar in Navidrome left the playlist stale until a manual Sync. Now opening the list catches it.

## Changes
- **Server** (`GET /api/playlists/$id`): returns `isLikedSongs` (from the existing `isCanonicalLikedPlaylist`). The page's old `id === 'liked-songs'` check was effectively dead — the real playlist id is a UUID.
- **Client** (`/playlists/$id`): fires `POST /api/playlists/liked-songs/sync` **once per playlist id** when `isLikedSongs` is true, then invalidates the playlist + feedback caches. Silent, non-blocking — the cached list renders immediately and refreshes when the rebuild lands. A ref guards against a refetch loop.

## Testing
- `liked-songs-set` (6), `feedback-decouple` (4), `playlists` (9) — all pass.
- Typecheck: no new errors (the `JSX.Element` error at `$id.tsx:267` and the `set-state-in-effect` lint warning at `:225` are pre-existing, in unrelated `SongRowContent`/`MarqueeText` code).

## Smoke test after deploy
1. Star a song, confirm it's in ❤️ Liked Songs.
2. Unstar it **in the Navidrome web client** (out of band).
3. Open ❤️ Liked Songs in AIDJ → it should disappear on its own (was previously stale until manual Sync).

## Out of scope / follow-ups
- The page still gates heart styling + hides the Collaborate button on `id === 'liked-songs'` (dead); could switch those to the new `isLikedSongs` flag in a cosmetic pass.
- Separate thread: `library-reconciliation` never initializes on prod (zero logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dm39VGE1neEGBUyfyaj9S6