### PR TITLE
feat: Server-side feedback broadcast bridge (PR a of 2)

### DIFF
--- a/docs/design/feedback-broadcast-server-bridge.md
+++ b/docs/design/feedback-broadcast-server-bridge.md
@@ -1,0 +1,135 @@
+# Server-authoritative feedback broadcast — design ideation
+
+Status: **ideation** (2026-08-14). Follows #138 (client-emit star/unstar over WS) and
+#139 (refetch feedback on focus/reconnect).
+
+## Goal
+
+When a user's like/star state changes, push it to **all their connected devices**
+live — even when the change does **not** originate from a browser that's currently
+holding a WebSocket:
+
+- API-only callers (scripts, integrations, `scripts/*`).
+- Server-side background changes: reconcile-on-open (PR D), `/api/playlists/liked-songs/sync`,
+  `syncLikedSongsToFeedback`, onboarding artist-select seeding.
+- Removes the current reliance on the *initiating browser* to emit (#138), which fails
+  if that tab is closed or offline.
+
+Non-goal: changes made **directly in the Navidrome client** never touch the app server,
+so nothing here can push them. #139 (refetch on focus/reconnect) stays the backstop for
+those. This bridge only covers **app-server-mediated** changes.
+
+## The core obstacle: module-instance boundary in prod
+
+The WS connection registry is a module-level `Map<userId, Set<WebSocket>>` in
+`src/lib/services/playback-websocket.ts`. Who instantiates it differs by environment:
+
+| Env | WS server created by | API/SSR handlers run in | Share the registry? |
+|-----|----------------------|-------------------------|---------------------|
+| dev (`vite dev`) | `vite-ws-plugin.ts` (Vite SSR module graph) | same Vite SSR graph | **Yes** — Vite dedupes to one module instance |
+| prod (`tsx server.ts`) | `server.ts`, importing **source** via tsx | the **bundled** `dist/server/server.js` | **No** — two separate module copies, one process |
+
+So in prod the live sockets live in the *source-loaded* module (server.ts), while an API
+route importing `playback-websocket` would get the *bundled* copy with an **empty** Map.
+A naive `export broadcastToAllDevices()` called from `star.ts` **silently no-ops in prod**
+and *works in dev* — the worst kind of bug. Any bridge must cross this boundary.
+
+Note: the WS runs only under the node-server path (`server.ts`) and the dev plugin. The
+`build:cloudflare` output has no WS server at all (Workers need Durable Objects), so this
+is a Coolify/node-server-only feature — not a regression to worry about.
+
+## Options
+
+### Option 1 — `globalThis` broadcast bridge (recommended first step)
+
+`setupPlaybackWebSocket` installs a broadcast fn on `globalThis` once, at boot:
+
+```ts
+// in playback-websocket.ts, inside setupPlaybackWebSocket
+globalThis.__aidjBroadcastToUser = broadcastToAllDevices; // (userId, message, log)
+```
+
+API routes / services call it defensively:
+
+```ts
+globalThis.__aidjBroadcastToUser?.(userId, { type: 'feedback_update', payload: { songId, liked } }, 'feedback_update');
+```
+
+- **Why it works in prod:** `globalThis` is shared across every module instance in the one
+  Node process. The registry stays private to the WS module; only the fn is shared.
+- **Pros:** ~30 lines, no infra, no-ops safely when WS isn't up (dev SSR, cloudflare, tests).
+- **Cons:** single-process only — breaks if aidj ever runs >1 replica. "Global" smell.
+
+### Option 2 — Postgres `LISTEN`/`NOTIFY` (future-proof)
+
+The WS server `LISTEN feedback_events` on boot (it already holds a pg `sql` client for
+`clearActiveDeviceIfMatches`). API routes `pg_notify('feedback_events', json)`; the WS
+process delivers to the matching user's sockets.
+
+- **Pros:** survives multi-replica (every replica LISTENs; whichever holds the user's socket
+  delivers); clean process separation; no globals.
+- **Cons:** more moving parts; a dedicated listen connection; 8KB payload cap (fine here).
+
+### Option 3 — internal loopback HTTP — rejected (overkill in one process).
+
+## Recommendation
+
+Ship **Option 1** now, but put the call behind one helper —
+`broadcastFeedbackChange(userId, { songId, liked })` — so the transport can be swapped to
+Option 2 later without touching call sites. Wire the helper into the **single choke point
+`setSongLiked()`** (PR A), so every server-side star write pushes automatically.
+
+## Decisions (locked 2026-08-14)
+
+1. **Transport:** `globalThis` bridge now, behind a `broadcastFeedbackChange()` helper so the
+   transport can later swap to Postgres `NOTIFY` without touching call sites.
+2. **Server-authoritative:** remove the client-side `sendPlaybackMessage('feedback_update', …)`
+   emits (the ones #138 added *and* PlayerBar's original). The browser keeps its optimistic
+   update and trusts the server push; #139 focus/reconnect refetch is the backstop. One source
+   of truth, less UI plumbing.
+3. **Granularity:** single-song `setSongLiked` emits `{ type:'feedback_update', songId, liked }`;
+   bulk paths emit **one coalesced** `{ type:'feedback_refresh' }` when finished. Clients keep
+   invalidating `feedback.all()` on either message.
+
+## Implementation plan
+
+**New module `src/lib/services/feedback-broadcast.ts`** (the swap-point; imports nothing from
+`playback-websocket`, only touches `globalThis`, so it never bundles a second registry copy):
+
+```ts
+declare global {
+  // installed by setupPlaybackWebSocket in the process that owns the sockets
+  var __aidjBroadcastToUser: ((userId: string, message: Record<string, unknown>, log: string) => void) | undefined;
+}
+export function broadcastFeedbackChange(userId: string, songId: string, liked: boolean) {
+  globalThis.__aidjBroadcastToUser?.(userId, { type: 'feedback_update', payload: { songId, liked } }, 'feedback_update');
+}
+export function broadcastFeedbackRefresh(userId: string) {
+  globalThis.__aidjBroadcastToUser?.(userId, { type: 'feedback_refresh' }, 'feedback_refresh');
+}
+```
+
+1. **Install the bridge** — `playback-websocket.ts` `setupPlaybackWebSocket()` sets
+   `globalThis.__aidjBroadcastToUser = broadcastToAllDevices`. Both `server.ts` (prod) and the
+   dev plugin call this, so the socket-owning process installs it; API routes in the same
+   process read it. No-ops safely where WS isn't up.
+2. **Emit from the choke point** — `setSongLiked()` (`liked-songs-sync.ts`) calls
+   `broadcastFeedbackChange(userId, songId, liked)` after its writes succeed. Bulk owners
+   (`rebuildLikedSongsPlaylist`, `syncLikedSongsToFeedback`) call `broadcastFeedbackRefresh(userId)`
+   once at the end. (Confirm bulk paths don't loop through `setSongLiked` — they operate on the
+   DB directly, so no per-song storm.)
+3. **Client receiver** — `usePlaybackSync.handleIncomingMessage` handles `feedback_refresh` the
+   same as `feedback_update` (dispatch `playback-feedback-update`). The server now *originates*
+   these via `broadcastToAllDevices` (all devices, initiator included — refetch is idempotent).
+4. **Remove client emits** — drop `sendPlaybackMessage('feedback_update', …)` from `HeartButton`,
+   the playlist star toggle, and `PlayerBar` (keep optimistic updates). The inbound
+   `feedback_update` relay case in `broadcastToUser` becomes dead but harmless.
+5. **Tests** — `setSongLiked` calls `broadcastFeedbackChange` (mock the global fn); receiver
+   dispatches on `feedback_refresh`.
+
+Deploys only under node-server (`server.ts`) — no WS under `build:cloudflare`, unchanged.
+
+## Scope note
+
+This does not obsolete #139 — direct-in-Navidrome changes still need the focus/reconnect
+refetch. It complements it by covering everything that flows through the app server.

--- a/src/lib/hooks/usePlaybackSync.ts
+++ b/src/lib/hooks/usePlaybackSync.ts
@@ -413,9 +413,12 @@ function handleIncomingMessage(
       break;
     }
 
-    case 'feedback_update': {
-      // Another device liked/unliked a song — dispatch a custom event
-      // so React Query caches can be invalidated
+    case 'feedback_update':
+    case 'feedback_refresh': {
+      // A like/star changed elsewhere — either a single-song update from another
+      // device or the server (feedback_update), or a coalesced bulk refresh after
+      // a reconcile/sync (feedback_refresh). Dispatch a custom event so mounted
+      // hearts invalidate their React Query feedback cache and refetch truth.
       if (typeof window !== 'undefined') {
         window.dispatchEvent(new CustomEvent('playback-feedback-update', {
           detail: msg.payload,

--- a/src/lib/services/__tests__/liked-songs-set.test.ts
+++ b/src/lib/services/__tests__/liked-songs-set.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import * as navidrome from '../navidrome';
 
 // Configurable resolve value for any awaited/`.then`ed db chain.
@@ -37,9 +37,16 @@ import { setSongLiked, isCanonicalLikedPlaylist } from '../liked-songs-sync';
 const CREDS = { username: 'u', token: 't', salt: 's' } as unknown as Parameters<typeof setSongLiked>[3];
 
 describe('setSongLiked write-through', () => {
+  const broadcast = vi.fn();
   beforeEach(() => {
     vi.clearAllMocks();
     resolveValue = [];
+    // Simulate the WS server having installed the broadcast bridge on globalThis.
+    globalThis.__aidjBroadcastToUser = broadcast;
+    broadcast.mockClear();
+  });
+  afterEach(() => {
+    globalThis.__aidjBroadcastToUser = undefined;
   });
 
   it('liking a song stars it in Navidrome (source of truth)', async () => {
@@ -57,6 +64,28 @@ describe('setSongLiked write-through', () => {
 
     expect(navidrome.unstarSong).toHaveBeenCalledWith('song-1', CREDS);
     expect(navidrome.starSong).not.toHaveBeenCalled();
+  });
+
+  it('broadcasts a single-song feedback_update to the user after a like', async () => {
+    resolveValue = [{ id: 'pl1', name: '❤️ Liked Songs', navidromeId: null }];
+    await setSongLiked('user-1', 'song-1', true, CREDS, { artist: 'A', title: 'T' });
+
+    expect(broadcast).toHaveBeenCalledWith(
+      'user-1',
+      { type: 'feedback_update', payload: { songId: 'song-1', liked: true } },
+      'feedback_update',
+    );
+  });
+
+  it('broadcasts liked:false after an unlike', async () => {
+    resolveValue = [];
+    await setSongLiked('user-1', 'song-1', false, CREDS);
+
+    expect(broadcast).toHaveBeenCalledWith(
+      'user-1',
+      { type: 'feedback_update', payload: { songId: 'song-1', liked: false } },
+      'feedback_update',
+    );
   });
 });
 

--- a/src/lib/services/feedback-broadcast.ts
+++ b/src/lib/services/feedback-broadcast.ts
@@ -1,0 +1,46 @@
+/**
+ * Server-authoritative feedback broadcast bridge.
+ *
+ * When like/star state changes on the server (via setSongLiked or a bulk
+ * reconcile), we want to push it to all of the user's connected devices so
+ * their hearts update live — even when the change didn't originate from a
+ * browser holding a WebSocket (API callers, background sync, reconcile-on-open).
+ *
+ * Why a globalThis indirection instead of importing playback-websocket directly:
+ * in production the WS server (server.ts, loaded from source via tsx) and the
+ * API/SSR handlers (the bundled dist/server/server.js) hold SEPARATE module
+ * instances of playback-websocket — so a direct import would read an empty
+ * connection registry and silently no-op. Both run in the same Node process,
+ * though, so a function parked on `globalThis` (installed by setupPlaybackWebSocket
+ * in whichever process owns the sockets) IS shared. It safely no-ops wherever the
+ * WS server isn't running (dev SSR, cloudflare build, unit tests).
+ *
+ * This module is the single swap-point: to move to Postgres LISTEN/NOTIFY later,
+ * change only the bodies below; call sites stay untouched.
+ *
+ * See docs/design/feedback-broadcast-server-bridge.md.
+ */
+
+declare global {
+  // `var` is required here — a global augmentation on globalThis can't use let/const.
+  var __aidjBroadcastToUser:
+    | ((userId: string, message: Record<string, unknown>, logType: string) => void)
+    | undefined;
+}
+
+/** Push a single-song like/unlike change to all of the user's devices. */
+export function broadcastFeedbackChange(userId: string, songId: string, liked: boolean): void {
+  globalThis.__aidjBroadcastToUser?.(
+    userId,
+    { type: 'feedback_update', payload: { songId, liked } },
+    'feedback_update',
+  );
+}
+
+/**
+ * Coalesced refresh signal for bulk changes (reconcile / sync) — one message
+ * instead of one-per-song. Clients invalidate their whole feedback cache.
+ */
+export function broadcastFeedbackRefresh(userId: string): void {
+  globalThis.__aidjBroadcastToUser?.(userId, { type: 'feedback_refresh' }, 'feedback_refresh');
+}

--- a/src/lib/services/liked-songs-sync.ts
+++ b/src/lib/services/liked-songs-sync.ts
@@ -25,6 +25,7 @@ import { getStarredSongs, starSong, unstarSong, getSongsByIds } from './navidrom
 import type { SubsonicSong } from './navidrome';
 import { getNavidromeUserCreds } from './navidrome-users';
 import type { SubsonicCreds } from './navidrome-users';
+import { broadcastFeedbackChange, broadcastFeedbackRefresh } from './feedback-broadcast';
 
 // ============================================================================
 // Types
@@ -227,6 +228,11 @@ export async function syncLikedSongsToFeedback(userId: string): Promise<SyncResu
     }
 
     console.log(`💜 [LikedSongsSync] Sync complete: ${result.synced} synced, ${result.unstarred} un-starred, ${result.unchanged} unchanged, ${result.errors} errors`);
+
+    // One coalesced refresh (not per-song) when the ledger actually changed.
+    if (result.synced > 0 || result.unstarred > 0) {
+      broadcastFeedbackRefresh(userId);
+    }
 
     return result;
   } catch (error) {
@@ -558,6 +564,10 @@ export async function setSongLiked(
         .where(eq(userPlaylists.id, likedPlaylist.id));
     }
   }
+
+  // 5. Push the change to the user's other connected devices so their hearts
+  // update live (server-authoritative; no-ops if no WS server in this process).
+  broadcastFeedbackChange(userId, songId, liked);
 }
 
 export async function rebuildLikedSongsPlaylist(
@@ -615,5 +625,7 @@ export async function rebuildLikedSongsPlaylist(
   }
 
   console.log(`✅ Rebuilt Liked Songs playlist: ${starredSongs.length} songs`);
+  // Coalesced refresh so any device viewing hearts re-pulls from the rebuilt set.
+  broadcastFeedbackRefresh(userId);
   return { playlistId: likedPlaylist.id, songCount: starredSongs.length };
 }

--- a/src/lib/services/playback-websocket.ts
+++ b/src/lib/services/playback-websocket.ts
@@ -18,7 +18,7 @@ const wsDeviceIds = new WeakMap<WebSocket, string>();
 
 // Message types
 interface PlaybackMessage {
-  type: 'state_update' | 'transfer' | 'command' | 'sync_request' | 'heartbeat' | 'feedback_update';
+  type: 'state_update' | 'transfer' | 'command' | 'sync_request' | 'heartbeat' | 'feedback_update' | 'feedback_refresh';
   payload?: Record<string, unknown>;
   deviceId: string;
 }
@@ -48,6 +48,12 @@ export function setupPlaybackWebSocket(
   getUserId: GetUserIdFromRequest,
   clearActiveDevice?: ClearActiveDevice,
 ) {
+  // Expose a server-side broadcast entry point for API routes / services that
+  // aren't part of this module's instance (see feedback-broadcast.ts for why
+  // the globalThis indirection is required in production).
+  globalThis.__aidjBroadcastToUser = (userId, message, logType) =>
+    broadcastToAllDevices(userId, message, logType);
+
   // Heartbeat check - terminate dead connections
   const HEARTBEAT_TIMEOUT = 60000; // 60 seconds
   const heartbeatInterval = setInterval(() => {


### PR DESCRIPTION
Part 1 of the server-authoritative feedback broadcast (see #138 follow-up).
Design: `docs/design/feedback-broadcast-server-bridge.md`.

## What
Push like/star changes to **all** of a user's connected devices from the **server**, so hearts update live even when the change didn't come from a browser holding a WebSocket — API callers, background reconcile-on-open (PR D), `liked-songs/sync`, etc.

## The prod trap this avoids
In the node-server build, `server.ts` loads `playback-websocket` from **source** (owns the socket registry), while API handlers run in the **separately-bundled** `dist/server/server.js`. A direct import to broadcast would read a *second, empty* registry and silently no-op in prod (while working in dev, where Vite dedupes). So:
- `setupPlaybackWebSocket()` installs `broadcastToAllDevices` on `globalThis` (shared across module instances in the one process).
- New `feedback-broadcast.ts` reads `globalThis.__aidjBroadcastToUser` — the single swap-point (→ Postgres `NOTIFY` later without touching call sites). No-ops safely where no WS server runs (dev SSR, cloudflare, tests).

## Wiring
- `setSongLiked()` → one `{ type:'feedback_update', payload:{ songId, liked } }`.
- `rebuildLikedSongsPlaylist` / `syncLikedSongsToFeedback` → one coalesced `{ type:'feedback_refresh' }` (verified these don't loop `setSongLiked`, so no per-song storm).
- Client receiver (`usePlaybackSync`) handles `feedback_refresh` like `feedback_update` → invalidate feedback cache + refetch.

## Scope: this is PR (a) of 2
The server push runs **alongside** the existing #138 client emits (belt-and-suspenders) so we can confirm it actually reaches devices on prod first. **PR (b)** removes the client emits to make the server the single source of truth.

## Testing
- `liked-songs-set` now asserts `setSongLiked` broadcasts `{songId, liked}` for like and unlike (8 tests); `feedback-decouple` (4) still green — 12 total pass.
- Typecheck: 0 new errors (count steady at baseline 456; the `playback-websocket:142` cast error pre-exists on main). Lint: 0 errors.

## Smoke test after deploy (node-server / Coolify)
Two devices open. Like a song on device A → heart fills on device B within ~1s **without** A having emitted (to isolate the server path, could temporarily verify via server logs `[WS TX] feedback_update`). Reconcile-on-open of Liked Songs → other device's hearts refresh.