### PR TITLE
fix: Refresh feedback cache on focus + WS reconnect (#139)

### DIFF
--- a/src/lib/hooks/usePlaybackSync.ts
+++ b/src/lib/hooks/usePlaybackSync.ts
@@ -214,6 +214,18 @@ function broadcastStateViaWS(ws: WebSocket | null): void {
 }
 
 /**
+ * Ask any mounted feedback consumers (PlayerBar, hearts) to re-pull like/star
+ * state. Reuses the cross-device `playback-feedback-update` event, whose handler
+ * invalidates `queryKeys.feedback.all()`. Used on tab focus and WS reconnect to
+ * catch out-of-band changes — e.g. a song unstarred directly in the Navidrome
+ * client while we were away, which emits no WS message of its own. See #139.
+ */
+function refreshFeedbackCache(): void {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent('playback-feedback-update'));
+}
+
+/**
  * Handle incoming WS messages from other devices
  */
 function handleIncomingMessage(
@@ -449,6 +461,9 @@ export function usePlaybackSync(): void {
       } else {
         // Coming back — check for updates from other devices
         fetchAndReconcileState();
+        // Also re-pull like/star state: it may have changed out-of-band (e.g.
+        // unstarred in the Navidrome client) while the tab was hidden. See #139.
+        refreshFeedbackCache();
       }
     };
 
@@ -472,6 +487,9 @@ export function usePlaybackSync(): void {
         }));
         // Also fetch from DB in case no other device is online to respond
         fetchAndReconcileState();
+        // A (re)connect can span an out-of-band star change we missed while
+        // disconnected — re-pull feedback so hearts reflect truth. See #139.
+        refreshFeedbackCache();
       },
       onMessage: (event: MessageEvent) => {
         try {


### PR DESCRIPTION
Closes #139.

## Problem
Unstar a song **directly in the Navidrome client**, then return to an already-open AIDJ tab — the heart stays filled until a hard reload. Traced on prod: the backend is correct (`is_active=0`, unstarred on Navidrome, absent from the playlist); only the tab's in-memory React Query `feedback` cache is stale. Out-of-band changes emit no WebSocket message, so nothing tells the tab to refetch.

## Fix
Re-pull like/star state at the two moments a tab rejoins reality:
- **`visibilitychange` → visible** (returning to a hidden tab)
- **WebSocket `onOpen`** (initial connect + every reconnect)

Both call a small `refreshFeedbackCache()` helper that dispatches the existing `playback-feedback-update` event — whose handler already invalidates `queryKeys.feedback.all()`. So every mounted heart (PlayerBar, HeartButton, library/search — they share that query cache) refetches truth. No `queryClient` threading needed into the sync hook.

## Testing
- Typecheck: 0 errors in the changed file. Lint: 0 errors (the one warning at the device-registration `fetch` is pre-existing/unrelated).
- Manual smoke (after deploy): star a song, unstar it in the Navidrome client, switch back to the AIDJ tab → heart clears without reload.

## Scope
This is the cheap, robust half. The complementary push-based half — broadcasting star/unstar over the WS from a single write-path choke point so **all** in-app like sources propagate live — is #138, next.