### PR TITLE
refactor: Remove client-side feedback emits — server-authoritative (PR b of 2)

### DIFF
--- a/src/components/layout/PlayerBar.tsx
+++ b/src/components/layout/PlayerBar.tsx
@@ -29,7 +29,7 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
 import { queryKeys } from '@/lib/query';
-import { usePlaybackSync, sendPlaybackMessage, sendRemoteCommand } from '@/lib/hooks/usePlaybackSync';
+import { usePlaybackSync, sendRemoteCommand } from '@/lib/hooks/usePlaybackSync';
 import { ResumePlaybackPrompt } from './ResumePlaybackPrompt';
 import { NowPlayingFullscreen } from './NowPlayingFullscreen';
 
@@ -446,12 +446,8 @@ export function PlayerBar() {
     onSuccess: (liked) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
       toast.success(liked ? '❤️ Liked' : '💔 Unliked', { duration: 1500 });
-      // Notify other devices so their like state updates. Star/like is now
-      // decoupled from thumbs (#136), so send an explicit `liked` boolean. See #138.
-      sendPlaybackMessage('feedback_update', {
-        songId: currentSong?.id,
-        liked,
-      });
+      // Cross-device propagation is server-authoritative now: the like endpoint
+      // (setSongLiked) broadcasts feedback_update to all devices. No client emit.
     },
     onError: (error: Error, _liked, context) => {
       // Revert optimistic update on error

--- a/src/components/library/HeartButton.tsx
+++ b/src/components/library/HeartButton.tsx
@@ -10,7 +10,6 @@ import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { Heart, Loader2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useSongFeedback } from '@/hooks/useSongFeedback';
-import { sendPlaybackMessage } from '@/lib/hooks/usePlaybackSync';
 import { queryKeys } from '@/lib/query';
 import { toast } from '@/lib/toast';
 import { cn } from '@/lib/utils';
@@ -60,9 +59,8 @@ export function HeartButton({ songId, artist, title, className, size = 'sm' }: H
     },
     onSuccess: (_data, newLiked) => {
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
-      // Propagate the star change to the user's other devices so their hearts
-      // update live (not just on Sync/refocus). See #138.
-      sendPlaybackMessage('feedback_update', { songId, liked: newLiked });
+      // Cross-device propagation is now server-authoritative: /api/navidrome/star
+      // → setSongLiked broadcasts feedback_update to all devices. No client emit.
       if (artist && title) {
         toast.success(`${newLiked ? 'Liked' : 'Unliked'} "${title}"`, {
           description: artist,

--- a/src/routes/playlists/$id.tsx
+++ b/src/routes/playlists/$id.tsx
@@ -33,7 +33,6 @@ import {
 import { Radio } from 'lucide-react';
 import { PageLayout } from '@/components/ui/page-layout';
 import { useAudioStore } from '@/lib/stores/audio';
-import { sendPlaybackMessage } from '@/lib/hooks/usePlaybackSync';
 import { cn } from '@/lib/utils';
 import { CollaborativePlaylistPanel } from '@/components/playlists/collaboration';
 import { StartRadioButton } from '@/components/radio/StartRadioButton';
@@ -907,11 +906,11 @@ function PlaylistDetailPage() {
       });
       return { previousPlaylist };
     },
-    onSuccess: (_data, { songId, star }) => {
+    onSuccess: (_data, { star }) => {
       // Invalidate feedback cache so PlayerBar heart icon updates
       queryClient.invalidateQueries({ queryKey: queryKeys.feedback.all() });
-      // Propagate the star change to the user's other devices. See #138.
-      sendPlaybackMessage('feedback_update', { songId, liked: star });
+      // Cross-device propagation is server-authoritative now (setSongLiked
+      // broadcasts feedback_update); no client emit needed.
       // When unstarring, the server removes the song from the liked songs playlist.
       // Refetch so the song disappears from the list without a full page refresh.
       if (!star) {


### PR DESCRIPTION
Part 2 of 2. Follows #142 (PR a), now verified live on prod.

## Verified on prod before this
With #142 deployed, toggling a like logged the **server** broadcast crossing the module boundary:
```
⭐ Unstarred song Yggn… in Navidrome  → [WS TX] type=feedback_update to=ALL 1 device(s)
⭐ Starred   song Yggn… in Navidrome  → [WS TX] type=feedback_update to=ALL 2 device(s)
                                         [WS TX] type=feedback_refresh   to=ALL 1 device(s)
```
The `to=ALL` lines are `setSongLiked → broadcastFeedbackChange` via the `globalThis` bridge — proving the server path reaches the live socket registry. The logs also showed each toggle broadcasting **twice** (server `to=ALL` + the old client relay `(excluding sender)`) — the redundancy this PR removes.

## Change
Remove the `sendPlaybackMessage('feedback_update', …)` calls (and now-unused imports) from:
- `HeartButton`
- the playlist-page star toggle (`routes/playlists/$id.tsx`)
- `PlayerBar`

Optimistic cache updates stay. Cross-device propagation now flows **solely** through the server (setSongLiked → broadcast). The inbound `feedback_update` relay case in the WS handler is **kept** as a rollout safety net — a still-cached old client tab that emits will still be relayed until it reloads.

## Testing
- `liked-songs-set` (8), `feedback-decouple` (4), `SongFeedbackButtons` (18) — 30 pass.
- Typecheck: 0 new errors. Lint: 0 errors.

## Smoke test after deploy
Same two-device like test. Logs should now show a **single** `[WS TX] type=feedback_update to=ALL N device(s)` per toggle (no `[WS RX] type=feedback_update from=…` / `(excluding sender)` pair). Heart still updates live on the other device.