### PR TITLE
feat: Broadcast star/unstar over WebSocket from all like surfaces (#138)

### DIFF
--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -446,10 +446,11 @@ export function PlayerBar() {
     onSuccess: (liked) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
       toast.success(liked ? '❤️ Liked' : '💔 Unliked', { duration: 1500 });
-      // Notify other devices so their like state updates
+      // Notify other devices so their like state updates. Star/like is now
+      // decoupled from thumbs (#136), so send an explicit `liked` boolean. See #138.
       sendPlaybackMessage('feedback_update', {
         songId: currentSong?.id,
-        feedbackType: liked ? 'thumbs_up' : 'thumbs_down',
+        liked,
       });
     },
     onError: (error: Error, _liked, context) => {

--- a/src/components/library/HeartButton.tsx
+++ b/src/components/library/HeartButton.tsx
@@ -10,6 +10,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Heart, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSongFeedback } from '@/hooks/useSongFeedback';
+import { sendPlaybackMessage } from '@/lib/hooks/usePlaybackSync';
 import { queryKeys } from '@/lib/query';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
@@ -59,6 +60,9 @@ export function HeartButton({ songId, artist, title, className, size = 'sm' }: H
     },
     onSuccess: (_data, newLiked) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
+      // Propagate the star change to the user's other devices so their hearts
+      // update live (not just on Sync/refocus). See #138.
+      sendPlaybackMessage('feedback_update', { songId, liked: newLiked });
       if (artist && title) {
         toast.success(`${newLiked ? 'Liked' : 'Unliked'} "${title}"`, {
           description: artist,

--- a/src/routes/playlists/$id.tsx
+++ b/src/routes/playlists/$id.tsx
@@ -33,6 +33,7 @@ import {
 import { Radio } from 'lucide-react';
 import { PageLayout } from '@/components/ui/page-layout';
 import { useAudioStore } from '@/lib/stores/audio';
+import { sendPlaybackMessage } from '@/lib/hooks/usePlaybackSync';
 import { cn } from '@/lib/utils';
 import { CollaborativePlaylistPanel } from '@/components/playlists/collaboration';
 import { StartRadioButton } from '@/components/radio/StartRadioButton';
@@ -906,9 +907,11 @@ function PlaylistDetailPage() {
       });
       return { previousPlaylist };
     },
-    onSuccess: (_data, { star }) => {
+    onSuccess: (_data, { songId, star }) => {
       // Invalidate feedback cache so PlayerBar heart icon updates
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
+      // Propagate the star change to the user's other devices. See #138.
+      sendPlaybackMessage('feedback_update', { songId, liked: star });
       // When unstarring, the server removes the song from the liked songs playlist.
       // Refetch so the song disappears from the list without a full page refresh.
       if (!star) {


### PR DESCRIPTION
Closes #138.

## Problem
Only the **PlayerBar** heart emitted a `feedback_update` WebSocket message. Liking/unliking from the **library** (`HeartButton`) or the **playlist star toggle** didn't push to the user's other devices — those tabs stayed stale until a manual Sync or a refocus (#139).

## Fix
Emit `feedback_update` from every star write surface via the existing `sendPlaybackMessage` singleton (already used by DevicePicker/PlayerBar):
- `HeartButton` `onSuccess`
- playlist-page star toggle `onSuccess`
- `PlayerBar` (existing emit site; payload updated)

Payload now carries an explicit **`{ songId, liked: boolean }`** instead of `feedbackType: 'thumbs_up'|'thumbs_down'`, since stars are decoupled from thumbs (#136). The receiver already invalidates `queryKeys.feedback.all()` on any `feedback_update`, so every mounted heart (PlayerBar, HeartButton, library/search) refetches on the other devices.

## Together with #139
- **#139** (merged): a tab re-pulls feedback on focus / WS reconnect — covers **out-of-band** changes (Navidrome client) and missed pushes.
- **#138** (this): in-app likes push **live** to other connected devices — no wait for focus.

## Scope note
Kept client-emit + server-relay, matching the existing architecture. A fully server-authoritative broadcast (from the star write-through, so it also fires for API-only callers) would need a WS-bridge from API routes into the vite-ws plugin's connection registry — larger and deferred.

## Testing
- `feedback-decouple` (4) + `liked-songs-set` (6) pass.
- Typecheck: 0 new errors. Lint: 0 errors (pre-existing warnings only).
- Manual (after deploy): open AIDJ on two devices; like a song in the library on device A → heart fills on device B within ~1s.