### PR TITLE
Per-song YouTube (MeTube) fallback download (#145)

### DIFF
--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -50,7 +50,35 @@ video ID available" — this fills exactly that gap.
 
 - `downloaded` — finished + verification passed (or verify disabled).
 - `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
-- `failed` — MeTube error or 5-min timeout.
+- `failed` — MeTube error or 5-min timeout, after exhausting retries.
+
+## Retries (added after the first prod test)
+
+YouTube download failures are frequently transient — see the PO-token finding
+below — so each track is retried up to `maxAttempts` (default 3, ceiling 5,
+overridable per request). Between attempts the failed MeTube entry is deleted so
+the same `ytsearch1:`-resolved id can be re-queued cleanly. The per-track
+`attempts` count is surfaced in the GET status.
+
+## Prod finding: MeTube PO-token / 403 (2026-08-18 first live test)
+
+First live test track (`ytsearch1:Sun Room Insincere`) confirmed the search
+resolves to the correct video ("Sun Room - Insincere [Official Audio]"), but the
+download itself errored:
+
+```
+[youtube] [pot:bgutil:http] Error reaching GET http://127.0.0.1:4416/ping …
+ERROR: unable to download video data: HTTP Error 403: Forbidden
+```
+
+yt-dlp wants a PO token from a bgutil provider at `127.0.0.1:4416` that is
+unreachable, so token-gated videos 403. **This is a MeTube/yt-dlp ops issue,
+independent of this feature**, but it caps the fallback's real-world success rate
+until the POT provider is running/reachable (or yt-dlp is pointed at a client
+that doesn't require the token). Retries help ride out the transient cases.
+
+Also fixed from that test: dropped `custom_name_prefix`, which had doubled the
+title (`"Sun Room - Insincere.Sun Room - Insincere [Official Audio]"`).
 
 ## How to test (Juan)
 

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -112,11 +112,18 @@ non-URL `url` (it does not go through `/api/metube/add`, which whitelists real
 site URLs; this path calls the MeTube service directly). If MeTube rejects it,
 fall back to resolving a video id via `youtube-music.ts` search first.
 
+## UI (added)
+
+The import wizard's **Confirmation step** "Download Missing Songs" dialog now has a
+**Lidarr / YouTube** toggle. Picking **YouTube** POSTs the selected `no_match`
+tracks (plus the `importJobId`) to `/api/downloads/youtube-fallback` instead of the
+Lidarr queue — so "after review, send the misses to MeTube" is a one-click action.
+`src/components/playlists/import/steps/confirmation-step.tsx`.
+
 ## Not built (follow-ups)
 
-- **UI.** No button yet — API only. The existing `/downloads/youtube` page is a
-  manual URL paste; a "download import misses" action could live there or in the
-  import review UI.
+- **Live per-track status in the UI.** The button starts the job and toasts; it
+  doesn't yet poll `GET ?jobId=` to show downloaded/mismatch/failed per track.
 - **Persistence.** Job state is in-memory (lost on redeploy). Fine for a testing
   tool; if this becomes a durable auto-fallback, fold it into the Import Manager (#132).
 - **Auto-trigger.** Currently manual. Wiring "Lidarr 0-albums → auto YouTube

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -1,0 +1,95 @@
+# Per-song YouTube (MeTube) fallback — issue #145
+
+**Date:** 2026-08-18
+**Status:** ✅ Built (backend + API + tests), pending deploy. No UI yet.
+
+## What this solves
+
+Playlist-import "misses" are sent to Lidarr, but a large fraction dead-end at
+"artist has 0 albums" (issue #144) and silently never download. This adds a
+second path: fetch each missed track **straight from YouTube via MeTube, one at a
+time**, using yt-dlp's `ytsearch1:` search syntax — **no YouTube API key / OAuth
+required**. Each result is verified against the requested artist/title so obvious
+wrong-video / live / mix / channel-rip results are flagged instead of silently
+polluting the library.
+
+The landed file is named `Artist - Title` and drops into MeTube's download
+folder, where the existing **Picard retag → Lidarr move → Navidrome rescan** flow
+picks it up. This module stops at "downloaded + verified"; reconciling the track
+back into the originating playlist is owned by the Import Manager (#132).
+
+## Why `ytsearch1:` and not the YouTube API
+
+`youtube-music.ts` exists but needs a Google API key + OAuth + quota. MeTube
+passes its `url` field straight to yt-dlp, and `ytsearch1:<query>` tells yt-dlp
+"download the top YouTube result for this query." Zero extra config. The prior
+`queueMetubeDownload` (playlist-download.ts) explicitly bailed with "No YouTube
+video ID available" — this fills exactly that gap.
+
+## Pieces
+
+- **`src/lib/services/youtube-fallback.ts`**
+  - `normalizeSearchQuery(track)` — primary artist + de-noised title.
+  - `buildYouTubeSearchUrl(query)` → `ytsearch1:…`.
+  - `verifyDownload(track, item)` — fuzzy title/artist check → `{ matched, score, reason }`.
+  - `queueAndAwaitDownload` — snapshots MeTube ids, queues one download, polls until
+    a *new* item reaches finished/error (one-at-a-time makes the new-id detection
+    unambiguous). 3s poll, 5-min per-track timeout.
+  - `startYouTubeFallbackJob` / `getYouTubeFallbackJob` — in-process job registry
+    (diagnostic/testing path polled while the page is open; no new DB table, mirrors
+    media-flow-manager). Cap `MAX_TRACKS_PER_JOB = 50`.
+- **`src/routes/api/downloads/youtube-fallback.ts`** (session-authed)
+  - `POST` — start a job from an explicit `tracks[]` **or** an `importJobId`
+    (pulls `no_match` + `pending_review` originals by default). Returns `{ jobId, total }`.
+  - `GET ?jobId=…` — per-track status + summary.
+- **`src/lib/services/__tests__/youtube-fallback.test.ts`** — 11 tests on the pure helpers.
+
+## Per-track status model
+
+`pending → searching → downloaded | mismatch | failed`
+
+- `downloaded` — finished + verification passed (or verify disabled).
+- `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
+- `failed` — MeTube error or 5-min timeout.
+
+## How to test (Juan)
+
+Start from the "Late aug" import misses (or any import job id):
+
+```bash
+# From a finished import job — pulls its no_match + pending_review tracks:
+curl -s -X POST https://<app>/api/downloads/youtube-fallback \
+  -H 'Content-Type: application/json' -b <session-cookie> \
+  -d '{"importJobId":"01cb5639-dbff-4f81-b415-c71240551ada"}'
+
+# Or explicit tracks:
+curl -s -X POST https://<app>/api/downloads/youtube-fallback \
+  -H 'Content-Type: application/json' -b <session-cookie> \
+  -d '{"tracks":[{"artist":"Sun Room","title":"Insincere"},
+                 {"artist":"Josh Baker","title":"My Place"},
+                 {"artist":"A. G. Cook","title":"Idyll"}]}'
+
+# Poll:
+curl -s "https://<app>/api/downloads/youtube-fallback?jobId=<jobId>" -b <session-cookie>
+```
+
+Watch server logs for `[YouTubeFallback]` lines. Then confirm the downloaded files
+land in MeTube's folder and run the Picard retag flow against them → Lidarr moves →
+Navidrome rescans → reconciliation remaps any ghost id → track is playable.
+
+## Runtime assumption to confirm on first run
+
+MeTube forwards `ytsearch1:` to yt-dlp — verify the deployed MeTube accepts a
+non-URL `url` (it does not go through `/api/metube/add`, which whitelists real
+site URLs; this path calls the MeTube service directly). If MeTube rejects it,
+fall back to resolving a video id via `youtube-music.ts` search first.
+
+## Not built (follow-ups)
+
+- **UI.** No button yet — API only. The existing `/downloads/youtube` page is a
+  manual URL paste; a "download import misses" action could live there or in the
+  import review UI.
+- **Persistence.** Job state is in-memory (lost on redeploy). Fine for a testing
+  tool; if this becomes a durable auto-fallback, fold it into the Import Manager (#132).
+- **Auto-trigger.** Currently manual. Wiring "Lidarr 0-albums → auto YouTube
+  fallback" is the #144 + #145 join.

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -52,6 +52,28 @@ video ID available" — this fills exactly that gap.
 - `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
 - `failed` — MeTube error or 5-min timeout, after exhausting retries.
 
+## Detection fix (after the first real batch, 2026-08-18)
+
+The first 16-track batch **false-failed** tracks that actually downloaded fine.
+Root cause: detection matched a *new MeTube id not in a pre-snapshot*, and the
+5-min per-attempt timeout fired **seconds before** these slow (5–10 min) downloads
+landed — then retried, re-adding a video already downloading, and could delete the
+in-flight item. Proof: Skank N Flex finished 11 s after the timeout; Got Bounce /
+HeadRush 6 s after.
+
+Fixes:
+- **Content-based detection** (`itemLikelyMatchesTrack`): match MeTube items by
+  title-token overlap + primary artist, not id-novelty. Survives MeTube's id-dedup
+  of already-downloaded videos and finds the item whenever it lands. A pre-existing
+  `finished` match returns immediately (idempotent re-sends).
+- **Patient window** raised to 12 min; a track still actively fetching when the
+  window closes is reported **`downloading`** (new status), *not* `failed`, and is
+  never deleted or retried.
+- **Retries only on confirmed errors** (403/PO-token), never on a slow-but-in-flight
+  download.
+
+Status model gains `downloading` (submitted, still fetching, unconfirmed).
+
 ## Retries (added after the first prod test)
 
 YouTube download failures are frequently transient — see the PO-token finding

--- a/src/components/playlists/import/steps/confirmation-step.tsx
+++ b/src/components/playlists/import/steps/confirmation-step.tsx
@@ -115,8 +115,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
         const response = await fetch('/api/downloads/youtube-fallback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // Send the explicit selected tracks; the route prefers `tracks` over
+          // `importJobId` anyway, so passing the job id here would be dead weight.
           body: JSON.stringify({
-            importJobId: importResult.importJobId,
             tracks: songsToDownload,
           }),
         });

--- a/src/components/playlists/import/steps/confirmation-step.tsx
+++ b/src/components/playlists/import/steps/confirmation-step.tsx
@@ -65,6 +65,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
   const [queuedCount, setQueuedCount] = useState(0);
   const [downloadFailed, setDownloadFailed] = useState(false);
   const [downloadErrorMessage, setDownloadErrorMessage] = useState<string | null>(null);
+  // Lidarr = album-based acquisition; YouTube = per-song MeTube fallback (#145),
+  // for the misses Lidarr can't get (e.g. "artist has 0 albums").
+  const [downloadService, setDownloadService] = useState<'lidarr' | 'youtube'>('lidarr');
 
   // Mock unmatched songs list (in real implementation, this would come from importResult)
   const unmatchedSongs: UnmatchedSong[] = importResult.unmatchedSongs || [
@@ -105,6 +108,43 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
 
     try {
       const songsToDownload = Array.from(selectedSongs).map(i => unmatchedSongs[i]);
+
+      // YouTube path: per-song MeTube fallback (#145). Fire-and-poll happens
+      // server-side; here we just start the job and report it.
+      if (downloadService === 'youtube') {
+        const response = await fetch('/api/downloads/youtube-fallback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            importJobId: importResult.importJobId,
+            tracks: songsToDownload,
+          }),
+        });
+
+        if (!response.ok) {
+          let errorMessage = 'Failed to start YouTube downloads';
+          try {
+            const error = await response.json();
+            errorMessage = error.message || error.error || errorMessage;
+          } catch {
+            /* non-JSON */
+          }
+          throw new Error(errorMessage);
+        }
+
+        const data = await response.json();
+        const started = data.data?.total ?? songsToDownload.length;
+
+        toast.success(`Sent ${started} song${started !== 1 ? 's' : ''} to YouTube`, {
+          description: 'Downloading one at a time via MeTube. Landed files flow through Picard → library rescan.',
+          duration: 8000,
+        });
+
+        setHasQueuedDownloads(true);
+        setQueuedCount(started);
+        setDownloadDialogOpen(false);
+        return;
+      }
 
       const response = await fetch('/api/downloads/queue', {
         method: 'POST',
@@ -381,9 +421,37 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
           <DialogHeader className="flex-shrink-0 space-y-0 md:space-y-1">
             <DialogTitle className="text-sm md:text-base">Download Missing Songs</DialogTitle>
             <DialogDescription className="hidden md:block text-xs">
-              Select which songs to download via Lidarr.
+              {downloadService === 'lidarr'
+                ? 'Find full albums via Lidarr.'
+                : 'Grab each song straight from YouTube via MeTube — for tracks Lidarr can’t get.'}
             </DialogDescription>
           </DialogHeader>
+
+          {/* Service selector: Lidarr (albums) vs YouTube (per-song fallback) */}
+          <div className="flex-shrink-0 grid grid-cols-2 gap-1 rounded-md border p-0.5">
+            <button
+              type="button"
+              onClick={() => setDownloadService('lidarr')}
+              className={`h-6 md:h-7 rounded text-[10px] md:text-xs font-medium transition-colors ${
+                downloadService === 'lidarr'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              Lidarr
+            </button>
+            <button
+              type="button"
+              onClick={() => setDownloadService('youtube')}
+              className={`h-6 md:h-7 rounded text-[10px] md:text-xs font-medium transition-colors ${
+                downloadService === 'youtube'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              YouTube
+            </button>
+          </div>
 
           {/* Song Selection */}
           {unmatchedSongs.length > 0 && (
@@ -417,7 +485,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
           )}
 
           <div className="flex-shrink-0 text-[9px] md:text-xs text-muted-foreground text-center px-2">
-            Note: Downloaded songs must be added to playlist manually after library rescan.
+            {downloadService === 'youtube'
+              ? 'Note: Downloads one at a time and verifies each match. Retag in Picard, then rescan the library to add them.'
+              : 'Note: Downloaded songs must be added to playlist manually after library rescan.'}
           </div>
 
           <DialogFooter className="flex-shrink-0 border-t pt-2 md:pt-3 gap-2">
@@ -428,12 +498,12 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
               {isDownloading ? (
                 <>
                   <Loader2 className="mr-1 h-3 w-3 md:h-4 md:w-4 animate-spin" />
-                  Queueing...
+                  {downloadService === 'youtube' ? 'Starting...' : 'Queueing...'}
                 </>
               ) : (
                 <>
                   <Download className="mr-1 h-3 w-3 md:h-4 md:w-4" />
-                  Queue {selectedSongs.size}
+                  {downloadService === 'youtube' ? `Send ${selectedSongs.size}` : `Queue ${selectedSongs.size}`}
                 </>
               )}
             </Button>

--- a/src/lib/services/__tests__/song-matcher.test.ts
+++ b/src/lib/services/__tests__/song-matcher.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the matcher's YouTube-rip title normalization (#131): a library track
+ * stored under its full video title (e.g. "Cloonee & Prospa - Good Girl (ft…)")
+ * must still match the requested title ("Good Girl") instead of being declared
+ * no_match and needlessly re-downloaded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripLeadingArtistPrefix, calculateMatchScore } from '../song-matcher';
+import type { ExportableSong } from '../playlist-export';
+import type { PlatformSearchResult } from '../song-matcher';
+
+describe('stripLeadingArtistPrefix', () => {
+  it('strips a leading artist prefix that overlaps the artist', () => {
+    expect(
+      stripLeadingArtistPrefix('Cloonee & Prospa - Good Girl (ft. Tristan Henry)', 'Cloonee')
+    ).toBe('Good Girl (ft. Tristan Henry)');
+  });
+
+  it('strips when the prefix contains any artist token', () => {
+    expect(stripLeadingArtistPrefix('zvle - 1MY', 'zvle')).toBe('1MY');
+  });
+
+  it('leaves a genuine "A - B" title alone when the prefix is unrelated to the artist', () => {
+    // "Home" is the artist; the title legitimately contains a dash.
+    expect(stripLeadingArtistPrefix('Resonance - Part II', 'Home')).toBe('Resonance - Part II');
+  });
+
+  it('returns the title unchanged when there is no dash', () => {
+    expect(stripLeadingArtistPrefix('Good Girl', 'Cloonee')).toBe('Good Girl');
+  });
+});
+
+describe('calculateMatchScore with polluted candidate titles', () => {
+  const source: ExportableSong = { title: 'Good Girl', artist: 'Cloonee', platform: 'spotify' };
+  const cand = (title: string): PlatformSearchResult => ({
+    platform: 'navidrome',
+    platformId: 'abc',
+    title,
+    artist: 'Cloonee',
+  });
+
+  it('matches a junk YouTube-rip title to the clean requested title', () => {
+    const clean = calculateMatchScore(source, cand('Good Girl'));
+    const junk = calculateMatchScore(source, cand('Cloonee & Prospa - Good Girl (ft. Tristan Henry)'));
+    // The stripped comparison should recover most of the title score.
+    expect(junk.score).toBeGreaterThan(70);
+    // And be in the same ballpark as the already-clean candidate.
+    expect(clean.score - junk.score).toBeLessThan(15);
+  });
+
+  it('keeps feat/version info distinct for normal titles (no artist prefix)', () => {
+    // A remix request should NOT be blurred into the original just because both
+    // share a base title — the feat-leniency only applies to rip-style prefixes.
+    const remixReq: ExportableSong = { title: 'Surround Sound (KAYTRANADA Remix)', artist: 'JID', platform: 'spotify' };
+    const remixCand: PlatformSearchResult = { platform: 'navidrome', platformId: 'r', title: 'Surround Sound (KAYTRANADA Remix)', artist: 'JID' };
+    const origCand: PlatformSearchResult = { platform: 'navidrome', platformId: 'o', title: 'Surround Sound (feat. 21 Savage & Baby Tate)', artist: 'JID' };
+    const remixScore = calculateMatchScore(remixReq, remixCand).score;
+    const origScore = calculateMatchScore(remixReq, origCand).score;
+    // The exact remix must score higher than the (feat-only) original.
+    expect(remixScore).toBeGreaterThan(origScore);
+  });
+});

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeSearchQuery,
   buildYouTubeSearchUrl,
   verifyDownload,
+  itemLikelyMatchesTrack,
 } from '../youtube-fallback';
 
 describe('normalizeSearchQuery', () => {
@@ -72,5 +73,49 @@ describe('verifyDownload', () => {
     const v = verifyDownload(track, {});
     expect(v.matched).toBe(false);
     expect(v.score).toBe(0);
+  });
+});
+
+describe('itemLikelyMatchesTrack (detection)', () => {
+  // Real cases that the strict id-based detection got wrong: MeTube's resolved
+  // title differs from the request but is clearly the same track.
+  it('matches a multi-artist request against MeTube’s resolved title', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Wax Motif;Taiki Nulight;Scrufizzer', title: 'Skank N Flex (with Scrufizzer)' },
+        { title: 'Wax Motif & Taiki Nulight - Skank n Flex ft. Scrufizzer' }
+      )
+    ).toBe(true);
+  });
+
+  it('matches "Got Bounce" by primary artist + title tokens', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Kumarion;STUCA', title: 'Got Bounce' },
+        { title: 'Kumarion & STUCA - Got Bounce' }
+      )
+    ).toBe(true);
+  });
+
+  it('does not match an unrelated download in a large history', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Kumarion', title: 'Got Bounce' },
+        { title: 'Some Other Artist - A Totally Different Song' }
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to filename', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Sun Room', title: 'Insincere' },
+        { filename: 'Sun Room - Insincere [Official Audio].mp3' }
+      )
+    ).toBe(true);
+  });
+
+  it('returns false with no title or filename', () => {
+    expect(itemLikelyMatchesTrack({ artist: 'A', title: 'B' }, {})).toBe(false);
   });
 });

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -4,14 +4,24 @@
  * No network / MeTube interaction is exercised here.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   normalizeSearchQuery,
   buildYouTubeSearchUrl,
   verifyDownload,
   itemLikelyMatchesTrack,
   libraryMatch,
+  startYouTubeFallbackJob,
+  getYouTubeFallbackJob,
 } from '../youtube-fallback';
+
+// The batch-runner tests below drive real MeTube interaction, so stub the client.
+vi.mock('../metube', () => ({
+  getQueue: vi.fn(),
+  addDownload: vi.fn().mockResolvedValue({ status: 'ok' }),
+  deleteDownloads: vi.fn().mockResolvedValue({ status: 'ok' }),
+}));
+import * as metube from '../metube';
 
 describe('normalizeSearchQuery', () => {
   it('uses the primary artist and drops collaborators', () => {
@@ -151,5 +161,66 @@ describe('libraryMatch (dedup guard vs Navidrome songs)', () => {
     expect(
       libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'When Did Your Heart Go Missing?', artist: 'Rooney' })
     ).toBe(false);
+  });
+});
+
+describe('batch runner attribution + retry policy', () => {
+  const finishedItem = {
+    id: 'vid1',
+    title: 'Cloonee - Good Girl',
+    url: 'ytsearch1:Cloonee Good Girl',
+    status: 'finished' as const,
+    filename: 'Cloonee - Good Girl.mp3',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Every poll sees exactly the one finished item.
+    (metube.getQueue as ReturnType<typeof vi.fn>).mockResolvedValue({
+      done: { vid1: finishedItem },
+      queue: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // #2: a single MeTube item that loosely matches two near-identical tracks must be
+  // attributed to only the first — the second must not be re-counted as the same file.
+  it('does not attribute one MeTube item to two tracks in a batch', async () => {
+    const track = { artist: 'Cloonee', title: 'Good Girl' };
+    const job = startYouTubeFallbackJob('user-1', [track, { ...track }], {
+      skipInLibrary: false, // don't touch Navidrome in this test
+    });
+
+    await vi.runAllTimersAsync();
+
+    const finished = getYouTubeFallbackJob(job.id, 'user-1');
+    expect(finished?.status).toBe('completed');
+    // First track claims vid1; the second can't reuse it, so it never resolves.
+    expect(finished?.results[0].status).toBe('downloaded');
+    expect(finished?.results[0].metubeId).toBe('vid1');
+    expect(finished?.results[1].status).toBe('failed');
+    expect(finished?.results[1].metubeId).toBeUndefined();
+  });
+
+  // #3: a bare timeout (nothing matching ever appeared) must NOT be retried — the
+  // same query would just re-resolve to the same undetectable video.
+  it('does not retry a track that merely timed out', async () => {
+    const track = { artist: 'Cloonee', title: 'Good Girl' };
+    // Two identical tracks: the first claims vid1, the second times out with nothing
+    // left to match. addDownload is only reachable on the second (the first is served
+    // from the pre-finished item) and must be called exactly once — no retries.
+    const job = startYouTubeFallbackJob('user-1', [track, { ...track }], {
+      skipInLibrary: false,
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(getYouTubeFallbackJob(job.id, 'user-1')?.status).toBe('completed');
+    expect(metube.addDownload as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the YouTube per-song fallback (issue #145) pure helpers:
+ * query normalization, the yt-dlp search URL, and download verification.
+ * No network / MeTube interaction is exercised here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSearchQuery,
+  buildYouTubeSearchUrl,
+  verifyDownload,
+} from '../youtube-fallback';
+
+describe('normalizeSearchQuery', () => {
+  it('uses the primary artist and drops collaborators', () => {
+    const q = normalizeSearchQuery({ artist: 'Flume;SOPHIE;Eprom', title: 'Spring' });
+    expect(q).toBe('Flume Spring');
+  });
+
+  it('strips feat./with qualifiers from the title', () => {
+    const q = normalizeSearchQuery({ artist: 'matt proxy', title: '5 (with fakemink)' });
+    expect(q).toBe('matt proxy 5');
+  });
+
+  it('strips remaster tags', () => {
+    const q = normalizeSearchQuery({ artist: 'Some Artist', title: 'A Song (2011 Remaster)' });
+    expect(q).toBe('Some Artist A Song');
+  });
+
+  it('collapses whitespace and trims', () => {
+    const q = normalizeSearchQuery({ artist: '  Sun Room ', title: '  Insincere  ' });
+    expect(q).toBe('Sun Room Insincere');
+  });
+});
+
+describe('buildYouTubeSearchUrl', () => {
+  it('produces a yt-dlp ytsearch1 pseudo-URL', () => {
+    expect(buildYouTubeSearchUrl('Sun Room Insincere')).toBe('ytsearch1:Sun Room Insincere');
+  });
+});
+
+describe('verifyDownload', () => {
+  const track = { artist: 'Sun Room', title: 'Insincere' };
+
+  it('accepts a clean official-video match', () => {
+    const v = verifyDownload(track, { title: 'Sun Room - Insincere (Official Video)' });
+    expect(v.matched).toBe(true);
+    expect(v.score).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('accepts a title-only match when artist is present elsewhere', () => {
+    const v = verifyDownload(track, { title: 'Insincere by Sun Room' });
+    expect(v.matched).toBe(true);
+  });
+
+  it('rejects an unrelated video', () => {
+    const v = verifyDownload(track, { title: 'Top 50 Summer House Mix 2024' });
+    expect(v.matched).toBe(false);
+  });
+
+  it('flags a wrong-title result from the same artist', () => {
+    const v = verifyDownload(track, { title: 'Sun Room - Cadillac (Live)' });
+    expect(v.matched).toBe(false);
+  });
+
+  it('falls back to filename when title is missing', () => {
+    const v = verifyDownload(track, { filename: 'Sun Room - Insincere.mp3' });
+    expect(v.matched).toBe(true);
+  });
+
+  it('returns unmatched with no result title', () => {
+    const v = verifyDownload(track, {});
+    expect(v.matched).toBe(false);
+    expect(v.score).toBe(0);
+  });
+});

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -10,6 +10,7 @@ import {
   buildYouTubeSearchUrl,
   verifyDownload,
   itemLikelyMatchesTrack,
+  libraryMatch,
 } from '../youtube-fallback';
 
 describe('normalizeSearchQuery', () => {
@@ -117,5 +118,38 @@ describe('itemLikelyMatchesTrack (detection)', () => {
 
   it('returns false with no title or filename', () => {
     expect(itemLikelyMatchesTrack({ artist: 'A', title: 'B' }, {})).toBe(false);
+  });
+});
+
+describe('libraryMatch (dedup guard vs Navidrome songs)', () => {
+  it('matches a CLEANLY-stored track (artist in a separate field)', () => {
+    // The bug case: Navidrome title="Calling You", artist="Valexus" (not in title).
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'Calling You', artist: 'Valexus' })
+    ).toBe(true);
+    expect(
+      libraryMatch({ artist: 'Valexus;Beehav3', title: 'Calling You' }, { title: 'Calling You', artist: 'Valexus & Beehav3' })
+    ).toBe(true);
+  });
+
+  it('matches a JUNK-titled copy (whole video title in the title field)', () => {
+    expect(
+      libraryMatch(
+        { artist: 'Wax Motif;Taiki Nulight;Scrufizzer', title: 'Skank N Flex (with Scrufizzer)' },
+        { title: 'Wax Motif & Taiki Nulight - Skank n Flex ft. Scrufizzer', artist: 'Wax Motif' }
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT match a same-title track by a different artist', () => {
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'Calling for You', artist: 'Drake' })
+    ).toBe(false);
+  });
+
+  it('does NOT match an unrelated song', () => {
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'When Did Your Heart Go Missing?', artist: 'Rooney' })
+    ).toBe(false);
   });
 });

--- a/src/lib/services/song-matcher.ts
+++ b/src/lib/services/song-matcher.ts
@@ -128,6 +128,24 @@ export function normalizeTitle(title: string): string {
 }
 
 /**
+ * Strip a leading "Artist - " prefix from a title when it overlaps the given
+ * artist. YouTube-rip imports frequently store the whole video title as the track
+ * title (e.g. "Cloonee & Prospa - Good Girl (ft. Tristan Henry)"), which tanks the
+ * title-similarity score against the real title ("Good Girl"). Only strips when the
+ * prefix shares a token with the artist, so genuine "A - B" titles are left alone.
+ */
+export function stripLeadingArtistPrefix(title: string, artist: string): string {
+  const m = title.match(/^(.{1,60}?)\s[-—–]\s(.+)$/);
+  if (!m) return title;
+  const prefix = normalizeArtist(m[1]);
+  const art = normalizeArtist(artist);
+  if (!prefix || !art) return title;
+  const artistTokens = new Set(art.split(' ').filter(Boolean));
+  const overlaps = prefix.split(' ').filter(Boolean).some((t) => artistTokens.has(t));
+  return overlaps ? m[2] : title;
+}
+
+/**
  * Calculate match score between two songs
  */
 export function calculateMatchScore(
@@ -142,11 +160,23 @@ export function calculateMatchScore(
     return { score: 100, confidence: 'exact', reason: 'ISRC code match' };
   }
 
-  // Title similarity (40% weight)
-  const titleSimilarity = stringSimilarity(
+  // Title similarity (40% weight). Also try the candidate title with a leading
+  // "Artist - " prefix stripped, so a polluted YouTube-rip title still matches.
+  // Feat/version info is only dropped on THIS recovery path (a candidate that had
+  // an artist prefix) — normal titles keep it, so remix/feat versions stay distinct.
+  const candidateStripped = stripLeadingArtistPrefix(candidate.title, candidate.artist);
+  let titleSimilarity = stringSimilarity(
     normalizeTitle(source.title),
     normalizeTitle(candidate.title)
   );
+  if (candidateStripped !== candidate.title) {
+    const dropFeat = (t: string) =>
+      t.replace(/\s*[([]\s*(feat|ft|featuring|with)\.?\s[^)\]]*[)\]]/gi, '');
+    titleSimilarity = Math.max(
+      titleSimilarity,
+      stringSimilarity(normalizeTitle(dropFeat(source.title)), normalizeTitle(dropFeat(candidateStripped)))
+    );
+  }
   score += titleSimilarity * 40;
   if (titleSimilarity > 0.9) reasons.push('Title matches closely');
   else if (titleSimilarity > 0.7) reasons.push('Title similar');

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -36,7 +36,8 @@ export type FallbackTrackStatus =
   | 'searching' // queued to MeTube, waiting for the download to land
   | 'downloaded' // finished; verification passed (or verification disabled)
   | 'mismatch' // finished, but verification thinks it's likely the wrong track
-  | 'failed'; // MeTube reported an error, or we timed out waiting
+  | 'downloading' // still fetching in MeTube when our window closed (not confirmed, not failed)
+  | 'failed'; // MeTube reported an error, after exhausting retries
 
 export interface FallbackVerification {
   matched: boolean;
@@ -83,8 +84,10 @@ export interface StartFallbackOptions {
 
 /** Poll MeTube this often while waiting for a single download. */
 const POLL_INTERVAL_MS = 3000;
-/** Give up on a single track after this long. */
-const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+/** Confirmation window for a single track. These downloads can take 5–10 min
+ *  under yt-dlp throttling, so this is generous; a slow one that's still fetching
+ *  when it closes is reported `downloading`, not failed. */
+const DOWNLOAD_TIMEOUT_MS = 12 * 60 * 1000;
 /** Small breather between tracks so each is attributable in MeTube/logs. */
 const BETWEEN_TRACKS_MS = 750;
 /** Wait between retry attempts for a track that failed to download. */
@@ -198,13 +201,41 @@ interface DownloadOutcome {
   item?: MeTubeDownload;
   errored?: boolean;
   timedOut?: boolean;
+  stillDownloading?: boolean; // timed out, but MeTube was still actively fetching it
   error?: string;
 }
 
 /**
- * Snapshot MeTube's current ids, queue a single `ytsearch1:` download, then poll
- * until a *new* item reaches a terminal (finished/error) state or we time out.
- * One-at-a-time makes the "new id" detection unambiguous.
+ * Loose "is this MeTube item our track?" check for DETECTION (not verification).
+ * We can't know the resolved video id in advance and MeTube keys by video id, so
+ * matching a *previously downloaded* video would never appear as a "new id".
+ * Instead we match on content: decent title-token overlap plus the primary artist
+ * present. Deliberately looser than `verifyDownload` — a loose-matched item that
+ * turns out to be wrong is still surfaced later as `mismatch` by verification.
+ */
+export function itemLikelyMatchesTrack(
+  track: FallbackTrack,
+  item: Partial<Pick<MeTubeDownload, 'title' | 'filename'>>
+): boolean {
+  const got = normalizeForCompare(item.title || item.filename || '');
+  if (!got) return false;
+  const wantTitle = normalizeForCompare(track.title);
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+  if (!wantTitle) return false;
+
+  const titleOverlap = got.includes(wantTitle) ? 1 : tokenOverlap(wantTitle, got);
+  const artistOk =
+    wantArtist.length < 3 || got.includes(wantArtist) || tokenOverlap(wantArtist, got) >= 0.5;
+
+  return titleOverlap >= 0.5 && artistOk;
+}
+
+/**
+ * Queue a single `ytsearch1:` download and wait for the matching item to reach a
+ * terminal state. Detection is content-based (see `itemLikelyMatchesTrack`) so it
+ * survives MeTube's id-dedup of already-downloaded videos and never gives up on a
+ * download that is simply slow — on timeout it reports `stillDownloading` rather
+ * than a false failure, and never deletes an in-flight item.
  */
 async function queueAndAwaitDownload(
   track: FallbackTrack,
@@ -217,12 +248,24 @@ async function queueAndAwaitDownload(
   } catch {
     before = { done: {}, queue: {} };
   }
-  const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
+
+  // Ignore a pre-existing *errored* entry for this track (a stale prior failure);
+  // but a pre-existing *finished* match means it's already downloaded — done.
+  const staleErrorIds = new Set(
+    Object.values(before.done)
+      .filter((d) => d.status === 'error' && itemLikelyMatchesTrack(track, d))
+      .map((d) => d.id)
+  );
+  const preFinished = Object.values(before.done).find(
+    (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+  );
+  if (preFinished) {
+    return { metubeId: preFinished.id, item: preFinished };
+  }
 
   try {
     // No custom_name_prefix: yt-dlp's own title (usually "Artist - Title …")
-    // already carries the naming, and prefixing it doubled the string
-    // ("Sun Room - Insincere.Sun Room - Insincere [Official Audio]"). Picard
+    // already carries the naming, and prefixing it doubled the string. Picard
     // retags from the audio fingerprint anyway, so the raw title filename is fine.
     await metube.addDownload({
       url: buildYouTubeSearchUrl(query),
@@ -236,7 +279,7 @@ async function queueAndAwaitDownload(
   }
 
   const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
-  let seenId: string | undefined;
+  let sawInFlight = false;
 
   while (Date.now() < deadline) {
     await sleep(POLL_INTERVAL_MS);
@@ -248,42 +291,53 @@ async function queueAndAwaitDownload(
       continue;
     }
 
-    // Terminal first: a new item in `done` is finished or errored.
-    const doneNew = Object.values(q.done).find((d) => !knownIds.has(d.id));
-    if (doneNew) {
-      if (doneNew.status === 'error') {
-        return { metubeId: doneNew.id, item: doneNew, errored: true, error: doneNew.msg || 'MeTube reported error' };
-      }
-      return { metubeId: doneNew.id, item: doneNew };
+    const finished = Object.values(q.done).find(
+      (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+    );
+    if (finished) return { metubeId: finished.id, item: finished };
+
+    const errored = Object.values(q.done).find(
+      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && itemLikelyMatchesTrack(track, d)
+    );
+    if (errored) {
+      return { metubeId: errored.id, item: errored, errored: true, error: errored.msg || 'MeTube reported error' };
     }
 
-    // Still in flight — remember the id so a timeout can still report it.
-    const queueNew = Object.values(q.queue).find((d) => !knownIds.has(d.id));
-    if (queueNew) seenId = queueNew.id;
+    // Actively fetching? These downloads can take 5–10 min, so this matters.
+    if (Object.values(q.queue).some((d) => itemLikelyMatchesTrack(track, d))) {
+      sawInFlight = true;
+    }
   }
 
-  return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
+  // Timed out. If MeTube was still fetching it, it will very likely finish shortly
+  // — report as still-downloading (NOT failed) and never delete it.
+  return {
+    timedOut: true,
+    stillDownloading: sawInFlight,
+    error: sawInFlight
+      ? 'still downloading when the confirmation window closed'
+      : 'no matching download appeared before timeout',
+  };
 }
 
 /**
- * Remove a failed/stuck MeTube entry so a retry can re-add the same id cleanly
- * (MeTube keys downloads by id, and `ytsearch1:` re-resolves to the same video).
+ * Remove a genuinely errored MeTube entry so a retry can re-add the same video
+ * cleanly. Only ever called for confirmed errors — never for in-flight downloads.
  */
-async function cleanupFailedDownload(metubeId?: string): Promise<void> {
+async function cleanupErroredDownload(metubeId?: string): Promise<void> {
   if (!metubeId) return;
-  for (const where of ['done', 'queue'] as const) {
-    try {
-      await metube.deleteDownloads([metubeId], where);
-    } catch {
-      /* best-effort */
-    }
+  try {
+    await metube.deleteDownloads([metubeId], 'done');
+  } catch {
+    /* best-effort */
   }
 }
 
 /**
- * Queue a track and, if it fails or times out, retry up to `maxAttempts` total.
- * YouTube 403 / PO-token errors are frequently transient, so a couple of retries
- * meaningfully lift the success rate. Returns the final outcome plus the attempt count.
+ * Queue a track and, on a *confirmed error*, retry up to `maxAttempts` (YouTube
+ * 403 / PO-token errors are often transient). A slow download that merely timed
+ * out while still fetching is NOT retried — retrying would re-queue a video that
+ * is already downloading. Returns the final outcome plus the attempt count.
  */
 async function queueWithRetries(
   track: FallbackTrack,
@@ -296,12 +350,13 @@ async function queueWithRetries(
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     outcome = await queueAndAwaitDownload(track, query, folder);
 
-    if (!outcome.errored && !outcome.timedOut) {
+    // Success, or a timeout on a still-in-flight download — don't retry either.
+    if ((!outcome.errored && !outcome.timedOut) || outcome.stillDownloading) {
       return { ...outcome, attempts: attempt };
     }
 
-    // Failed — clean up so the next attempt can re-queue the same id.
-    await cleanupFailedDownload(outcome.metubeId);
+    // Confirmed error (or nothing ever appeared) — clean up and retry.
+    if (outcome.errored) await cleanupErroredDownload(outcome.metubeId);
 
     if (attempt < maxAttempts) {
       console.warn(
@@ -350,7 +405,12 @@ async function runJob(job: FallbackJob): Promise<void> {
       entry.filename = outcome.item.filename;
     }
 
-    if (outcome.errored || outcome.timedOut) {
+    if (outcome.stillDownloading) {
+      // Slow download still fetching when our window closed — not a failure.
+      entry.status = 'downloading';
+      entry.error = outcome.error;
+      console.log(`[YouTubeFallback] STILL DOWNLOADING ${label} (unconfirmed): ${entry.error}`);
+    } else if (outcome.errored || outcome.timedOut) {
       entry.status = 'failed';
       entry.error = outcome.error;
       console.warn(
@@ -378,7 +438,7 @@ async function runJob(job: FallbackJob): Promise<void> {
 
   const summary = summarizeJob(job);
   console.log(
-    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.failed} failed (of ${summary.total})`
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
   );
 }
 
@@ -388,9 +448,10 @@ export function summarizeJob(job: FallbackJob): {
   searching: number;
   downloaded: number;
   mismatch: number;
+  downloading: number;
   failed: number;
 } {
-  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, failed: 0 };
+  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
   for (const r of job.results) summary[r.status]++;
   return summary;
 }

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -53,6 +53,7 @@ export interface FallbackTrackResult {
   filename?: string;
   verification?: FallbackVerification;
   error?: string;
+  attempts?: number; // how many download attempts were made (>=1 once started)
   startedAt?: number;
   finishedAt?: number;
 }
@@ -65,6 +66,7 @@ export interface FallbackJob {
   updatedAt: number;
   verify: boolean;
   folder?: string;
+  maxAttempts: number;
   currentIndex: number;
   results: FallbackTrackResult[];
 }
@@ -72,6 +74,7 @@ export interface FallbackJob {
 export interface StartFallbackOptions {
   verify?: boolean; // default true
   folder?: string; // MeTube subfolder; default = MeTube's configured folder
+  maxAttempts?: number; // download attempts per track before giving up (default 3)
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +87,13 @@ const POLL_INTERVAL_MS = 3000;
 const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 /** Small breather between tracks so each is attributable in MeTube/logs. */
 const BETWEEN_TRACKS_MS = 750;
+/** Wait between retry attempts for a track that failed to download. */
+const RETRY_DELAY_MS = 5000;
+/** Default download attempts per track. YouTube 403 / PO-token errors are often
+ *  transient, so we re-queue a few times before declaring a track failed. */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+/** Ceiling on attempts, whatever the caller asks for. */
+export const MAX_ATTEMPTS_LIMIT = 5;
 /** Hard cap on tracks per job to avoid runaway batches. */
 export const MAX_TRACKS_PER_JOB = 50;
 
@@ -210,12 +220,15 @@ async function queueAndAwaitDownload(
   const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
 
   try {
+    // No custom_name_prefix: yt-dlp's own title (usually "Artist - Title …")
+    // already carries the naming, and prefixing it doubled the string
+    // ("Sun Room - Insincere.Sun Room - Insincere [Official Audio]"). Picard
+    // retags from the audio fingerprint anyway, so the raw title filename is fine.
     await metube.addDownload({
       url: buildYouTubeSearchUrl(query),
       format: 'mp3',
       quality: 'best',
       folder,
-      custom_name_prefix: `${track.artist} - ${track.title}`,
       auto_start: true,
     });
   } catch (err) {
@@ -252,6 +265,54 @@ async function queueAndAwaitDownload(
   return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
 }
 
+/**
+ * Remove a failed/stuck MeTube entry so a retry can re-add the same id cleanly
+ * (MeTube keys downloads by id, and `ytsearch1:` re-resolves to the same video).
+ */
+async function cleanupFailedDownload(metubeId?: string): Promise<void> {
+  if (!metubeId) return;
+  for (const where of ['done', 'queue'] as const) {
+    try {
+      await metube.deleteDownloads([metubeId], where);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Queue a track and, if it fails or times out, retry up to `maxAttempts` total.
+ * YouTube 403 / PO-token errors are frequently transient, so a couple of retries
+ * meaningfully lift the success rate. Returns the final outcome plus the attempt count.
+ */
+async function queueWithRetries(
+  track: FallbackTrack,
+  query: string,
+  folder: string | undefined,
+  maxAttempts: number,
+  label: string
+): Promise<DownloadOutcome & { attempts: number }> {
+  let outcome: DownloadOutcome = {};
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    outcome = await queueAndAwaitDownload(track, query, folder);
+
+    if (!outcome.errored && !outcome.timedOut) {
+      return { ...outcome, attempts: attempt };
+    }
+
+    // Failed — clean up so the next attempt can re-queue the same id.
+    await cleanupFailedDownload(outcome.metubeId);
+
+    if (attempt < maxAttempts) {
+      console.warn(
+        `[YouTubeFallback] attempt ${attempt}/${maxAttempts} failed for ${label}: ${outcome.error}; retrying in ${RETRY_DELAY_MS}ms`
+      );
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+  return { ...outcome, attempts: maxAttempts };
+}
+
 // ---------------------------------------------------------------------------
 // In-process job registry + batch runner
 // ---------------------------------------------------------------------------
@@ -276,10 +337,12 @@ async function runJob(job: FallbackJob): Promise<void> {
     entry.startedAt = Date.now();
     job.updatedAt = Date.now();
 
+    const label = `"${entry.track.artist} - ${entry.track.title}"`;
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
-    const outcome = await queueAndAwaitDownload(entry.track, entry.query, job.folder);
+    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
     entry.metubeId = outcome.metubeId;
+    entry.attempts = outcome.attempts;
     entry.finishedAt = Date.now();
 
     if (outcome.item) {
@@ -290,7 +353,9 @@ async function runJob(job: FallbackJob): Promise<void> {
     if (outcome.errored || outcome.timedOut) {
       entry.status = 'failed';
       entry.error = outcome.error;
-      console.warn(`[YouTubeFallback] FAILED "${entry.track.artist} - ${entry.track.title}": ${entry.error}`);
+      console.warn(
+        `[YouTubeFallback] FAILED ${label} after ${outcome.attempts} attempt(s): ${entry.error}`
+      );
     } else if (job.verify && outcome.item) {
       const verification = verifyDownload(entry.track, outcome.item);
       entry.verification = verification;
@@ -349,6 +414,11 @@ export function startYouTubeFallbackJob(
     throw new Error('No valid tracks to download (each needs an artist and title)');
   }
 
+  const maxAttempts = Math.min(
+    MAX_ATTEMPTS_LIMIT,
+    Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
+  );
+
   const now = Date.now();
   const job: FallbackJob = {
     id: crypto.randomUUID(),
@@ -358,6 +428,7 @@ export function startYouTubeFallbackJob(
     updatedAt: now,
     verify: options.verify ?? true,
     folder: options.folder,
+    maxAttempts,
     currentIndex: 0,
     results: cleaned.map((track) => ({
       track,

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -33,6 +33,7 @@ export interface FallbackTrack {
 
 export type FallbackTrackStatus =
   | 'pending' // not yet started
+  | 'skipped' // already in the library (dedup guard) — not downloaded
   | 'searching' // queued to MeTube, waiting for the download to land
   | 'downloaded' // finished; verification passed (or verification disabled)
   | 'mismatch' // finished, but verification thinks it's likely the wrong track
@@ -68,6 +69,7 @@ export interface FallbackJob {
   verify: boolean;
   folder?: string;
   maxAttempts: number;
+  skipInLibrary: boolean;
   currentIndex: number;
   results: FallbackTrackResult[];
 }
@@ -76,6 +78,7 @@ export interface StartFallbackOptions {
   verify?: boolean; // default true
   folder?: string; // MeTube subfolder; default = MeTube's configured folder
   maxAttempts?: number; // download attempts per track before giving up (default 3)
+  skipInLibrary?: boolean; // dedup guard: skip tracks already in Navidrome (default true)
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +324,36 @@ async function queueAndAwaitDownload(
 }
 
 /**
+ * Dedup guard: is this track already in the Navidrome library? Uses a loose
+ * content match (same as detection) so it catches copies stored under a polluted
+ * YouTube-rip title that the import matcher scored too low — the exact case that
+ * causes the same track to be re-downloaded. Navidrome import is lazy so this
+ * module stays importable in tests without pulling in the service graph.
+ */
+async function findInLibrary(track: FallbackTrack): Promise<{ title: string } | null> {
+  try {
+    const { search } = await import('./navidrome');
+    const primaryArtist = (track.artist || '').split(/[;,]/)[0].trim();
+    const query = normalizeSearchQuery(track); // "<primary artist> <clean title>"
+    const results = await search(query).catch(() => [] as Array<{ title?: string; name?: string }>);
+    const hit = results.find((s) =>
+      itemLikelyMatchesTrack(track, { title: s.title || s.name || '' })
+    );
+    if (hit) return { title: hit.title || hit.name || '' };
+    // Fallback: an artist-only search catches copies whose stored title is the
+    // full "Artist - Title (ft…)" video title (loose match handles the rest).
+    if (primaryArtist.length > 2) {
+      const r2 = await search(primaryArtist).catch(() => [] as Array<{ title?: string; name?: string }>);
+      const hit2 = r2.find((s) => itemLikelyMatchesTrack(track, { title: s.title || s.name || '' }));
+      if (hit2) return { title: hit2.title || hit2.name || '' };
+    }
+    return null;
+  } catch {
+    return null; // never let a library-check failure block a download
+  }
+}
+
+/**
  * Remove a genuinely errored MeTube entry so a retry can re-add the same video
  * cleanly. Only ever called for confirmed errors — never for in-flight downloads.
  */
@@ -393,6 +426,22 @@ async function runJob(job: FallbackJob): Promise<void> {
     job.updatedAt = Date.now();
 
     const label = `"${entry.track.artist} - ${entry.track.title}"`;
+
+    // Dedup guard: don't re-download something already in the library (even if it
+    // was stored under a junk title the import matcher missed).
+    if (job.skipInLibrary) {
+      const existing = await findInLibrary(entry.track);
+      if (existing) {
+        entry.status = 'skipped';
+        entry.resultTitle = existing.title;
+        entry.finishedAt = Date.now();
+        job.updatedAt = Date.now();
+        console.log(`[YouTubeFallback] SKIP (already in library) ${label} -> "${existing.title}"`);
+        if (i < job.results.length - 1) await sleep(BETWEEN_TRACKS_MS);
+        continue;
+      }
+    }
+
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
     const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
@@ -438,20 +487,21 @@ async function runJob(job: FallbackJob): Promise<void> {
 
   const summary = summarizeJob(job);
   console.log(
-    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.skipped} skipped, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
   );
 }
 
 export function summarizeJob(job: FallbackJob): {
   total: number;
   pending: number;
+  skipped: number;
   searching: number;
   downloaded: number;
   mismatch: number;
   downloading: number;
   failed: number;
 } {
-  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
+  const summary = { total: job.results.length, pending: 0, skipped: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
   for (const r of job.results) summary[r.status]++;
   return summary;
 }
@@ -490,6 +540,7 @@ export function startYouTubeFallbackJob(
     verify: options.verify ?? true,
     folder: options.folder,
     maxAttempts,
+    skipInLibrary: options.skipInLibrary ?? true,
     currentIndex: 0,
     results: cleaned.map((track) => ({
       track,

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -1,0 +1,386 @@
+/**
+ * YouTube per-song fallback download (issue #145)
+ *
+ * When a playlist-import "miss" can't be resolved through Lidarr (commonly the
+ * "artist has 0 albums" dead-end — see issue #144), we can still fetch the track
+ * straight from YouTube via MeTube, **one song at a time**, using yt-dlp's
+ * `ytsearch1:` search syntax (no YouTube API key / OAuth required). Each download
+ * is verified against the requested artist/title so obvious wrong-video / live /
+ * channel-rip results are flagged instead of silently polluting the library.
+ *
+ * The landed file (named `Artist - Title`) drops into MeTube's download folder,
+ * where the existing Picard retag → Lidarr move → Navidrome rescan flow can pick
+ * it up. This module deliberately stops at "file downloaded + verified"; the
+ * reconcile-back-into-playlist step is owned by the Import Manager (issue #132).
+ *
+ * Job state is kept in-process (this is a diagnostic / testing path polled while
+ * the page is open), mirroring the media-flow-manager pattern — no new table.
+ */
+
+import * as metube from './metube';
+import type { MeTubeDownload } from './metube';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FallbackTrack {
+  artist: string;
+  title: string;
+  album?: string;
+  duration?: number; // seconds, if known
+}
+
+export type FallbackTrackStatus =
+  | 'pending' // not yet started
+  | 'searching' // queued to MeTube, waiting for the download to land
+  | 'downloaded' // finished; verification passed (or verification disabled)
+  | 'mismatch' // finished, but verification thinks it's likely the wrong track
+  | 'failed'; // MeTube reported an error, or we timed out waiting
+
+export interface FallbackVerification {
+  matched: boolean;
+  score: number; // 0..1
+  reason: string;
+}
+
+export interface FallbackTrackResult {
+  track: FallbackTrack;
+  query: string;
+  status: FallbackTrackStatus;
+  metubeId?: string;
+  resultTitle?: string;
+  filename?: string;
+  verification?: FallbackVerification;
+  error?: string;
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+export interface FallbackJob {
+  id: string;
+  userId: string;
+  status: 'running' | 'completed' | 'failed';
+  createdAt: number;
+  updatedAt: number;
+  verify: boolean;
+  folder?: string;
+  currentIndex: number;
+  results: FallbackTrackResult[];
+}
+
+export interface StartFallbackOptions {
+  verify?: boolean; // default true
+  folder?: string; // MeTube subfolder; default = MeTube's configured folder
+}
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Poll MeTube this often while waiting for a single download. */
+const POLL_INTERVAL_MS = 3000;
+/** Give up on a single track after this long. */
+const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+/** Small breather between tracks so each is attributable in MeTube/logs. */
+const BETWEEN_TRACKS_MS = 750;
+/** Hard cap on tracks per job to avoid runaway batches. */
+export const MAX_TRACKS_PER_JOB = 50;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a clean YouTube search query from a track. Uses the primary artist
+ * (drops `;`/`,`-joined collaborators, which hurt search) and strips noisy
+ * qualifiers that rarely appear in YouTube titles.
+ */
+export function normalizeSearchQuery(track: FallbackTrack): string {
+  const primaryArtist = (track.artist || '')
+    .split(/[;,]/)[0]
+    .trim();
+
+  const cleanTitle = (track.title || '')
+    .replace(/\s*\((?:with|feat\.?|ft\.?|featuring)\s+[^)]+\)/gi, '')
+    .replace(/\s*\[(?:with|feat\.?|ft\.?|featuring)\s+[^\]]+\]/gi, '')
+    .replace(/\s*\([^)]*\b(?:remaster|remastered|deluxe|anniversary|expanded|bonus)\b[^)]*\)/gi, '')
+    .replace(/\s*\[[^\]]*\b(?:remaster|remastered|deluxe|anniversary|expanded|bonus)\b[^\]]*\]/gi, '')
+    .replace(/\s+-\s*\d{4}\s*remaster(?:ed)?\s*$/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  return `${primaryArtist} ${cleanTitle}`.trim();
+}
+
+/**
+ * yt-dlp search "URL". MeTube passes the `url` field straight to yt-dlp, which
+ * treats `ytsearch1:<query>` as "download the top YouTube result for <query>".
+ */
+export function buildYouTubeSearchUrl(query: string): string {
+  return `ytsearch1:${query}`;
+}
+
+/** Lowercase, strip punctuation, collapse whitespace — for loose comparison. */
+function normalizeForCompare(s: string): string {
+  return (s || '')
+    .toLowerCase()
+    .replace(/\(.*?\)|\[.*?\]/g, ' ') // drop bracketed qualifiers
+    .replace(/\b(official|music|video|audio|lyrics?|visualizer|hd|4k)\b/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenOverlap(want: string, got: string): number {
+  const wantTokens = want.split(' ').filter(Boolean);
+  if (wantTokens.length === 0) return 0;
+  const gotSet = new Set(got.split(' ').filter(Boolean));
+  const hits = wantTokens.filter((t) => gotSet.has(t)).length;
+  return hits / wantTokens.length;
+}
+
+/**
+ * Verify a completed MeTube item is plausibly the requested track. Because
+ * `ytsearch1:` returns whatever YouTube ranks first, this guards against live
+ * versions, remixes, hour-long mixes, and channel rips.
+ */
+export function verifyDownload(
+  track: FallbackTrack,
+  item: Partial<Pick<MeTubeDownload, 'title' | 'filename'>>
+): FallbackVerification {
+  const resultTitle = (item.title || item.filename || '').toString();
+  if (!resultTitle) {
+    return { matched: false, score: 0, reason: 'no result title to verify against' };
+  }
+
+  const got = normalizeForCompare(resultTitle);
+  const wantTitle = normalizeForCompare(track.title);
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+
+  const titleScore = got.includes(wantTitle) && wantTitle.length > 0 ? 1 : tokenOverlap(wantTitle, got);
+  const artistScore =
+    wantArtist.length < 3 // too short to be a reliable signal
+      ? 1
+      : got.includes(wantArtist)
+        ? 1
+        : tokenOverlap(wantArtist, got);
+
+  // Title carries most of the weight; a strong title + present artist passes.
+  const score = titleScore * 0.65 + artistScore * 0.35;
+  const matched = titleScore >= 0.6 && score >= 0.6;
+
+  return {
+    matched,
+    score: Math.round(score * 100) / 100,
+    reason: `title ${(titleScore * 100) | 0}% / artist ${(artistScore * 100) | 0}% vs "${resultTitle}"`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MeTube interaction: queue one track and wait for it to land
+// ---------------------------------------------------------------------------
+
+interface DownloadOutcome {
+  metubeId?: string;
+  item?: MeTubeDownload;
+  errored?: boolean;
+  timedOut?: boolean;
+  error?: string;
+}
+
+/**
+ * Snapshot MeTube's current ids, queue a single `ytsearch1:` download, then poll
+ * until a *new* item reaches a terminal (finished/error) state or we time out.
+ * One-at-a-time makes the "new id" detection unambiguous.
+ */
+async function queueAndAwaitDownload(
+  track: FallbackTrack,
+  query: string,
+  folder?: string
+): Promise<DownloadOutcome> {
+  let before: metube.MeTubeQueueResponse;
+  try {
+    before = await metube.getQueue();
+  } catch {
+    before = { done: {}, queue: {} };
+  }
+  const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
+
+  try {
+    await metube.addDownload({
+      url: buildYouTubeSearchUrl(query),
+      format: 'mp3',
+      quality: 'best',
+      folder,
+      custom_name_prefix: `${track.artist} - ${track.title}`,
+      auto_start: true,
+    });
+  } catch (err) {
+    return { errored: true, error: err instanceof Error ? err.message : 'MeTube add failed' };
+  }
+
+  const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
+  let seenId: string | undefined;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+
+    let q: metube.MeTubeQueueResponse;
+    try {
+      q = await metube.getQueue();
+    } catch {
+      continue;
+    }
+
+    // Terminal first: a new item in `done` is finished or errored.
+    const doneNew = Object.values(q.done).find((d) => !knownIds.has(d.id));
+    if (doneNew) {
+      if (doneNew.status === 'error') {
+        return { metubeId: doneNew.id, item: doneNew, errored: true, error: doneNew.msg || 'MeTube reported error' };
+      }
+      return { metubeId: doneNew.id, item: doneNew };
+    }
+
+    // Still in flight — remember the id so a timeout can still report it.
+    const queueNew = Object.values(q.queue).find((d) => !knownIds.has(d.id));
+    if (queueNew) seenId = queueNew.id;
+  }
+
+  return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
+}
+
+// ---------------------------------------------------------------------------
+// In-process job registry + batch runner
+// ---------------------------------------------------------------------------
+
+const jobs = new Map<string, FallbackJob>();
+
+/** Drop jobs older than this on the next start, so the map can't grow forever. */
+const JOB_TTL_MS = 6 * 60 * 60 * 1000;
+
+function pruneOldJobs() {
+  const cutoff = Date.now() - JOB_TTL_MS;
+  for (const [id, job] of jobs) {
+    if (job.status !== 'running' && job.updatedAt < cutoff) jobs.delete(id);
+  }
+}
+
+async function runJob(job: FallbackJob): Promise<void> {
+  for (let i = 0; i < job.results.length; i++) {
+    job.currentIndex = i;
+    const entry = job.results[i];
+    entry.status = 'searching';
+    entry.startedAt = Date.now();
+    job.updatedAt = Date.now();
+
+    console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
+
+    const outcome = await queueAndAwaitDownload(entry.track, entry.query, job.folder);
+    entry.metubeId = outcome.metubeId;
+    entry.finishedAt = Date.now();
+
+    if (outcome.item) {
+      entry.resultTitle = outcome.item.title;
+      entry.filename = outcome.item.filename;
+    }
+
+    if (outcome.errored || outcome.timedOut) {
+      entry.status = 'failed';
+      entry.error = outcome.error;
+      console.warn(`[YouTubeFallback] FAILED "${entry.track.artist} - ${entry.track.title}": ${entry.error}`);
+    } else if (job.verify && outcome.item) {
+      const verification = verifyDownload(entry.track, outcome.item);
+      entry.verification = verification;
+      entry.status = verification.matched ? 'downloaded' : 'mismatch';
+      console.log(
+        `[YouTubeFallback] ${entry.status.toUpperCase()} "${entry.track.artist} - ${entry.track.title}" (${verification.reason})`
+      );
+    } else {
+      entry.status = 'downloaded';
+      console.log(`[YouTubeFallback] DOWNLOADED "${entry.track.artist} - ${entry.track.title}"`);
+    }
+
+    job.updatedAt = Date.now();
+    if (i < job.results.length - 1) await sleep(BETWEEN_TRACKS_MS);
+  }
+
+  job.status = 'completed';
+  job.currentIndex = job.results.length;
+  job.updatedAt = Date.now();
+
+  const summary = summarizeJob(job);
+  console.log(
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.failed} failed (of ${summary.total})`
+  );
+}
+
+export function summarizeJob(job: FallbackJob): {
+  total: number;
+  pending: number;
+  searching: number;
+  downloaded: number;
+  mismatch: number;
+  failed: number;
+} {
+  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, failed: 0 };
+  for (const r of job.results) summary[r.status]++;
+  return summary;
+}
+
+/**
+ * Create and start a fallback job. Returns immediately with the job id; the
+ * batch runs one track at a time in the background. Throws on empty/oversized input.
+ */
+export function startYouTubeFallbackJob(
+  userId: string,
+  tracks: FallbackTrack[],
+  options: StartFallbackOptions = {}
+): FallbackJob {
+  pruneOldJobs();
+
+  const cleaned = tracks
+    .filter((t) => t && t.title && t.artist)
+    .slice(0, MAX_TRACKS_PER_JOB);
+
+  if (cleaned.length === 0) {
+    throw new Error('No valid tracks to download (each needs an artist and title)');
+  }
+
+  const now = Date.now();
+  const job: FallbackJob = {
+    id: crypto.randomUUID(),
+    userId,
+    status: 'running',
+    createdAt: now,
+    updatedAt: now,
+    verify: options.verify ?? true,
+    folder: options.folder,
+    currentIndex: 0,
+    results: cleaned.map((track) => ({
+      track,
+      query: normalizeSearchQuery(track),
+      status: 'pending' as FallbackTrackStatus,
+    })),
+  };
+
+  jobs.set(job.id, job);
+
+  // Fire-and-forget; a crash marks the job failed but never takes down the server.
+  runJob(job).catch((err) => {
+    job.status = 'failed';
+    job.updatedAt = Date.now();
+    console.error(`[YouTubeFallback] Job ${job.id} crashed:`, err);
+  });
+
+  return job;
+}
+
+/** Fetch a job, scoped to its owner. */
+export function getYouTubeFallbackJob(jobId: string, userId: string): FallbackJob | undefined {
+  const job = jobs.get(jobId);
+  if (!job || job.userId !== userId) return undefined;
+  return job;
+}

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -243,7 +243,8 @@ export function itemLikelyMatchesTrack(
 async function queueAndAwaitDownload(
   track: FallbackTrack,
   query: string,
-  folder?: string
+  folder: string | undefined,
+  claimedIds: Set<string>
 ): Promise<DownloadOutcome> {
   let before: metube.MeTubeQueueResponse;
   try {
@@ -252,15 +253,21 @@ async function queueAndAwaitDownload(
     before = { done: {}, queue: {} };
   }
 
+  // Content detection can't tell "the item I just queued" from some other item
+  // that loosely matches this track — including one already claimed by an earlier
+  // track in the same batch (e.g. "Song" vs "Song (Remix)"). Exclude claimed ids so
+  // each MeTube item is attributed to at most one track.
+  const matches = (d: MeTubeDownload) => !claimedIds.has(d.id) && itemLikelyMatchesTrack(track, d);
+
   // Ignore a pre-existing *errored* entry for this track (a stale prior failure);
   // but a pre-existing *finished* match means it's already downloaded — done.
   const staleErrorIds = new Set(
     Object.values(before.done)
-      .filter((d) => d.status === 'error' && itemLikelyMatchesTrack(track, d))
+      .filter((d) => d.status === 'error' && matches(d))
       .map((d) => d.id)
   );
   const preFinished = Object.values(before.done).find(
-    (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+    (d) => d.status === 'finished' && matches(d)
   );
   if (preFinished) {
     return { metubeId: preFinished.id, item: preFinished };
@@ -295,19 +302,19 @@ async function queueAndAwaitDownload(
     }
 
     const finished = Object.values(q.done).find(
-      (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+      (d) => d.status === 'finished' && matches(d)
     );
     if (finished) return { metubeId: finished.id, item: finished };
 
     const errored = Object.values(q.done).find(
-      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && itemLikelyMatchesTrack(track, d)
+      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && matches(d)
     );
     if (errored) {
       return { metubeId: errored.id, item: errored, errored: true, error: errored.msg || 'MeTube reported error' };
     }
 
     // Actively fetching? These downloads can take 5–10 min, so this matters.
-    if (Object.values(q.queue).some((d) => itemLikelyMatchesTrack(track, d))) {
+    if (Object.values(q.queue).some((d) => matches(d))) {
       sawInFlight = true;
     }
   }
@@ -397,28 +404,33 @@ async function cleanupErroredDownload(metubeId?: string): Promise<void> {
 
 /**
  * Queue a track and, on a *confirmed error*, retry up to `maxAttempts` (YouTube
- * 403 / PO-token errors are often transient). A slow download that merely timed
- * out while still fetching is NOT retried — retrying would re-queue a video that
- * is already downloading. Returns the final outcome plus the attempt count.
+ * 403 / PO-token errors are often transient). We retry ONLY confirmed errors:
+ * a bare timeout (nothing matching ever appeared) means the same `ytsearch1:`
+ * query would just re-resolve to the same video our content detection couldn't
+ * see — re-queuing it risks a duplicate/orphan file, not a better outcome. A
+ * still-in-flight timeout is likewise left alone (it's probably about to finish).
+ * Returns the final outcome plus the attempt count.
  */
 async function queueWithRetries(
   track: FallbackTrack,
   query: string,
   folder: string | undefined,
   maxAttempts: number,
-  label: string
+  label: string,
+  claimedIds: Set<string>
 ): Promise<DownloadOutcome & { attempts: number }> {
   let outcome: DownloadOutcome = {};
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    outcome = await queueAndAwaitDownload(track, query, folder);
+    outcome = await queueAndAwaitDownload(track, query, folder, claimedIds);
 
-    // Success, or a timeout on a still-in-flight download — don't retry either.
-    if ((!outcome.errored && !outcome.timedOut) || outcome.stillDownloading) {
+    // Anything but a confirmed error is terminal — success, mismatch-to-verify,
+    // still-downloading, or a bare timeout all stop here (see docstring).
+    if (!outcome.errored) {
       return { ...outcome, attempts: attempt };
     }
 
-    // Confirmed error (or nothing ever appeared) — clean up and retry.
-    if (outcome.errored) await cleanupErroredDownload(outcome.metubeId);
+    // Confirmed error — clean up the failed entry and retry.
+    await cleanupErroredDownload(outcome.metubeId);
 
     if (attempt < maxAttempts) {
       console.warn(
@@ -447,6 +459,9 @@ function pruneOldJobs() {
 }
 
 async function runJob(job: FallbackJob): Promise<void> {
+  // MeTube ids already attributed to an earlier track in this batch, so a shared
+  // loose-match (e.g. near-duplicate titles) can't be counted twice. See #2.
+  const claimedIds = new Set<string>();
   for (let i = 0; i < job.results.length; i++) {
     job.currentIndex = i;
     const entry = job.results[i];
@@ -473,10 +488,12 @@ async function runJob(job: FallbackJob): Promise<void> {
 
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
-    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
+    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label, claimedIds);
     entry.metubeId = outcome.metubeId;
     entry.attempts = outcome.attempts;
     entry.finishedAt = Date.now();
+    // Claim this MeTube item so a later, similarly-titled track can't reuse it.
+    if (outcome.metubeId) claimedIds.add(outcome.metubeId);
 
     if (outcome.item) {
       entry.resultTitle = outcome.item.title;

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -330,21 +330,50 @@ async function queueAndAwaitDownload(
  * causes the same track to be re-downloaded. Navidrome import is lazy so this
  * module stays importable in tests without pulling in the service graph.
  */
+type LibSong = { title?: string; name?: string; artist?: string };
+
+/**
+ * Does a Navidrome song correspond to the requested track? Unlike a MeTube item
+ * (whose title is the full "Artist - Title" video title), a Navidrome song keeps
+ * artist and title in separate fields — AND a junk-titled copy may carry the whole
+ * video title in `title`. So we accept a match on either shape:
+ *  - clean: title matches by containment/overlap AND the artist field matches, or
+ *  - junk:  the stored title contains both the requested title and artist tokens.
+ */
+export function libraryMatch(track: FallbackTrack, song: LibSong): boolean {
+  const gotTitle = normalizeForCompare(song.title || song.name || '');
+  const wantTitle = normalizeForCompare(track.title);
+  if (!gotTitle || !wantTitle) return false;
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+
+  const titleOk =
+    gotTitle.includes(wantTitle) || wantTitle.includes(gotTitle) || tokenOverlap(wantTitle, gotTitle) >= 0.6;
+  if (!titleOk) return false;
+
+  const gotArtist = normalizeForCompare(song.artist || '');
+  const artistOk =
+    wantArtist.length < 3 ||
+    gotArtist.includes(wantArtist) ||
+    wantArtist.includes(gotArtist) ||
+    tokenOverlap(wantArtist, gotArtist) >= 0.5 ||
+    // junk copy: artist is baked into the title string
+    gotTitle.includes(wantArtist) ||
+    tokenOverlap(wantArtist, gotTitle) >= 0.5;
+  return artistOk;
+}
+
 async function findInLibrary(track: FallbackTrack): Promise<{ title: string } | null> {
   try {
     const { search } = await import('./navidrome');
     const primaryArtist = (track.artist || '').split(/[;,]/)[0].trim();
     const query = normalizeSearchQuery(track); // "<primary artist> <clean title>"
-    const results = await search(query).catch(() => [] as Array<{ title?: string; name?: string }>);
-    const hit = results.find((s) =>
-      itemLikelyMatchesTrack(track, { title: s.title || s.name || '' })
-    );
+    const results = (await search(query).catch(() => [])) as LibSong[];
+    const hit = results.find((s) => libraryMatch(track, s));
     if (hit) return { title: hit.title || hit.name || '' };
-    // Fallback: an artist-only search catches copies whose stored title is the
-    // full "Artist - Title (ft…)" video title (loose match handles the rest).
+    // Fallback: artist-only search (catches title-mismatch / junk-title copies).
     if (primaryArtist.length > 2) {
-      const r2 = await search(primaryArtist).catch(() => [] as Array<{ title?: string; name?: string }>);
-      const hit2 = r2.find((s) => itemLikelyMatchesTrack(track, { title: s.title || s.name || '' }));
+      const r2 = (await search(primaryArtist).catch(() => [])) as LibSong[];
+      const hit2 = r2.find((s) => libraryMatch(track, s));
       if (hit2) return { title: hit2.title || hit2.name || '' };
     }
     return null;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as ApiDiscoveryFeedIndexRouteImport } from './routes/api/discover
 import { Route as ApiDiscoveryFeedAnalyticsRouteImport } from './routes/api/discovery-feed/analytics'
 import { Route as ApiDiscoveryFeedInteractionsRouteImport } from './routes/api/discovery-feed/interactions'
 import { Route as ApiDownloadsQueueRouteImport } from './routes/api/downloads/queue'
+import { Route as ApiDownloadsYoutubeFallbackRouteImport } from './routes/api/downloads/youtube-fallback'
 import { Route as ApiLastfmBackfillRouteImport } from './routes/api/lastfm/backfill'
 import { Route as ApiLastfmSearchRouteImport } from './routes/api/lastfm/search'
 import { Route as ApiLastfmSimilarArtistsRouteImport } from './routes/api/lastfm/similar-artists'
@@ -549,6 +550,12 @@ const ApiDownloadsQueueRoute = ApiDownloadsQueueRouteImport.update({
   path: '/api/downloads/queue',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiDownloadsYoutubeFallbackRoute =
+  ApiDownloadsYoutubeFallbackRouteImport.update({
+    id: '/api/downloads/youtube-fallback',
+    path: '/api/downloads/youtube-fallback',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiLastfmBackfillRoute = ApiLastfmBackfillRouteImport.update({
   id: '/api/lastfm/backfill',
   path: '/api/lastfm/backfill',
@@ -1237,6 +1244,7 @@ export interface FileRoutesByFullPath {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1420,6 +1428,7 @@ export interface FileRoutesByTo {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1607,6 +1616,7 @@ export interface FileRoutesById {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1794,6 +1804,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -1977,6 +1988,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -2163,6 +2175,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -2338,6 +2351,7 @@ export interface RootRouteChildren {
   ApiDiscoveryFeedAnalyticsRoute: typeof ApiDiscoveryFeedAnalyticsRoute
   ApiDiscoveryFeedInteractionsRoute: typeof ApiDiscoveryFeedInteractionsRoute
   ApiDownloadsQueueRoute: typeof ApiDownloadsQueueRoute
+  ApiDownloadsYoutubeFallbackRoute: typeof ApiDownloadsYoutubeFallbackRoute
   ApiLastfmBackfillRoute: typeof ApiLastfmBackfillRoute
   ApiLastfmSearchRoute: typeof ApiLastfmSearchRoute
   ApiLastfmSimilarArtistsRoute: typeof ApiLastfmSimilarArtistsRoute
@@ -2914,6 +2928,13 @@ declare module '@tanstack/react-router' {
       path: '/api/downloads/queue'
       fullPath: '/api/downloads/queue'
       preLoaderRoute: typeof ApiDownloadsQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/downloads/youtube-fallback': {
+      id: '/api/downloads/youtube-fallback'
+      path: '/api/downloads/youtube-fallback'
+      fullPath: '/api/downloads/youtube-fallback'
+      preLoaderRoute: typeof ApiDownloadsYoutubeFallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/lastfm/backfill': {
@@ -3960,6 +3981,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiDiscoveryFeedAnalyticsRoute: ApiDiscoveryFeedAnalyticsRoute,
   ApiDiscoveryFeedInteractionsRoute: ApiDiscoveryFeedInteractionsRoute,
   ApiDownloadsQueueRoute: ApiDownloadsQueueRoute,
+  ApiDownloadsYoutubeFallbackRoute: ApiDownloadsYoutubeFallbackRoute,
   ApiLastfmBackfillRoute: ApiLastfmBackfillRoute,
   ApiLastfmSearchRoute: ApiLastfmSearchRoute,
   ApiLastfmSimilarArtistsRoute: ApiLastfmSimilarArtistsRoute,

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -43,6 +43,7 @@ const StartSchema = z
     verify: z.boolean().optional(),
     folder: z.string().optional(),
     maxAttempts: z.number().int().min(1).max(5).optional(),
+    skipInLibrary: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.tracks?.length && !data.importJobId) {
@@ -106,6 +107,7 @@ const POST = withAuthAndErrorHandling(
         verify: data.verify,
         folder: data.folder,
         maxAttempts: data.maxAttempts,
+        skipInLibrary: data.skipInLibrary,
       });
     } catch (err) {
       return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -1,0 +1,185 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { playlistImportJobs } from '../../../lib/db/schema/playlist-export.schema';
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+  errorResponse,
+} from '../../../lib/utils/api-response';
+import {
+  startYouTubeFallbackJob,
+  getYouTubeFallbackJob,
+  summarizeJob,
+  MAX_TRACKS_PER_JOB,
+  type FallbackTrack,
+} from '../../../lib/services/youtube-fallback';
+
+/**
+ * Per-song YouTube (MeTube) fallback download — issue #145.
+ *
+ * POST: start a job. Provide either an explicit `tracks` array, or an
+ * `importJobId` to pull the misses (no_match / pending_review by default) from a
+ * finished playlist import. Downloads run one at a time and are verified against
+ * the requested artist/title. Returns a `jobId` to poll.
+ *
+ * GET ?jobId=…: report per-track status + a summary.
+ */
+
+const TrackSchema = z.object({
+  artist: z.string().min(1),
+  title: z.string().min(1),
+  album: z.string().optional(),
+  duration: z.number().optional(),
+});
+
+const StartSchema = z
+  .object({
+    tracks: z.array(TrackSchema).optional(),
+    importJobId: z.string().uuid().optional(),
+    // Which import statuses to pull when importJobId is used.
+    statuses: z.array(z.enum(['no_match', 'pending_review', 'matched', 'skipped'])).optional(),
+    verify: z.boolean().optional(),
+    folder: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.tracks?.length && !data.importJobId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide either `tracks` or `importJobId`',
+      });
+    }
+  });
+
+const POST = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const body = await request.json();
+    const data = StartSchema.parse(body);
+
+    let tracks: FallbackTrack[];
+
+    if (data.tracks?.length) {
+      tracks = data.tracks;
+    } else {
+      // Pull misses from a finished import job (scoped to this user).
+      const importJob = await db
+        .select()
+        .from(playlistImportJobs)
+        .where(
+          and(
+            eq(playlistImportJobs.id, data.importJobId!),
+            eq(playlistImportJobs.userId, session.user.id)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0]);
+
+      if (!importJob) {
+        return errorResponse('NOT_FOUND', 'Import job not found', { status: 404 });
+      }
+
+      const wanted = new Set(data.statuses ?? ['no_match', 'pending_review']);
+      const results = importJob.matchResults ?? [];
+      tracks = results
+        .filter((r) => wanted.has(r.status))
+        .map((r) => ({
+          artist: r.originalSong.artist,
+          title: r.originalSong.title,
+          album: r.originalSong.album,
+          duration: r.originalSong.duration,
+        }));
+
+      if (tracks.length === 0) {
+        return errorResponse(
+          'NO_TRACKS',
+          `Import job has no tracks in status: ${[...wanted].join(', ')}`,
+          { status: 400 }
+        );
+      }
+    }
+
+    let job;
+    try {
+      job = startYouTubeFallbackJob(session.user.id, tracks, {
+        verify: data.verify,
+        folder: data.folder,
+      });
+    } catch (err) {
+      return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {
+        status: 400,
+      });
+    }
+
+    const truncated = tracks.length > MAX_TRACKS_PER_JOB;
+
+    return successResponse(
+      {
+        jobId: job.id,
+        status: job.status,
+        total: job.results.length,
+        verify: job.verify,
+        truncated,
+        message: truncated
+          ? `Started per-song YouTube download for the first ${MAX_TRACKS_PER_JOB} of ${tracks.length} tracks.`
+          : `Started per-song YouTube download for ${job.results.length} track(s).`,
+      },
+      202
+    );
+  },
+  {
+    service: 'downloads/youtube-fallback',
+    operation: 'start',
+    defaultCode: 'YT_FALLBACK_ERROR',
+    defaultMessage: 'Failed to start YouTube fallback download',
+  }
+);
+
+const GET = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const url = new URL(request.url);
+    const jobId = url.searchParams.get('jobId');
+    if (!jobId) {
+      return errorResponse('VALIDATION_ERROR', 'jobId is required', { status: 400 });
+    }
+
+    const job = getYouTubeFallbackJob(jobId, session.user.id);
+    if (!job) {
+      return errorResponse('NOT_FOUND', 'Job not found (it may have expired)', { status: 404 });
+    }
+
+    return successResponse({
+      jobId: job.id,
+      status: job.status,
+      verify: job.verify,
+      currentIndex: job.currentIndex,
+      summary: summarizeJob(job),
+      results: job.results.map((r) => ({
+        artist: r.track.artist,
+        title: r.track.title,
+        query: r.query,
+        status: r.status,
+        resultTitle: r.resultTitle,
+        verification: r.verification,
+        error: r.error,
+      })),
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+    });
+  },
+  {
+    service: 'downloads/youtube-fallback',
+    operation: 'status',
+    defaultCode: 'YT_FALLBACK_STATUS_ERROR',
+    defaultMessage: 'Failed to get YouTube fallback status',
+  }
+);
+
+export const Route = createFileRoute('/api/downloads/youtube-fallback')({
+  server: {
+    handlers: {
+      POST,
+      GET,
+    },
+  },
+});

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -42,6 +42,7 @@ const StartSchema = z
     statuses: z.array(z.enum(['no_match', 'pending_review', 'matched', 'skipped'])).optional(),
     verify: z.boolean().optional(),
     folder: z.string().optional(),
+    maxAttempts: z.number().int().min(1).max(5).optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.tracks?.length && !data.importJobId) {
@@ -104,6 +105,7 @@ const POST = withAuthAndErrorHandling(
       job = startYouTubeFallbackJob(session.user.id, tracks, {
         verify: data.verify,
         folder: data.folder,
+        maxAttempts: data.maxAttempts,
       });
     } catch (err) {
       return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {
@@ -152,6 +154,7 @@ const GET = withAuthAndErrorHandling(
       jobId: job.id,
       status: job.status,
       verify: job.verify,
+      maxAttempts: job.maxAttempts,
       currentIndex: job.currentIndex,
       summary: summarizeJob(job),
       results: job.results.map((r) => ({
@@ -161,6 +164,7 @@ const GET = withAuthAndErrorHandling(
         status: r.status,
         resultTitle: r.resultTitle,
         verification: r.verification,
+        attempts: r.attempts,
         error: r.error,
       })),
       createdAt: job.createdAt,


### PR DESCRIPTION
Closes #145.

## What
Fetches playlist-import misses straight from YouTube via MeTube, **one at a time**, using yt-dlp's `ytsearch1:` search syntax — **no YouTube API key / OAuth**. Fills the gap where the old `queueMetubeDownload` bailed with *"No YouTube video ID available"*, and gives the Lidarr "0 albums" dead-end (#144) a working alternative.

Each download is **verified** against the requested artist/title, so wrong-video / live / hour-long-mix / channel-rip results are flagged (`mismatch`) instead of silently polluting the library. Landed files are named `Artist - Title` and drop into MeTube's folder for the existing **Picard retag → Lidarr move → Navidrome rescan** flow. Stops at *downloaded + verified*; reconciling back into the playlist stays with the Import Manager (#132).

## Changes
- **`src/lib/services/youtube-fallback.ts`** — pure helpers (`normalizeSearchQuery`, `buildYouTubeSearchUrl`, `verifyDownload`) + one-at-a-time batch runner with an in-process job registry (no new DB table; mirrors media-flow-manager). Cap 50 tracks/job.
- **`src/routes/api/downloads/youtube-fallback.ts`** (session-authed) — `POST` starts a job from explicit `tracks[]` **or** an `importJobId` (pulls `no_match` + `pending_review` by default); `GET ?jobId=` polls per-track status + summary.
- **`src/lib/services/__tests__/youtube-fallback.test.ts`** — 11 tests on the pure helpers.
- **`src/routeTree.gen.ts`** — surgical registration of the new route (mirrors the `/api/downloads/queue` sibling; +22 lines, no reorder churn).

Per-track lifecycle: `pending → searching → downloaded | mismatch | failed`.

## Checks
- Typecheck: **0 new errors** (total unchanged at the pre-existing baseline).
- Lint: clean (2 deprecation warnings identical to the sibling `import.ts` conventions).
- Tests: **11/11** green.

## How to test
```bash
# From the "Late aug" import job (pulls its no_match + pending_review misses):
curl -s -X POST /api/downloads/youtube-fallback -H 'Content-Type: application/json' -b <cookie> \
  -d '{"importJobId":"01cb5639-dbff-4f81-b415-c71240551ada"}'
curl -s '/api/downloads/youtube-fallback?jobId=<jobId>' -b <cookie>
```
Then run the Picard flow against the landed files. Server logs show `[YouTubeFallback]` per track.

## Runtime assumption to confirm on first run
This path calls the MeTube service **directly** (bypassing `/api/metube/add`, which whitelists real site URLs), so it relies on the deployed MeTube accepting a non-URL `ytsearch1:…` value (yt-dlp supports it; MeTube passes `url` straight through). If rejected, fall back to resolving a video id via `youtube-music.ts` search first.

## Not in this PR (follow-ups)
- UI button (API-only for now).
- Persistence across redeploy (in-memory job state — fine for a testing tool).
- Auto-trigger from the Lidarr "0 albums" dead-end (the #144 → #145 join).

## Related
#144 (upstream: misses that never queue) · #132 (reconcile arrivals back into the playlist) · #131 (matcher). Design notes in `docs/design/youtube-per-song-fallback.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EssvghF6669EHaTFDwRMDq