### PR TITLE
feat: per-song YouTube/MeTube fallback (#145) + library-reconciliation prod boot

### DIFF
--- a/docs/design/library-reconciliation-notes.md
+++ b/docs/design/library-reconciliation-notes.md
@@ -1,0 +1,39 @@
+# Library Reconciliation: Lessons Learned
+
+## The Problem
+When Picard retags MeTube downloads and Lidarr moves them to proper artist folders,
+Navidrome creates new song IDs for the files at their new paths. The old IDs become
+"metadata ghosts" — `getSong` still returns data (Navidrome's DB hasn't been cleaned),
+but the actual file is gone and streaming returns an XML error instead of audio.
+
+## Key Insight: Metadata Check Is Not Enough
+`getSongsByIds` will succeed for ghost entries — Navidrome keeps the metadata row even
+after the file is deleted/moved. The ONLY reliable check is a HEAD request on the
+`/rest/stream` endpoint: if `Content-Type` is `application/xml` instead of `audio/*`,
+the file is gone.
+
+## Duplicate Key Handling
+When remapping old ID → new ID, the new ID may already exist in `liked_songs_sync`,
+`playlist_songs`, or `recommendation_feedback` (if the user re-liked the song after
+Picard retagged it). The correct action is to DELETE the old ghost row rather than
+failing on the unique constraint.
+
+## MeTube Download Patterns
+MeTube downloads have distinctive patterns:
+- Path: `Artist/[Unknown Album]/Artist - Title.mp3`
+- Title field often contains `Artist - Title` (the full YouTube title)
+- Artist field may contain the YouTube channel name, not the actual artist
+- After Picard: path becomes `Artist/Album/## - Title.flac`
+
+## Channel Name Pollution
+Some broken entries had YouTube channel names as the artist:
+- "Chill Nation", "Majestic Casual", "Music Disc Lyrics", "DEEP OBELISK",
+  "Toolroom Records", "MUTATE", "SUBSIDIA"
+These won't match the real artist in a search. The 11 songs that couldn't be
+auto-remapped were mostly this pattern.
+
+## Stats from 2026-07-30 Manual Run
+- 3641 total song IDs checked across liked_songs_sync + playlist_songs
+- 57 broken (stream returns XML, not audio)
+- 46 successfully remapped to new IDs
+- 11 truly missing (channel name as artist, not in library)

--- a/docs/design/library-reconciliation-prod-init.md
+++ b/docs/design/library-reconciliation-prod-init.md
@@ -1,0 +1,151 @@
+# Why `library-reconciliation` never runs on prod — root cause + fix
+
+**Date:** 2026-08-18
+**Status:** ✅ Built (steps 1–3), pending deploy. See "Implementation" below.
+**Context:** Prerequisite for the download→rescan→re-match reconciler (see the
+E2E pipeline gap: "new songs not added"). Reconciliation owns the only Navidrome
+`startScan` + ghost-star cleanup in the app; if it never runs, nothing downstream
+that depends on a library scan can work automatically.
+
+---
+
+## TL;DR
+
+The library-reconciliation scheduled job **has never run a single time** on the
+current prod container. Root cause: **nothing initializes it.** Its schedule is an
+in-process `setTimeout` that is only ever armed by `initialize()`, and
+`initialize()` is called from exactly two API routes that **no client ever hits**.
+The prod server entry (`server.ts`) boots WebSockets but does **not** bootstrap any
+background job. Fix: initialize reconciliation at prod boot in `server.ts`, run it
+shortly after start, and (for durability against redeploys) drive the cadence from
+a persisted `next_run_at` rather than a long-lived in-memory timer.
+
+---
+
+## Evidence (prod, container up since 2026-08-14 19:35 UTC — ~4 days)
+
+- Entry confirmed: container `Cmd = [npx tsx server.ts]`; logs show
+  `[Server] Listening on http://0.0.0.0:3000`.
+- `[LibraryReconciliation]` log lines on the live container:
+  - `Initialized` → **0**
+  - `Next run at …` → **0**
+  - `Done: … checked …` → **0**
+- Expected at 6h cadence over 4 days: ~16 runs. Actual: **0**.
+- No reconcile-adjacent log lines of any kind (no trigger-route hits either).
+
+## The three-layer root cause
+
+### 1. Schedule is in-process and only armed by `initialize()`
+`src/lib/services/library-reconciliation.ts`:
+- Singleton (`getInstance`) with a private `constructor()` — creating/looking up the
+  manager does **not** schedule anything.
+- `scheduleNextRun()` (the only thing that arms the `setTimeout`) is called from
+  `initialize()`, `start()`, and after each `triggerNow()`. So with no
+  `initialize()`/`start()`/`triggerNow()`, `nextRunAt` stays null forever.
+
+### 2. `initialize()` is only reachable from routes nothing calls
+- `initializeReconciliation(userId)` is invoked **only** from:
+  - `src/routes/api/library-reconciliation/status.ts`
+  - `src/routes/api/library-reconciliation/trigger.ts`
+- Grep for client fetches of `/api/library-reconciliation/*` in `src/**` → **none**.
+- The Tasks UI *does* surface reconciliation, but via
+  `task-aggregator.ts` → `getReconciliationManager()` + `getStatus()`. That returns
+  the singleton and reads status; it **never calls `initialize()`**. So even opening
+  the Tasks page does not start the loop.
+
+**Contrast — why background-discovery *does* self-start:** its `status.ts` route
+calls `initializeBackgroundDiscovery(userId, …)`, **and** a client store
+(`src/lib/stores/discovery-suggestions.ts`) polls `/api/background-discovery/status`
+whenever the Discover page is open. Reconciliation has neither a client poller nor a
+boot hook, so its lazy-init trigger never fires.
+
+### 3. Prod server entry bootstraps nothing
+- `server.ts` `start()` (the real prod boot path) sets up the HTTP handler + the
+  playback WebSocket, then `server.listen(...)`. It never imports or initializes any
+  background service (reconciliation, discovery, lastfm-backfill, session-materializer).
+- The dev-only equivalent, `vite-ws-plugin.ts::configureServer`, is a **Vite
+  dev-server hook** — it does not run in the `node-server` production build either.
+- Net: **there is no production boot hook that starts background jobs.**
+
+## Secondary issues surfaced (worth fixing alongside)
+
+- **In-memory timer resets on every redeploy.** Even once initialized, the 6h
+  `setTimeout` lives in process memory. A Coolify redeploy (frequent) wipes it. If
+  redeploys land < 6h apart, a boot-armed timer would *never* fire. (This container
+  happened to survive 4 days, so boot-init alone would have fired ~16×.)
+- **Single-user singleton.** `initialize(userId)` binds the one singleton to one
+  user, but reconciliation reconciles *that user's* liked/feedback/playlist song IDs.
+  Fine for Juan's single-admin setup; a latent bug for multi-user.
+
+## Fix
+
+### Recommended: initialize at prod boot in `server.ts`, cadence from DB
+1. In `server.ts::start()` (after `server.listen`), call
+   `initializeReconciliation(<adminUserId>)` for the admin/owner user (the same
+   account used for shared Navidrome ops). Wrap in try/catch so a failure never
+   blocks the server.
+2. Kick a first run shortly after boot (e.g. 2–5 min delay, not a full 6h) so a
+   fresh deploy reconciles soon rather than only 6h later. This also neutralizes the
+   redeploy-resets-timer problem for the common case.
+3. **Durability:** persist `last_run_at` / `next_run_at` (e.g. a small
+   `reconciliation_state` row, or reuse an existing settings table). On boot, compute
+   the first delay as `max(0, next_run_at - now)` instead of always a fresh 6h, so
+   cadence survives restarts. Optionally replace the long `setTimeout` with a short
+   heartbeat interval (e.g. every 15 min) that checks "is it due?" — more robust than
+   a single multi-hour timer.
+
+**Why here:** `server.ts` is the one place guaranteed to run once per prod process
+start, already async, already the home of the other server-lifetime concern (WS).
+
+### Alternative: external scheduler → trigger route
+Have Coolify (or host cron / a sidecar) `POST /api/library-reconciliation/trigger`
+every 6h. The trigger route already lazy-inits + runs.
+- Pros: durable across restarts by construction; observable via HTTP status.
+- Cons: the route is `withAuthAndErrorHandling` (session-authed) and keys off
+  `session.user.id`, so cron needs a valid admin session/token, and the run is tied
+  to whichever user the token belongs to. Needs infra config outside the app.
+- Verdict: viable, but boot-init keeps everything in-repo and avoids a service token.
+
+### Not sufficient alone
+- Adding a client poller for the status endpoint (mirroring discovery) would only run
+  reconciliation while a user has a specific page open — fragile and user-dependent.
+
+## Suggested implementation order
+1. Boot-init in `server.ts` + first-run-soon (fixes the "never runs" bug immediately).
+2. Persist `next_run_at` and derive the boot delay from it (fixes redeploy resets).
+3. Only then build the download→rescan→re-match reconciler on top (the E2E fix that
+   depends on scans actually happening).
+
+## Implementation (built 2026-08-18)
+
+- **New table `library_reconciliation_state`** (PK `user_id`) — mirrors
+  `discovery_job_state`. Schema: `src/lib/db/schema/library-reconciliation.schema.ts`,
+  re-exported from `schema/index.ts`. Migration `drizzle/0029_library_reconciliation_state.sql`
+  — **already applied to prod** (additive CREATE TABLE + 2 indexes + FK).
+- **Persistence + resume** in `library-reconciliation.ts`:
+  - `initialize()` is now idempotent (boot hook + status/trigger routes won't stack
+    timers), loads persisted state, and schedules from `next_run_at` if it's in the
+    future, else `FIRST_RUN_DELAY_MS` (3 min) for overdue/never-run.
+  - `loadState()`/`saveState()` (upsert) persist enabled/frequency/last_run_at/
+    next_run_at/is_running/last_error/last_result. Persisted on init, run start,
+    run finish, start(), stop().
+- **Boot hook** `bootstrapBackgroundJobs()` in `server.ts`, called fire-and-forget
+  after `server.listen`. Resolves the owner as `RECONCILIATION_USER_ID` env →
+  earliest `role='admin'` user → earliest user (→ Juan on prod). Failures never block
+  startup.
+
+**Activates on next deploy** (`npx tsx server.ts` boot). Expected logs:
+`[Server] Library reconciliation bootstrapped for user …` then
+`[LibraryReconciliation] Initialized … next run …`, and ~3 min later `Done: … checked …`.
+
+**Not yet done:** step 3's optional heartbeat-interval variant (kept the resume-from-
+`next_run_at` approach instead), and the multi-user singleton limitation (still runs
+for one owner user only). The download→rescan→re-match reconciler builds on top of this.
+
+## Files
+- `src/lib/services/library-reconciliation.ts` — singleton, `initialize`,
+  `scheduleNextRun`, `triggerNow` (lines ~88–188).
+- `src/routes/api/library-reconciliation/{status,trigger}.ts` — only init callers.
+- `src/lib/services/task-aggregator.ts` (~265) — surfaces status without init.
+- `server.ts` — prod boot entry; **proposed init site**.
+- `vite-ws-plugin.ts` — dev-only `configureServer` (not a prod hook).

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -50,7 +50,35 @@ video ID available" — this fills exactly that gap.
 
 - `downloaded` — finished + verification passed (or verify disabled).
 - `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
-- `failed` — MeTube error or 5-min timeout.
+- `failed` — MeTube error or 5-min timeout, after exhausting retries.
+
+## Retries (added after the first prod test)
+
+YouTube download failures are frequently transient — see the PO-token finding
+below — so each track is retried up to `maxAttempts` (default 3, ceiling 5,
+overridable per request). Between attempts the failed MeTube entry is deleted so
+the same `ytsearch1:`-resolved id can be re-queued cleanly. The per-track
+`attempts` count is surfaced in the GET status.
+
+## Prod finding: MeTube PO-token / 403 (2026-08-18 first live test)
+
+First live test track (`ytsearch1:Sun Room Insincere`) confirmed the search
+resolves to the correct video ("Sun Room - Insincere [Official Audio]"), but the
+download itself errored:
+
+```
+[youtube] [pot:bgutil:http] Error reaching GET http://127.0.0.1:4416/ping …
+ERROR: unable to download video data: HTTP Error 403: Forbidden
+```
+
+yt-dlp wants a PO token from a bgutil provider at `127.0.0.1:4416` that is
+unreachable, so token-gated videos 403. **This is a MeTube/yt-dlp ops issue,
+independent of this feature**, but it caps the fallback's real-world success rate
+until the POT provider is running/reachable (or yt-dlp is pointed at a client
+that doesn't require the token). Retries help ride out the transient cases.
+
+Also fixed from that test: dropped `custom_name_prefix`, which had doubled the
+title (`"Sun Room - Insincere.Sun Room - Insincere [Official Audio]"`).
 
 ## How to test (Juan)
 

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -112,11 +112,18 @@ non-URL `url` (it does not go through `/api/metube/add`, which whitelists real
 site URLs; this path calls the MeTube service directly). If MeTube rejects it,
 fall back to resolving a video id via `youtube-music.ts` search first.
 
+## UI (added)
+
+The import wizard's **Confirmation step** "Download Missing Songs" dialog now has a
+**Lidarr / YouTube** toggle. Picking **YouTube** POSTs the selected `no_match`
+tracks (plus the `importJobId`) to `/api/downloads/youtube-fallback` instead of the
+Lidarr queue — so "after review, send the misses to MeTube" is a one-click action.
+`src/components/playlists/import/steps/confirmation-step.tsx`.
+
 ## Not built (follow-ups)
 
-- **UI.** No button yet — API only. The existing `/downloads/youtube` page is a
-  manual URL paste; a "download import misses" action could live there or in the
-  import review UI.
+- **Live per-track status in the UI.** The button starts the job and toasts; it
+  doesn't yet poll `GET ?jobId=` to show downloaded/mismatch/failed per track.
 - **Persistence.** Job state is in-memory (lost on redeploy). Fine for a testing
   tool; if this becomes a durable auto-fallback, fold it into the Import Manager (#132).
 - **Auto-trigger.** Currently manual. Wiring "Lidarr 0-albums → auto YouTube

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -1,0 +1,95 @@
+# Per-song YouTube (MeTube) fallback — issue #145
+
+**Date:** 2026-08-18
+**Status:** ✅ Built (backend + API + tests), pending deploy. No UI yet.
+
+## What this solves
+
+Playlist-import "misses" are sent to Lidarr, but a large fraction dead-end at
+"artist has 0 albums" (issue #144) and silently never download. This adds a
+second path: fetch each missed track **straight from YouTube via MeTube, one at a
+time**, using yt-dlp's `ytsearch1:` search syntax — **no YouTube API key / OAuth
+required**. Each result is verified against the requested artist/title so obvious
+wrong-video / live / mix / channel-rip results are flagged instead of silently
+polluting the library.
+
+The landed file is named `Artist - Title` and drops into MeTube's download
+folder, where the existing **Picard retag → Lidarr move → Navidrome rescan** flow
+picks it up. This module stops at "downloaded + verified"; reconciling the track
+back into the originating playlist is owned by the Import Manager (#132).
+
+## Why `ytsearch1:` and not the YouTube API
+
+`youtube-music.ts` exists but needs a Google API key + OAuth + quota. MeTube
+passes its `url` field straight to yt-dlp, and `ytsearch1:<query>` tells yt-dlp
+"download the top YouTube result for this query." Zero extra config. The prior
+`queueMetubeDownload` (playlist-download.ts) explicitly bailed with "No YouTube
+video ID available" — this fills exactly that gap.
+
+## Pieces
+
+- **`src/lib/services/youtube-fallback.ts`**
+  - `normalizeSearchQuery(track)` — primary artist + de-noised title.
+  - `buildYouTubeSearchUrl(query)` → `ytsearch1:…`.
+  - `verifyDownload(track, item)` — fuzzy title/artist check → `{ matched, score, reason }`.
+  - `queueAndAwaitDownload` — snapshots MeTube ids, queues one download, polls until
+    a *new* item reaches finished/error (one-at-a-time makes the new-id detection
+    unambiguous). 3s poll, 5-min per-track timeout.
+  - `startYouTubeFallbackJob` / `getYouTubeFallbackJob` — in-process job registry
+    (diagnostic/testing path polled while the page is open; no new DB table, mirrors
+    media-flow-manager). Cap `MAX_TRACKS_PER_JOB = 50`.
+- **`src/routes/api/downloads/youtube-fallback.ts`** (session-authed)
+  - `POST` — start a job from an explicit `tracks[]` **or** an `importJobId`
+    (pulls `no_match` + `pending_review` originals by default). Returns `{ jobId, total }`.
+  - `GET ?jobId=…` — per-track status + summary.
+- **`src/lib/services/__tests__/youtube-fallback.test.ts`** — 11 tests on the pure helpers.
+
+## Per-track status model
+
+`pending → searching → downloaded | mismatch | failed`
+
+- `downloaded` — finished + verification passed (or verify disabled).
+- `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
+- `failed` — MeTube error or 5-min timeout.
+
+## How to test (Juan)
+
+Start from the "Late aug" import misses (or any import job id):
+
+```bash
+# From a finished import job — pulls its no_match + pending_review tracks:
+curl -s -X POST https://<app>/api/downloads/youtube-fallback \
+  -H 'Content-Type: application/json' -b <session-cookie> \
+  -d '{"importJobId":"01cb5639-dbff-4f81-b415-c71240551ada"}'
+
+# Or explicit tracks:
+curl -s -X POST https://<app>/api/downloads/youtube-fallback \
+  -H 'Content-Type: application/json' -b <session-cookie> \
+  -d '{"tracks":[{"artist":"Sun Room","title":"Insincere"},
+                 {"artist":"Josh Baker","title":"My Place"},
+                 {"artist":"A. G. Cook","title":"Idyll"}]}'
+
+# Poll:
+curl -s "https://<app>/api/downloads/youtube-fallback?jobId=<jobId>" -b <session-cookie>
+```
+
+Watch server logs for `[YouTubeFallback]` lines. Then confirm the downloaded files
+land in MeTube's folder and run the Picard retag flow against them → Lidarr moves →
+Navidrome rescans → reconciliation remaps any ghost id → track is playable.
+
+## Runtime assumption to confirm on first run
+
+MeTube forwards `ytsearch1:` to yt-dlp — verify the deployed MeTube accepts a
+non-URL `url` (it does not go through `/api/metube/add`, which whitelists real
+site URLs; this path calls the MeTube service directly). If MeTube rejects it,
+fall back to resolving a video id via `youtube-music.ts` search first.
+
+## Not built (follow-ups)
+
+- **UI.** No button yet — API only. The existing `/downloads/youtube` page is a
+  manual URL paste; a "download import misses" action could live there or in the
+  import review UI.
+- **Persistence.** Job state is in-memory (lost on redeploy). Fine for a testing
+  tool; if this becomes a durable auto-fallback, fold it into the Import Manager (#132).
+- **Auto-trigger.** Currently manual. Wiring "Lidarr 0-albums → auto YouTube
+  fallback" is the #144 + #145 join.

--- a/docs/design/youtube-per-song-fallback.md
+++ b/docs/design/youtube-per-song-fallback.md
@@ -52,6 +52,28 @@ video ID available" — this fills exactly that gap.
 - `mismatch` — finished, but the result title doesn't look like the request (review before trusting).
 - `failed` — MeTube error or 5-min timeout, after exhausting retries.
 
+## Detection fix (after the first real batch, 2026-08-18)
+
+The first 16-track batch **false-failed** tracks that actually downloaded fine.
+Root cause: detection matched a *new MeTube id not in a pre-snapshot*, and the
+5-min per-attempt timeout fired **seconds before** these slow (5–10 min) downloads
+landed — then retried, re-adding a video already downloading, and could delete the
+in-flight item. Proof: Skank N Flex finished 11 s after the timeout; Got Bounce /
+HeadRush 6 s after.
+
+Fixes:
+- **Content-based detection** (`itemLikelyMatchesTrack`): match MeTube items by
+  title-token overlap + primary artist, not id-novelty. Survives MeTube's id-dedup
+  of already-downloaded videos and finds the item whenever it lands. A pre-existing
+  `finished` match returns immediately (idempotent re-sends).
+- **Patient window** raised to 12 min; a track still actively fetching when the
+  window closes is reported **`downloading`** (new status), *not* `failed`, and is
+  never deleted or retried.
+- **Retries only on confirmed errors** (403/PO-token), never on a slow-but-in-flight
+  download.
+
+Status model gains `downloading` (submitted, still fetching, unconfirmed).
+
 ## Retries (added after the first prod test)
 
 YouTube download failures are frequently transient — see the PO-token finding

--- a/drizzle/0029_library_reconciliation_state.sql
+++ b/drizzle/0029_library_reconciliation_state.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "library_reconciliation_state" (
+	"user_id" text PRIMARY KEY NOT NULL,
+	"enabled" boolean DEFAULT true NOT NULL,
+	"frequency_hours" integer DEFAULT 6 NOT NULL,
+	"last_run_at" timestamp,
+	"next_run_at" timestamp,
+	"is_running" boolean DEFAULT false NOT NULL,
+	"last_error" text,
+	"last_result" jsonb,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "library_reconciliation_state" ADD CONSTRAINT "library_reconciliation_state_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "library_reconciliation_state_next_run_at_idx" ON "library_reconciliation_state" USING btree ("next_run_at");--> statement-breakpoint
+CREATE INDEX "library_reconciliation_state_enabled_idx" ON "library_reconciliation_state" USING btree ("enabled");

--- a/drizzle/meta/0029_snapshot.json
+++ b/drizzle/meta/0029_snapshot.json
@@ -1,0 +1,8089 @@
+{
+  "id": "5ca6ee5f-9169-4a43-af6d-f2a812cbb4c5",
+  "prevId": "b08d7413-cf83-41b7-838d-f3a317510fdf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendations_cache": {
+      "name": "recommendations_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prompt_hash": {
+          "name": "prompt_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendations": {
+          "name": "recommendations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "quality_score": {
+          "name": "quality_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_count": {
+          "name": "feedback_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "recommendations_cache_user_id_user_id_fk": {
+          "name": "recommendations_cache_user_id_user_id_fk",
+          "tableFrom": "recommendations_cache",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "impersonated_by": {
+          "name": "impersonated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.two_factor": {
+      "name": "two_factor",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "backup_codes": {
+          "name": "backup_codes",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "two_factor_user_id_user_id_fk": {
+          "name": "two_factor_user_id_user_id_fk",
+          "tableFrom": "two_factor",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'user'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "two_factor_enabled": {
+          "name": "two_factor_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_preferences": {
+      "name": "user_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_settings": {
+          "name": "recommendation_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"aiEnabled\":true,\"frequency\":\"always\",\"styleBasedPlaylists\":true,\"useFeedbackForPersonalization\":true,\"enableSeasonalRecommendations\":true,\"syncFeedbackToNavidrome\":true,\"aiDJEnabled\":false,\"aiDJQueueThreshold\":2,\"aiDJBatchSize\":3,\"aiDJUseCurrentContext\":true,\"aiDJGenreExploration\":50,\"autoplayEnabled\":false,\"autoplayBlendMode\":\"crossfade\",\"autoplayTransitionDuration\":4,\"autoplaySmartTransitions\":true}'::jsonb"
+        },
+        "playback_settings": {
+          "name": "playback_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"volume\":0.5,\"autoplayNext\":true,\"crossfadeDuration\":0,\"defaultQuality\":\"high\"}'::jsonb"
+        },
+        "notification_settings": {
+          "name": "notification_settings",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"browserNotifications\":false,\"downloadCompletion\":true,\"recommendationUpdates\":true}'::jsonb"
+        },
+        "dashboard_layout": {
+          "name": "dashboard_layout",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'{\"showRecommendations\":true,\"showRecentlyPlayed\":true,\"widgetOrder\":[\"recommendations\",\"recentlyPlayed\"]}'::jsonb"
+        },
+        "onboarding_status": {
+          "name": "onboarding_status",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_preferences_user_id_user_id_fk": {
+          "name": "user_preferences_user_id_user_id_fk",
+          "tableFrom": "user_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_preferences_user_id_unique": {
+          "name": "user_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_feedback": {
+      "name": "recommendation_feedback",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommendation_cache_id": {
+          "name": "recommendation_cache_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_type": {
+          "name": "feedback_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'recommendation'"
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hour_of_day": {
+          "name": "hour_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_feedback_user_id_idx": {
+          "name": "recommendation_feedback_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_timestamp_idx": {
+          "name": "recommendation_feedback_timestamp_idx",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_cache_id_idx": {
+          "name": "recommendation_feedback_cache_id_idx",
+          "columns": [
+            {
+              "expression": "recommendation_cache_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_type_time_idx": {
+          "name": "recommendation_feedback_user_type_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "feedback_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_month_idx": {
+          "name": "recommendation_feedback_month_idx",
+          "columns": [
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_season_idx": {
+          "name": "recommendation_feedback_season_idx",
+          "columns": [
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_season_idx": {
+          "name": "recommendation_feedback_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_month_idx": {
+          "name": "recommendation_feedback_user_month_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_song_id_idx": {
+          "name": "recommendation_feedback_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_feedback_user_song_id_idx": {
+          "name": "recommendation_feedback_user_song_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_feedback_user_id_user_id_fk": {
+          "name": "recommendation_feedback_user_id_user_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk": {
+          "name": "recommendation_feedback_recommendation_cache_id_recommendations_cache_id_fk",
+          "tableFrom": "recommendation_feedback",
+          "tableTo": "recommendations_cache",
+          "columnsFrom": [
+            "recommendation_cache_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "recommendation_feedback_user_song_unique": {
+          "name": "recommendation_feedback_user_song_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_songs": {
+      "name": "playlist_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist_title": {
+          "name": "song_artist_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "position": {
+          "name": "position",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_songs_playlist_id_idx": {
+          "name": "playlist_songs_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_song_id_idx": {
+          "name": "playlist_songs_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_songs_position_idx": {
+          "name": "playlist_songs_position_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "position",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_songs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_songs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_songs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_song": {
+          "name": "unique_playlist_song",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_playlists": {
+      "name": "user_playlists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navidrome_id": {
+          "name": "navidrome_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_liked_songs": {
+          "name": "is_liked_songs",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_synced": {
+          "name": "last_synced",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_duration": {
+          "name": "total_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "smart_playlist_criteria": {
+          "name": "smart_playlist_criteria",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_playlists_user_id_idx": {
+          "name": "user_playlists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_created_at_idx": {
+          "name": "user_playlists_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_navidrome_id_idx": {
+          "name": "user_playlists_navidrome_id_idx",
+          "columns": [
+            {
+              "expression": "navidrome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "user_playlists_one_liked_per_user": {
+          "name": "user_playlists_one_liked_per_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "\"user_playlists\".\"is_liked_songs\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_playlists_user_id_user_id_fk": {
+          "name": "user_playlists_user_id_user_id_fk",
+          "tableFrom": "user_playlists",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_user_playlist_name": {
+          "name": "unique_user_playlist_name",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.collaboration_activity": {
+      "name": "collaboration_activity",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "activity_type": {
+          "name": "activity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "activity_playlist_id_idx": {
+          "name": "activity_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_user_id_idx": {
+          "name": "activity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "activity_created_at_idx": {
+          "name": "activity_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "collaboration_activity_playlist_id_user_playlists_id_fk": {
+          "name": "collaboration_activity_playlist_id_user_playlists_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "collaboration_activity_user_id_user_id_fk": {
+          "name": "collaboration_activity_user_id_user_id_fk",
+          "tableFrom": "collaboration_activity",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaboration_settings": {
+      "name": "playlist_collaboration_settings",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "privacy": {
+          "name": "privacy",
+          "type": "playlist_privacy",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'private'"
+        },
+        "allow_suggestions": {
+          "name": "allow_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "auto_approve_threshold": {
+          "name": "auto_approve_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "max_suggestions_per_user": {
+          "name": "max_suggestions_per_user",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 10
+        },
+        "max_total_suggestions": {
+          "name": "max_total_suggestions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 50
+        },
+        "notify_on_suggestion": {
+          "name": "notify_on_suggestion",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "notify_on_vote": {
+          "name": "notify_on_vote",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "notify_on_approval": {
+          "name": "notify_on_approval",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "share_code": {
+          "name": "share_code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "collab_settings_playlist_id_idx": {
+          "name": "collab_settings_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collab_settings_share_code_idx": {
+          "name": "collab_settings_share_code_idx",
+          "columns": [
+            {
+              "expression": "share_code",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaboration_settings_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaboration_settings_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaboration_settings",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playlist_collaboration_settings_playlist_id_unique": {
+          "name": "playlist_collaboration_settings_playlist_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id"
+          ]
+        },
+        "playlist_collaboration_settings_share_code_unique": {
+          "name": "playlist_collaboration_settings_share_code_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "share_code"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_collaborators": {
+      "name": "playlist_collaborators",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "role": {
+          "name": "role",
+          "type": "collaborator_role",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'viewer'"
+        },
+        "invited_by": {
+          "name": "invited_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "invited_at": {
+          "name": "invited_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "accepted_at": {
+          "name": "accepted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_active_at": {
+          "name": "last_active_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_online": {
+          "name": "is_online",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "collaborators_playlist_id_idx": {
+          "name": "collaborators_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "collaborators_user_id_idx": {
+          "name": "collaborators_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_collaborators_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_collaborators_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_user_id_user_id_fk": {
+          "name": "playlist_collaborators_user_id_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_collaborators_invited_by_user_id_fk": {
+          "name": "playlist_collaborators_invited_by_user_id_fk",
+          "tableFrom": "playlist_collaborators",
+          "tableTo": "user",
+          "columnsFrom": [
+            "invited_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_playlist_collaborator": {
+          "name": "unique_playlist_collaborator",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_suggestions": {
+      "name": "playlist_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_title": {
+          "name": "song_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_artist": {
+          "name": "song_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_album": {
+          "name": "song_album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_by": {
+          "name": "suggested_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "suggestion_status",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "upvotes": {
+          "name": "upvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "downvotes": {
+          "name": "downvotes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "score": {
+          "name": "score",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed_by": {
+          "name": "processed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "processed_at": {
+          "name": "processed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rejection_reason": {
+          "name": "rejection_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_available": {
+          "name": "is_available",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "availability_checked_at": {
+          "name": "availability_checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "suggestions_playlist_id_idx": {
+          "name": "suggestions_playlist_id_idx",
+          "columns": [
+            {
+              "expression": "playlist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_suggested_by_idx": {
+          "name": "suggestions_suggested_by_idx",
+          "columns": [
+            {
+              "expression": "suggested_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_status_idx": {
+          "name": "suggestions_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "suggestions_score_idx": {
+          "name": "suggestions_score_idx",
+          "columns": [
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_suggestions_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_suggestions_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_suggested_by_user_id_fk": {
+          "name": "playlist_suggestions_suggested_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "suggested_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_suggestions_processed_by_user_id_fk": {
+          "name": "playlist_suggestions_processed_by_user_id_fk",
+          "tableFrom": "playlist_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "processed_by"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_song_playlist": {
+          "name": "unique_suggestion_song_playlist",
+          "nullsNotDistinct": false,
+          "columns": [
+            "playlist_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.suggestion_votes": {
+      "name": "suggestion_votes",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "suggestion_id": {
+          "name": "suggestion_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vote": {
+          "name": "vote",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "voted_at": {
+          "name": "voted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "votes_suggestion_id_idx": {
+          "name": "votes_suggestion_id_idx",
+          "columns": [
+            {
+              "expression": "suggestion_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "votes_user_id_idx": {
+          "name": "votes_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "suggestion_votes_suggestion_id_playlist_suggestions_id_fk": {
+          "name": "suggestion_votes_suggestion_id_playlist_suggestions_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "playlist_suggestions",
+          "columnsFrom": [
+            "suggestion_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "suggestion_votes_user_id_user_id_fk": {
+          "name": "suggestion_votes_user_id_user_id_fk",
+          "tableFrom": "suggestion_votes",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "unique_suggestion_vote": {
+          "name": "unique_suggestion_vote",
+          "nullsNotDistinct": false,
+          "columns": [
+            "suggestion_id",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_profiles": {
+      "name": "library_profiles",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "genre_distribution": {
+          "name": "genre_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_keywords": {
+          "name": "top_keywords",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_analyzed": {
+          "name": "last_analyzed",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "refresh_needed": {
+          "name": "refresh_needed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        }
+      },
+      "indexes": {
+        "library_profiles_user_id_idx": {
+          "name": "library_profiles_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_last_analyzed_idx": {
+          "name": "library_profiles_last_analyzed_idx",
+          "columns": [
+            {
+              "expression": "last_analyzed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_profiles_refresh_needed_idx": {
+          "name": "library_profiles_refresh_needed_idx",
+          "columns": [
+            {
+              "expression": "refresh_needed",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_profiles_user_id_user_id_fk": {
+          "name": "library_profiles_user_id_user_id_fk",
+          "tableFrom": "library_profiles",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "library_profiles_user_id_unique": {
+          "name": "library_profiles_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.compound_scores": {
+      "name": "compound_scores",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "source_count": {
+          "name": "source_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "recency_weighted_score": {
+          "name": "recency_weighted_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "compound_scores_user_id_idx": {
+          "name": "compound_scores_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_user_score_idx": {
+          "name": "compound_scores_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "compound_scores_song_id_idx": {
+          "name": "compound_scores_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "compound_scores_user_id_user_id_fk": {
+          "name": "compound_scores_user_id_user_id_fk",
+          "tableFrom": "compound_scores",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "compound_scores_unique": {
+          "name": "compound_scores_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_history": {
+      "name": "listening_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_duration": {
+          "name": "song_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed": {
+          "name": "completed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_detected": {
+          "name": "skip_detected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "session_id": {
+          "name": "session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "listening_history_user_id_idx": {
+          "name": "listening_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_played_at_idx": {
+          "name": "listening_history_played_at_idx",
+          "columns": [
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_user_played_at_idx": {
+          "name": "listening_history_user_played_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_song_id_idx": {
+          "name": "listening_history_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_artist_idx": {
+          "name": "listening_history_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_skip_idx": {
+          "name": "listening_history_skip_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "skip_detected",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "played_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_history_session_id_idx": {
+          "name": "listening_history_session_id_idx",
+          "columns": [
+            {
+              "expression": "session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_history_user_id_user_id_fk": {
+          "name": "listening_history_user_id_user_id_fk",
+          "tableFrom": "listening_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "listening_history_session_id_listening_sessions_id_fk": {
+          "name": "listening_history_session_id_listening_sessions_id_fk",
+          "tableFrom": "listening_history",
+          "tableTo": "listening_sessions",
+          "columnsFrom": [
+            "session_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.track_similarities": {
+      "name": "track_similarities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "source_artist": {
+          "name": "source_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_title": {
+          "name": "source_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_artist": {
+          "name": "target_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_title": {
+          "name": "target_title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_song_id": {
+          "name": "target_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "track_similarities_source_idx": {
+          "name": "track_similarities_source_idx",
+          "columns": [
+            {
+              "expression": "source_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "source_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_idx": {
+          "name": "track_similarities_target_idx",
+          "columns": [
+            {
+              "expression": "target_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_target_song_id_idx": {
+          "name": "track_similarities_target_song_id_idx",
+          "columns": [
+            {
+              "expression": "target_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "track_similarities_expires_at_idx": {
+          "name": "track_similarities_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "track_similarities_unique": {
+          "name": "track_similarities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "source_artist",
+            "source_title",
+            "target_artist",
+            "target_title"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_artists": {
+      "name": "indexed_artists",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_artist_id": {
+          "name": "navidrome_artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_count": {
+          "name": "album_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "genres": {
+          "name": "genres",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_artists_user_id_idx": {
+          "name": "indexed_artists_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_user_artist_idx": {
+          "name": "indexed_artists_user_artist_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_artist_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_artists_name_idx": {
+          "name": "indexed_artists_name_idx",
+          "columns": [
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.indexed_songs": {
+      "name": "indexed_songs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_song_id": {
+          "name": "navidrome_song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "album_id": {
+          "name": "album_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_id": {
+          "name": "artist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "track": {
+          "name": "track",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "song_key": {
+          "name": "song_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "checksum": {
+          "name": "checksum",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_modified_at": {
+          "name": "last_modified_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "indexed_songs_user_id_idx": {
+          "name": "indexed_songs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_user_song_idx": {
+          "name": "indexed_songs_user_song_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "navidrome_song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_song_key_idx": {
+          "name": "indexed_songs_song_key_idx",
+          "columns": [
+            {
+              "expression": "song_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_artist_idx": {
+          "name": "indexed_songs_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "indexed_songs_synced_at_idx": {
+          "name": "indexed_songs_synced_at_idx",
+          "columns": [
+            {
+              "expression": "synced_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_sync_state": {
+      "name": "library_sync_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "last_full_sync_at": {
+          "name": "last_full_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_incremental_sync_at": {
+          "name": "last_incremental_sync_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_started_at": {
+          "name": "last_sync_started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_sync_completed_at": {
+          "name": "last_sync_completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'idle'"
+        },
+        "current_phase": {
+          "name": "current_phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_items": {
+          "name": "processed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "error_count": {
+          "name": "error_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "checkpoint": {
+          "name": "checkpoint",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "sync_frequency_minutes": {
+          "name": "sync_frequency_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 30
+        },
+        "batch_size": {
+          "name": "batch_size",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 100
+        },
+        "max_concurrent_requests": {
+          "name": "max_concurrent_requests",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 3
+        },
+        "auto_sync_enabled": {
+          "name": "auto_sync_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": true
+        },
+        "last_sync_duration_ms": {
+          "name": "last_sync_duration_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_songs_indexed": {
+          "name": "total_songs_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_artists_indexed": {
+          "name": "total_artists_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "total_albums_indexed": {
+          "name": "total_albums_indexed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "library_sync_state_user_id_idx": {
+          "name": "library_sync_state_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.sync_error_log": {
+      "name": "sync_error_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sync_session_id": {
+          "name": "sync_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_type": {
+          "name": "error_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_stack": {
+          "name": "error_stack",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "phase": {
+          "name": "phase",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_id": {
+          "name": "item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "resolved": {
+          "name": "resolved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sync_error_log_user_id_idx": {
+          "name": "sync_error_log_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_session_idx": {
+          "name": "sync_error_log_session_idx",
+          "columns": [
+            {
+              "expression": "sync_session_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "sync_error_log_created_at_idx": {
+          "name": "sync_error_log_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.mood_snapshots": {
+      "name": "mood_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_distribution": {
+          "name": "mood_distribution",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "total_listens": {
+          "name": "total_listens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_feedback": {
+          "name": "total_feedback",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_up_count": {
+          "name": "thumbs_up_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "thumbs_down_count": {
+          "name": "thumbs_down_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "acceptance_rate": {
+          "name": "acceptance_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "diversity_score": {
+          "name": "diversity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "mood_snapshots_user_id_idx": {
+          "name": "mood_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_start_idx": {
+          "name": "mood_snapshots_period_start_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_idx": {
+          "name": "mood_snapshots_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_period_type_idx": {
+          "name": "mood_snapshots_period_type_idx",
+          "columns": [
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "mood_snapshots_user_period_type_idx": {
+          "name": "mood_snapshots_user_period_type_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "mood_snapshots_user_id_user_id_fk": {
+          "name": "mood_snapshots_user_id_user_id_fk",
+          "tableFrom": "mood_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.recommendation_history": {
+      "name": "recommendation_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recommended_songs": {
+          "name": "recommended_songs",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_context": {
+          "name": "mood_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "reasoning_factors": {
+          "name": "reasoning_factors",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "taste_profile_snapshot": {
+          "name": "taste_profile_snapshot",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "recommendation_history_user_id_idx": {
+          "name": "recommendation_history_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_generated_at_idx": {
+          "name": "recommendation_history_generated_at_idx",
+          "columns": [
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_user_generated_at_idx": {
+          "name": "recommendation_history_user_generated_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "generated_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "recommendation_history_source_idx": {
+          "name": "recommendation_history_source_idx",
+          "columns": [
+            {
+              "expression": "source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "recommendation_history_user_id_user_id_fk": {
+          "name": "recommendation_history_user_id_user_id_fk",
+          "tableFrom": "recommendation_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.taste_snapshots": {
+      "name": "taste_snapshots",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "captured_at": {
+          "name": "captured_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "profile_data": {
+          "name": "profile_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "export_formats": {
+          "name": "export_formats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_auto_generated": {
+          "name": "is_auto_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "taste_snapshots_user_id_idx": {
+          "name": "taste_snapshots_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "taste_snapshots_captured_at_idx": {
+          "name": "taste_snapshots_captured_at_idx",
+          "columns": [
+            {
+              "expression": "captured_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "taste_snapshots_user_id_user_id_fk": {
+          "name": "taste_snapshots_user_id_user_id_fk",
+          "tableFrom": "taste_snapshots",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_analytics": {
+      "name": "discovery_feed_analytics",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "period_start": {
+          "name": "period_start",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_end": {
+          "name": "period_end",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "aggregation_level": {
+          "name": "aggregation_level",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_items_shown": {
+          "name": "total_items_shown",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_clicks": {
+          "name": "total_clicks",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_plays": {
+          "name": "total_plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_duration": {
+          "name": "total_play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_saves": {
+          "name": "total_saves",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_skips": {
+          "name": "total_skips",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dismissals": {
+          "name": "total_dismissals",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_likes": {
+          "name": "total_likes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_dislikes": {
+          "name": "total_dislikes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_not_interested": {
+          "name": "total_not_interested",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "click_through_rate": {
+          "name": "click_through_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "play_rate": {
+          "name": "play_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "save_rate": {
+          "name": "save_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "dismissal_rate": {
+          "name": "dismissal_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "source_breakdown": {
+          "name": "source_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "time_slot_breakdown": {
+          "name": "time_slot_breakdown",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "notifications_sent": {
+          "name": "notifications_sent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notifications_opened": {
+          "name": "notifications_opened",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "notification_open_rate": {
+          "name": "notification_open_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_analytics_period_idx": {
+          "name": "discovery_feed_analytics_period_idx",
+          "columns": [
+            {
+              "expression": "period_start",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "period_end",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_analytics_user_id_idx": {
+          "name": "discovery_feed_analytics_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_analytics_user_id_user_id_fk": {
+          "name": "discovery_feed_analytics_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_analytics",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_feed_analytics_unique": {
+          "name": "discovery_feed_analytics_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "period_start",
+            "aggregation_level",
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_feed_items": {
+      "name": "discovery_feed_items",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "item_type": {
+          "name": "item_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_id": {
+          "name": "content_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "subtitle": {
+          "name": "subtitle",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "recommendation_source": {
+          "name": "recommendation_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "target_time_slot": {
+          "name": "target_time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'any'"
+        },
+        "target_context": {
+          "name": "target_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "shown": {
+          "name": "shown",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "shown_at": {
+          "name": "shown_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked": {
+          "name": "clicked",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "played": {
+          "name": "played",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "played_at": {
+          "name": "played_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "play_duration": {
+          "name": "play_duration",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "saved": {
+          "name": "saved",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "skipped": {
+          "name": "skipped",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "dismissed": {
+          "name": "dismissed",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "feedback": {
+          "name": "feedback",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feedback_at": {
+          "name": "feedback_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_feed_items_user_id_idx": {
+          "name": "discovery_feed_items_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_time_slot_idx": {
+          "name": "discovery_feed_items_user_time_slot_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "target_time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_shown_at_idx": {
+          "name": "discovery_feed_items_shown_at_idx",
+          "columns": [
+            {
+              "expression": "shown_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_expires_at_idx": {
+          "name": "discovery_feed_items_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_feed_items_user_content_idx": {
+          "name": "discovery_feed_items_user_content_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "content_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "item_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_feed_items_user_id_user_id_fk": {
+          "name": "discovery_feed_items_user_id_user_id_fk",
+          "tableFrom": "discovery_feed_items",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_notification_preferences": {
+      "name": "discovery_notification_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency": {
+          "name": "frequency",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'daily'"
+        },
+        "preferred_times": {
+          "name": "preferred_times",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[\"09:00\",\"17:00\"]'::jsonb"
+        },
+        "quiet_hours_start": {
+          "name": "quiet_hours_start",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'22:00'"
+        },
+        "quiet_hours_end": {
+          "name": "quiet_hours_end",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'08:00'"
+        },
+        "active_days": {
+          "name": "active_days",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[0,1,2,3,4,5,6]'::jsonb"
+        },
+        "include_new_releases": {
+          "name": "include_new_releases",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_personalized": {
+          "name": "include_personalized",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_time_based_suggestions": {
+          "name": "include_time_based_suggestions",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "include_trending": {
+          "name": "include_trending",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "max_notifications_per_day": {
+          "name": "max_notifications_per_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 3
+        },
+        "computed_optimal_time": {
+          "name": "computed_optimal_time",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ab_test_group": {
+          "name": "ab_test_group",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'control'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_notification_prefs_user_id_idx": {
+          "name": "discovery_notification_prefs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_notification_preferences_user_id_user_id_fk": {
+          "name": "discovery_notification_preferences_user_id_user_id_fk",
+          "tableFrom": "discovery_notification_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_notification_preferences_user_id_unique": {
+          "name": "discovery_notification_preferences_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_patterns": {
+      "name": "listening_patterns",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "top_moods": {
+          "name": "top_moods",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avg_energy": {
+          "name": "avg_energy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "avg_bpm": {
+          "name": "avg_bpm",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "primary_context": {
+          "name": "primary_context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'general'"
+        },
+        "sample_count": {
+          "name": "sample_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_updated": {
+          "name": "last_updated",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "listening_patterns_user_id_idx": {
+          "name": "listening_patterns_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_time_slot_idx": {
+          "name": "listening_patterns_time_slot_idx",
+          "columns": [
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_patterns_user_time_day_idx": {
+          "name": "listening_patterns_user_time_day_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "day_of_week",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_patterns_user_id_user_id_fk": {
+          "name": "listening_patterns_user_id_user_id_fk",
+          "tableFrom": "listening_patterns",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "listening_patterns_unique": {
+          "name": "listening_patterns_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "day_of_week"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.scheduled_notifications": {
+      "name": "scheduled_notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action_url": {
+          "name": "action_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "feed_item_id": {
+          "name": "feed_item_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "notification_type": {
+          "name": "notification_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "scheduled_for": {
+          "name": "scheduled_for",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "clicked_at": {
+          "name": "clicked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "ab_test_variant": {
+          "name": "ab_test_variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "scheduled_notifications_status_scheduled_idx": {
+          "name": "scheduled_notifications_status_scheduled_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "scheduled_for",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_user_id_idx": {
+          "name": "scheduled_notifications_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "scheduled_notifications_type_status_idx": {
+          "name": "scheduled_notifications_type_status_idx",
+          "columns": [
+            {
+              "expression": "notification_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "scheduled_notifications_user_id_user_id_fk": {
+          "name": "scheduled_notifications_user_id_user_id_fk",
+          "tableFrom": "scheduled_notifications",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.platform_credentials": {
+      "name": "platform_credentials",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "platform": {
+          "name": "platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "token_expiry": {
+          "name": "token_expiry",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_user_id": {
+          "name": "platform_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "platform_username": {
+          "name": "platform_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scopes": {
+          "name": "scopes",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "platform_credentials_user_platform_idx": {
+          "name": "platform_credentials_user_platform_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "platform",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "platform_credentials_user_id_user_id_fk": {
+          "name": "platform_credentials_user_id_user_id_fk",
+          "tableFrom": "platform_credentials",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_download_jobs": {
+      "name": "playlist_download_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "import_job_id": {
+          "name": "import_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_items": {
+          "name": "total_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "completed_items": {
+          "name": "completed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "failed_items": {
+          "name": "failed_items",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "download_queue": {
+          "name": "download_queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "pending_organization": {
+          "name": "pending_organization",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_download_jobs_user_id_idx": {
+          "name": "playlist_download_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_service_idx": {
+          "name": "playlist_download_jobs_service_idx",
+          "columns": [
+            {
+              "expression": "service",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_status_idx": {
+          "name": "playlist_download_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_download_jobs_created_at_idx": {
+          "name": "playlist_download_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_download_jobs_user_id_user_id_fk": {
+          "name": "playlist_download_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk": {
+          "name": "playlist_download_jobs_import_job_id_playlist_import_jobs_id_fk",
+          "tableFrom": "playlist_download_jobs",
+          "tableTo": "playlist_import_jobs",
+          "columnsFrom": [
+            "import_job_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_export_jobs": {
+      "name": "playlist_export_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "playlist_id": {
+          "name": "playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_platform": {
+          "name": "source_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "exported_data": {
+          "name": "exported_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_export_jobs_user_id_idx": {
+          "name": "playlist_export_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_status_idx": {
+          "name": "playlist_export_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_export_jobs_created_at_idx": {
+          "name": "playlist_export_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_export_jobs_user_id_user_id_fk": {
+          "name": "playlist_export_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_export_jobs_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_export_jobs_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_export_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playlist_import_jobs": {
+      "name": "playlist_import_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "format": {
+          "name": "format",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "target_platform": {
+          "name": "target_platform",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "original_filename": {
+          "name": "original_filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_name": {
+          "name": "playlist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "playlist_description": {
+          "name": "playlist_description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_playlist_id": {
+          "name": "created_playlist_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "total_songs": {
+          "name": "total_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "processed_songs": {
+          "name": "processed_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "matched_songs": {
+          "name": "matched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "unmatched_songs": {
+          "name": "unmatched_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "pending_review_songs": {
+          "name": "pending_review_songs",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "match_results": {
+          "name": "match_results",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_details": {
+          "name": "error_details",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "playlist_import_jobs_user_id_idx": {
+          "name": "playlist_import_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_status_idx": {
+          "name": "playlist_import_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "playlist_import_jobs_created_at_idx": {
+          "name": "playlist_import_jobs_created_at_idx",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": false,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playlist_import_jobs_user_id_user_id_fk": {
+          "name": "playlist_import_jobs_user_id_user_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "playlist_import_jobs_created_playlist_id_user_playlists_id_fk": {
+          "name": "playlist_import_jobs_created_playlist_id_user_playlists_id_fk",
+          "tableFrom": "playlist_import_jobs",
+          "tableTo": "user_playlists",
+          "columnsFrom": [
+            "created_playlist_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.music_identity_summaries": {
+      "name": "music_identity_summaries",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "period_type": {
+          "name": "period_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "year": {
+          "name": "year",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ai_insights": {
+          "name": "ai_insights",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mood_profile": {
+          "name": "mood_profile",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_affinities": {
+          "name": "artist_affinities",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "trend_analysis": {
+          "name": "trend_analysis",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_tracks": {
+          "name": "top_tracks",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "stats": {
+          "name": "stats",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "card_theme": {
+          "name": "card_theme",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'default'"
+        },
+        "card_data": {
+          "name": "card_data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "share_token": {
+          "name": "share_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_public": {
+          "name": "is_public",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "music_identity_user_id_idx": {
+          "name": "music_identity_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_user_period_idx": {
+          "name": "music_identity_user_period_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "year",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "month",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "music_identity_share_token_idx": {
+          "name": "music_identity_share_token_idx",
+          "columns": [
+            {
+              "expression": "share_token",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "music_identity_summaries_user_id_user_id_fk": {
+          "name": "music_identity_summaries_user_id_user_id_fk",
+          "tableFrom": "music_identity_summaries",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.lyrics_cache": {
+      "name": "lyrics_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "duration": {
+          "name": "duration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lyrics": {
+          "name": "lyrics",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "synced_lyrics": {
+          "name": "synced_lyrics",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "instrumental": {
+          "name": "instrumental",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_job_state": {
+      "name": "discovery_job_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 12
+        },
+        "max_suggestions_per_run": {
+          "name": "max_suggestions_per_run",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 15
+        },
+        "seed_count": {
+          "name": "seed_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 10
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_running": {
+          "name": "is_running",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "consecutive_failures": {
+          "name": "consecutive_failures",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "total_suggestions_generated": {
+          "name": "total_suggestions_generated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_approved": {
+          "name": "total_approved",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_rejected": {
+          "name": "total_rejected",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_job_state_next_run_at_idx": {
+          "name": "discovery_job_state_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_job_state_enabled_idx": {
+          "name": "discovery_job_state_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_job_state_user_id_user_id_fk": {
+          "name": "discovery_job_state_user_id_user_id_fk",
+          "tableFrom": "discovery_job_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_rejection_history": {
+      "name": "discovery_rejection_history",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "rejected_at": {
+          "name": "rejected_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "discovery_rejection_expires_at_idx": {
+          "name": "discovery_rejection_expires_at_idx",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_rejection_user_artist_track_idx": {
+          "name": "discovery_rejection_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_rejection_history_user_id_user_id_fk": {
+          "name": "discovery_rejection_history_user_id_user_id_fk",
+          "tableFrom": "discovery_rejection_history",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "discovery_rejection_unique": {
+          "name": "discovery_rejection_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist_name",
+            "track_name"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.discovery_suggestions": {
+      "name": "discovery_suggestions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "track_name": {
+          "name": "track_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album_name": {
+          "name": "album_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_artist": {
+          "name": "seed_artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "seed_track": {
+          "name": "seed_track",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "match_score": {
+          "name": "match_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "lastfm_url": {
+          "name": "lastfm_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "explanation": {
+          "name": "explanation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "suggested_at": {
+          "name": "suggested_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "reviewed_at": {
+          "name": "reviewed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "discovery_suggestions_user_status_idx": {
+          "name": "discovery_suggestions_user_status_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_user_artist_track_idx": {
+          "name": "discovery_suggestions_user_artist_track_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "track_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_match_score_idx": {
+          "name": "discovery_suggestions_match_score_idx",
+          "columns": [
+            {
+              "expression": "match_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "discovery_suggestions_seed_artist_idx": {
+          "name": "discovery_suggestions_seed_artist_idx",
+          "columns": [
+            {
+              "expression": "seed_artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "discovery_suggestions_user_id_user_id_fk": {
+          "name": "discovery_suggestions_user_id_user_id_fk",
+          "tableFrom": "discovery_suggestions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_affinities": {
+      "name": "artist_affinities",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "affinity_score": {
+          "name": "affinity_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "liked_count": {
+          "name": "liked_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "skip_count": {
+          "name": "skip_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "total_play_time": {
+          "name": "total_play_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_affinities_user_id_idx": {
+          "name": "artist_affinities_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_user_score_idx": {
+          "name": "artist_affinities_user_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "affinity_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_affinities_artist_idx": {
+          "name": "artist_affinities_artist_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_affinities_user_id_user_id_fk": {
+          "name": "artist_affinities_user_id_user_id_fk",
+          "tableFrom": "artist_affinities",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_affinities_unique": {
+          "name": "artist_affinities_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.liked_songs_sync": {
+      "name": "liked_songs_sync",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_id": {
+          "name": "song_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        }
+      },
+      "indexes": {
+        "liked_songs_sync_user_id_idx": {
+          "name": "liked_songs_sync_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_song_id_idx": {
+          "name": "liked_songs_sync_song_id_idx",
+          "columns": [
+            {
+              "expression": "song_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "liked_songs_sync_user_active_idx": {
+          "name": "liked_songs_sync_user_active_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "is_active",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "liked_songs_sync_user_id_user_id_fk": {
+          "name": "liked_songs_sync_user_id_user_id_fk",
+          "tableFrom": "liked_songs_sync",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "liked_songs_sync_unique": {
+          "name": "liked_songs_sync_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "song_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.temporal_preferences": {
+      "name": "temporal_preferences",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "time_slot": {
+          "name": "time_slot",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genre": {
+          "name": "genre",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "preference_score": {
+          "name": "preference_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "play_count": {
+          "name": "play_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "temporal_preferences_user_id_idx": {
+          "name": "temporal_preferences_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_time_idx": {
+          "name": "temporal_preferences_user_time_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "time_slot",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_user_season_idx": {
+          "name": "temporal_preferences_user_season_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "season",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "temporal_preferences_genre_idx": {
+          "name": "temporal_preferences_genre_idx",
+          "columns": [
+            {
+              "expression": "genre",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "temporal_preferences_user_id_user_id_fk": {
+          "name": "temporal_preferences_user_id_user_id_fk",
+          "tableFrom": "temporal_preferences",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "temporal_preferences_unique": {
+          "name": "temporal_preferences_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "time_slot",
+            "season",
+            "genre"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.saved_cover_art": {
+      "name": "saved_cover_art",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "entity_id": {
+          "name": "entity_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "entity_type": {
+          "name": "entity_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "album": {
+          "name": "album",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "image_url": {
+          "name": "image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "saved_at": {
+          "name": "saved_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "saved_cover_art_entity_id_unique": {
+          "name": "saved_cover_art_entity_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "entity_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.cover_art_fetch_jobs": {
+      "name": "cover_art_fetch_jobs",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "total": {
+          "name": "total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "processed": {
+          "name": "processed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "found": {
+          "name": "found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "not_found": {
+          "name": "not_found",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "cover_art_fetch_jobs_user_id_idx": {
+          "name": "cover_art_fetch_jobs_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "cover_art_fetch_jobs_status_idx": {
+          "name": "cover_art_fetch_jobs_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "cover_art_fetch_jobs_user_id_user_id_fk": {
+          "name": "cover_art_fetch_jobs_user_id_user_id_fk",
+          "tableFrom": "cover_art_fetch_jobs",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.playback_sessions": {
+      "name": "playback_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "active_device_id": {
+          "name": "active_device_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_device_name": {
+          "name": "active_device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "active_device_type": {
+          "name": "active_device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "queue": {
+          "name": "queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "original_queue": {
+          "name": "original_queue",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "'[]'::jsonb"
+        },
+        "current_index": {
+          "name": "current_index",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "current_position_ms": {
+          "name": "current_position_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0
+        },
+        "is_playing": {
+          "name": "is_playing",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "volume": {
+          "name": "volume",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 0.5
+        },
+        "is_shuffled": {
+          "name": "is_shuffled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "queue_updated_at": {
+          "name": "queue_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "position_updated_at": {
+          "name": "position_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "play_state_updated_at": {
+          "name": "play_state_updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "playback_sessions_user_id_idx": {
+          "name": "playback_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "playback_sessions_user_id_user_id_fk": {
+          "name": "playback_sessions_user_id_user_id_fk",
+          "tableFrom": "playback_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "playback_sessions_user_id_unique": {
+          "name": "playback_sessions_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.devices": {
+      "name": "devices",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_name": {
+          "name": "device_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "device_type": {
+          "name": "device_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_seen_at": {
+          "name": "last_seen_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "devices_user_id_idx": {
+          "name": "devices_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "devices_user_id_user_id_fk": {
+          "name": "devices_user_id_user_id_fk",
+          "tableFrom": "devices",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.explicit_content_cache": {
+      "name": "explicit_content_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist": {
+          "name": "artist",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_explicit": {
+          "name": "is_explicit",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'deezer'"
+        },
+        "confidence": {
+          "name": "confidence",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "default": 1
+        },
+        "checked_at": {
+          "name": "checked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "explicit_artist_title_idx": {
+          "name": "explicit_artist_title_idx",
+          "columns": [
+            {
+              "expression": "artist",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "title",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.navidrome_users": {
+      "name": "navidrome_users",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_username": {
+          "name": "navidrome_username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_password": {
+          "name": "navidrome_password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_salt": {
+          "name": "navidrome_salt",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "navidrome_token": {
+          "name": "navidrome_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "navidrome_users_user_id_user_id_fk": {
+          "name": "navidrome_users_user_id_user_id_fk",
+          "tableFrom": "navidrome_users",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "navidrome_users_user_id_unique": {
+          "name": "navidrome_users_user_id_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id"
+          ]
+        },
+        "navidrome_users_navidrome_username_unique": {
+          "name": "navidrome_users_navidrome_username_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "navidrome_username"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_metadata_cache": {
+      "name": "artist_metadata_cache",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "artist_name": {
+          "name": "artist_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_name_normalized": {
+          "name": "artist_name_normalized",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mbid": {
+          "name": "mbid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "navidrome_id": {
+          "name": "navidrome_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "disambiguation": {
+          "name": "disambiguation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "artist_type": {
+          "name": "artist_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "country": {
+          "name": "country",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "formed_year": {
+          "name": "formed_year",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ended": {
+          "name": "ended",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "tags": {
+          "name": "tags",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "genres": {
+          "name": "genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "bio": {
+          "name": "bio",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "relations": {
+          "name": "relations",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "similar_artists": {
+          "name": "similar_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "release_groups": {
+          "name": "release_groups",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "cover_image_url": {
+          "name": "cover_image_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_id": {
+          "name": "lidarr_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "lidarr_monitored": {
+          "name": "lidarr_monitored",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "fetched_at": {
+          "name": "fetched_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_artist_metadata_name": {
+          "name": "idx_artist_metadata_name",
+          "columns": [
+            {
+              "expression": "artist_name_normalized",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_metadata_mbid": {
+          "name": "idx_artist_metadata_mbid",
+          "columns": [
+            {
+              "expression": "mbid",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_artist_metadata_navidrome": {
+          "name": "idx_artist_metadata_navidrome",
+          "columns": [
+            {
+              "expression": "navidrome_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.artist_cooccurrence": {
+      "name": "artist_cooccurrence",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_a": {
+          "name": "artist_a",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "artist_b": {
+          "name": "artist_b",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cooccurrence_score": {
+          "name": "cooccurrence_score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "coplay_count": {
+          "name": "coplay_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_coplayed_at": {
+          "name": "last_coplayed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "calculated_at": {
+          "name": "calculated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "artist_cooccurrence_user_artist_score_idx": {
+          "name": "artist_cooccurrence_user_artist_score_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "artist_a",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "cooccurrence_score",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "artist_cooccurrence_user_id_idx": {
+          "name": "artist_cooccurrence_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "artist_cooccurrence_user_id_user_id_fk": {
+          "name": "artist_cooccurrence_user_id_user_id_fk",
+          "tableFrom": "artist_cooccurrence",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "artist_cooccurrence_unique": {
+          "name": "artist_cooccurrence_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "artist_a",
+            "artist_b"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.listening_sessions": {
+      "name": "listening_sessions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ended_at": {
+          "name": "ended_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "duration_minutes": {
+          "name": "duration_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "song_count": {
+          "name": "song_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_artist_count": {
+          "name": "unique_artist_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "unique_genre_count": {
+          "name": "unique_genre_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "completion_rate": {
+          "name": "completion_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "skip_rate": {
+          "name": "skip_rate",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "avg_play_percentage": {
+          "name": "avg_play_percentage",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_artists": {
+          "name": "top_artists",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "top_genres": {
+          "name": "top_genres",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_mix": {
+          "name": "source_mix",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "dominant_source": {
+          "name": "dominant_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "day_of_week": {
+          "name": "day_of_week",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "hour_of_day": {
+          "name": "hour_of_day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "season": {
+          "name": "season",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rating": {
+          "name": "rating",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "rated_at": {
+          "name": "rated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "listening_sessions_user_id_idx": {
+          "name": "listening_sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_sessions_user_started_at_idx": {
+          "name": "listening_sessions_user_started_at_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "started_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_sessions_user_rating_idx": {
+          "name": "listening_sessions_user_rating_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "rating",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "listening_sessions_user_source_idx": {
+          "name": "listening_sessions_user_source_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "dominant_source",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "listening_sessions_user_id_user_id_fk": {
+          "name": "listening_sessions_user_id_user_id_fk",
+          "tableFrom": "listening_sessions",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "listening_sessions_user_start_unique": {
+          "name": "listening_sessions_user_start_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "user_id",
+            "started_at"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.library_reconciliation_state": {
+      "name": "library_reconciliation_state",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "frequency_hours": {
+          "name": "frequency_hours",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 6
+        },
+        "last_run_at": {
+          "name": "last_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "next_run_at": {
+          "name": "next_run_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_running": {
+          "name": "is_running",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_result": {
+          "name": "last_result",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "library_reconciliation_state_next_run_at_idx": {
+          "name": "library_reconciliation_state_next_run_at_idx",
+          "columns": [
+            {
+              "expression": "next_run_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "library_reconciliation_state_enabled_idx": {
+          "name": "library_reconciliation_state_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "library_reconciliation_state_user_id_user_id_fk": {
+          "name": "library_reconciliation_state_user_id_user_id_fk",
+          "tableFrom": "library_reconciliation_state",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.collaborator_role": {
+      "name": "collaborator_role",
+      "schema": "public",
+      "values": [
+        "owner",
+        "editor",
+        "viewer"
+      ]
+    },
+    "public.playlist_privacy": {
+      "name": "playlist_privacy",
+      "schema": "public",
+      "values": [
+        "public",
+        "private",
+        "invite_only"
+      ]
+    },
+    "public.suggestion_status": {
+      "name": "suggestion_status",
+      "schema": "public",
+      "values": [
+        "pending",
+        "approved",
+        "rejected"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -204,6 +204,13 @@
       "when": 1786667074126,
       "tag": "0028_add_is_liked_songs",
       "breakpoints": true
+    },
+    {
+      "idx": 29,
+      "version": "7",
+      "when": 1787072802827,
+      "tag": "0029_library_reconciliation_state",
+      "breakpoints": true
     }
   ]
 }

--- a/server.ts
+++ b/server.ts
@@ -17,9 +17,55 @@ import sirv from 'sirv';
 import { setupPlaybackWebSocket } from './src/lib/services/playback-websocket';
 import { getUserIdFromRequest } from './src/lib/auth/ws-session';
 import { clearActiveDeviceIfMatches } from './src/lib/auth/ws-playback-ops';
+import { db } from './src/lib/db';
+import { user } from './src/lib/db/schema';
+import { eq, asc } from 'drizzle-orm';
+import { initializeReconciliation } from './src/lib/services/library-reconciliation';
 
 const PORT = parseInt(process.env.PORT || '3000', 10);
 const HOST = process.env.HOST || '0.0.0.0';
+
+/**
+ * Bootstrap server-lifetime background jobs. This is the ONLY prod boot hook —
+ * `vite-ws-plugin.ts` is dev-only, so without this the reconciliation scheduler
+ * is never initialized on prod and its 6-hour timer is never armed.
+ *
+ * Reconciliation is a single-user singleton, so we run it for the owner: the
+ * `RECONCILIATION_USER_ID` env override, else the earliest `admin` user, else
+ * the earliest user. Failures never block server startup.
+ */
+async function bootstrapBackgroundJobs() {
+  try {
+    let userId: string | undefined = process.env.RECONCILIATION_USER_ID?.trim() || undefined;
+
+    if (!userId) {
+      const admins = await db
+        .select({ id: user.id })
+        .from(user)
+        .where(eq(user.role, 'admin'))
+        .orderBy(asc(user.createdAt))
+        .limit(1);
+      userId = admins[0]?.id;
+    }
+    if (!userId) {
+      const anyUser = await db
+        .select({ id: user.id })
+        .from(user)
+        .orderBy(asc(user.createdAt))
+        .limit(1);
+      userId = anyUser[0]?.id;
+    }
+    if (!userId) {
+      console.warn('[Server] No user found — skipping library reconciliation bootstrap');
+      return;
+    }
+
+    await initializeReconciliation(userId);
+    console.log(`[Server] Library reconciliation bootstrapped for user ${userId}`);
+  } catch (err) {
+    console.error('[Server] Failed to bootstrap background jobs:', err);
+  }
+}
 
 async function start() {
   // Import the built handler and convert to a proper Node handler
@@ -78,6 +124,8 @@ async function start() {
   server.listen(PORT, HOST, () => {
     console.log(`[Server] Listening on http://${HOST}:${PORT}`);
     console.log(`[Server] WebSocket available at ws://${HOST}:${PORT}/ws/playback`);
+    // Fire-and-forget: never let background bootstrap block/kill the listener.
+    void bootstrapBackgroundJobs();
   });
 
   // Graceful shutdown

--- a/src/components/playlists/import/steps/confirmation-step.tsx
+++ b/src/components/playlists/import/steps/confirmation-step.tsx
@@ -115,8 +115,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
         const response = await fetch('/api/downloads/youtube-fallback', {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
+          // Send the explicit selected tracks; the route prefers `tracks` over
+          // `importJobId` anyway, so passing the job id here would be dead weight.
           body: JSON.stringify({
-            importJobId: importResult.importJobId,
             tracks: songsToDownload,
           }),
         });

--- a/src/components/playlists/import/steps/confirmation-step.tsx
+++ b/src/components/playlists/import/steps/confirmation-step.tsx
@@ -65,6 +65,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
   const [queuedCount, setQueuedCount] = useState(0);
   const [downloadFailed, setDownloadFailed] = useState(false);
   const [downloadErrorMessage, setDownloadErrorMessage] = useState<string | null>(null);
+  // Lidarr = album-based acquisition; YouTube = per-song MeTube fallback (#145),
+  // for the misses Lidarr can't get (e.g. "artist has 0 albums").
+  const [downloadService, setDownloadService] = useState<'lidarr' | 'youtube'>('lidarr');
 
   // Mock unmatched songs list (in real implementation, this would come from importResult)
   const unmatchedSongs: UnmatchedSong[] = importResult.unmatchedSongs || [
@@ -105,6 +108,43 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
 
     try {
       const songsToDownload = Array.from(selectedSongs).map(i => unmatchedSongs[i]);
+
+      // YouTube path: per-song MeTube fallback (#145). Fire-and-poll happens
+      // server-side; here we just start the job and report it.
+      if (downloadService === 'youtube') {
+        const response = await fetch('/api/downloads/youtube-fallback', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            importJobId: importResult.importJobId,
+            tracks: songsToDownload,
+          }),
+        });
+
+        if (!response.ok) {
+          let errorMessage = 'Failed to start YouTube downloads';
+          try {
+            const error = await response.json();
+            errorMessage = error.message || error.error || errorMessage;
+          } catch {
+            /* non-JSON */
+          }
+          throw new Error(errorMessage);
+        }
+
+        const data = await response.json();
+        const started = data.data?.total ?? songsToDownload.length;
+
+        toast.success(`Sent ${started} song${started !== 1 ? 's' : ''} to YouTube`, {
+          description: 'Downloading one at a time via MeTube. Landed files flow through Picard → library rescan.',
+          duration: 8000,
+        });
+
+        setHasQueuedDownloads(true);
+        setQueuedCount(started);
+        setDownloadDialogOpen(false);
+        return;
+      }
 
       const response = await fetch('/api/downloads/queue', {
         method: 'POST',
@@ -381,9 +421,37 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
           <DialogHeader className="flex-shrink-0 space-y-0 md:space-y-1">
             <DialogTitle className="text-sm md:text-base">Download Missing Songs</DialogTitle>
             <DialogDescription className="hidden md:block text-xs">
-              Select which songs to download via Lidarr.
+              {downloadService === 'lidarr'
+                ? 'Find full albums via Lidarr.'
+                : 'Grab each song straight from YouTube via MeTube — for tracks Lidarr can’t get.'}
             </DialogDescription>
           </DialogHeader>
+
+          {/* Service selector: Lidarr (albums) vs YouTube (per-song fallback) */}
+          <div className="flex-shrink-0 grid grid-cols-2 gap-1 rounded-md border p-0.5">
+            <button
+              type="button"
+              onClick={() => setDownloadService('lidarr')}
+              className={`h-6 md:h-7 rounded text-[10px] md:text-xs font-medium transition-colors ${
+                downloadService === 'lidarr'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              Lidarr
+            </button>
+            <button
+              type="button"
+              onClick={() => setDownloadService('youtube')}
+              className={`h-6 md:h-7 rounded text-[10px] md:text-xs font-medium transition-colors ${
+                downloadService === 'youtube'
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:bg-muted'
+              }`}
+            >
+              YouTube
+            </button>
+          </div>
 
           {/* Song Selection */}
           {unmatchedSongs.length > 0 && (
@@ -417,7 +485,9 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
           )}
 
           <div className="flex-shrink-0 text-[9px] md:text-xs text-muted-foreground text-center px-2">
-            Note: Downloaded songs must be added to playlist manually after library rescan.
+            {downloadService === 'youtube'
+              ? 'Note: Downloads one at a time and verifies each match. Retag in Picard, then rescan the library to add them.'
+              : 'Note: Downloaded songs must be added to playlist manually after library rescan.'}
           </div>
 
           <DialogFooter className="flex-shrink-0 border-t pt-2 md:pt-3 gap-2">
@@ -428,12 +498,12 @@ export function ConfirmationStep({ importResult, playlistName, onReviewClick, re
               {isDownloading ? (
                 <>
                   <Loader2 className="mr-1 h-3 w-3 md:h-4 md:w-4 animate-spin" />
-                  Queueing...
+                  {downloadService === 'youtube' ? 'Starting...' : 'Queueing...'}
                 </>
               ) : (
                 <>
                   <Download className="mr-1 h-3 w-3 md:h-4 md:w-4" />
-                  Queue {selectedSongs.size}
+                  {downloadService === 'youtube' ? `Send ${selectedSongs.size}` : `Queue ${selectedSongs.size}`}
                 </>
               )}
             </Button>

--- a/src/lib/db/schema/index.ts
+++ b/src/lib/db/schema/index.ts
@@ -22,3 +22,4 @@ export * from "./navidrome-users.schema";
 export * from "./artist-metadata.schema";
 export * from "./artist-cooccurrence.schema";
 export * from "./listening-sessions.schema";
+export * from "./library-reconciliation.schema";

--- a/src/lib/db/schema/library-reconciliation.schema.ts
+++ b/src/lib/db/schema/library-reconciliation.schema.ts
@@ -1,0 +1,48 @@
+import { pgTable, text, timestamp, integer, boolean, jsonb, index } from "drizzle-orm/pg-core";
+import { user } from "./auth.schema";
+
+/**
+ * Library Reconciliation Job State
+ *
+ * Persists the reconciliation scheduler's cadence so it survives process
+ * restarts / redeploys (the in-memory setTimeout is wiped on every deploy).
+ * One row per user (PK = userId). Mirrors `discovery_job_state`.
+ *
+ * `next_run_at` is the source of truth for when the job is due: on boot the
+ * manager resumes from it instead of always waiting a fresh `frequency_hours`.
+ */
+export const libraryReconciliationState = pgTable("library_reconciliation_state", {
+  // Primary key is userId (one job state per user)
+  userId: text("user_id")
+    .primaryKey()
+    .references(() => user.id, { onDelete: "cascade" }),
+
+  // Job configuration
+  enabled: boolean("enabled").default(true).notNull(),
+  frequencyHours: integer("frequency_hours").default(6).notNull(),
+
+  // Run tracking
+  lastRunAt: timestamp("last_run_at"),
+  nextRunAt: timestamp("next_run_at"),
+  isRunning: boolean("is_running").default(false).notNull(),
+
+  // Failure handling
+  lastError: text("last_error"),
+
+  // Last run summary (checkedIds/deadIds/remapped/notFound/durationMs)
+  lastResult: jsonb("last_result"),
+
+  // Timestamps
+  createdAt: timestamp("created_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+  updatedAt: timestamp("updated_at")
+    .$defaultFn(() => new Date())
+    .notNull(),
+}, (table) => ({
+  // Index for finding jobs due to run
+  nextRunAtIdx: index("library_reconciliation_state_next_run_at_idx").on(table.nextRunAt),
+  enabledIdx: index("library_reconciliation_state_enabled_idx").on(table.enabled),
+}));
+
+export type LibraryReconciliationState = typeof libraryReconciliationState.$inferSelect;

--- a/src/lib/services/__tests__/song-matcher.test.ts
+++ b/src/lib/services/__tests__/song-matcher.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for the matcher's YouTube-rip title normalization (#131): a library track
+ * stored under its full video title (e.g. "Cloonee & Prospa - Good Girl (ft…)")
+ * must still match the requested title ("Good Girl") instead of being declared
+ * no_match and needlessly re-downloaded.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { stripLeadingArtistPrefix, calculateMatchScore } from '../song-matcher';
+import type { ExportableSong } from '../playlist-export';
+import type { PlatformSearchResult } from '../song-matcher';
+
+describe('stripLeadingArtistPrefix', () => {
+  it('strips a leading artist prefix that overlaps the artist', () => {
+    expect(
+      stripLeadingArtistPrefix('Cloonee & Prospa - Good Girl (ft. Tristan Henry)', 'Cloonee')
+    ).toBe('Good Girl (ft. Tristan Henry)');
+  });
+
+  it('strips when the prefix contains any artist token', () => {
+    expect(stripLeadingArtistPrefix('zvle - 1MY', 'zvle')).toBe('1MY');
+  });
+
+  it('leaves a genuine "A - B" title alone when the prefix is unrelated to the artist', () => {
+    // "Home" is the artist; the title legitimately contains a dash.
+    expect(stripLeadingArtistPrefix('Resonance - Part II', 'Home')).toBe('Resonance - Part II');
+  });
+
+  it('returns the title unchanged when there is no dash', () => {
+    expect(stripLeadingArtistPrefix('Good Girl', 'Cloonee')).toBe('Good Girl');
+  });
+});
+
+describe('calculateMatchScore with polluted candidate titles', () => {
+  const source: ExportableSong = { title: 'Good Girl', artist: 'Cloonee', platform: 'spotify' };
+  const cand = (title: string): PlatformSearchResult => ({
+    platform: 'navidrome',
+    platformId: 'abc',
+    title,
+    artist: 'Cloonee',
+  });
+
+  it('matches a junk YouTube-rip title to the clean requested title', () => {
+    const clean = calculateMatchScore(source, cand('Good Girl'));
+    const junk = calculateMatchScore(source, cand('Cloonee & Prospa - Good Girl (ft. Tristan Henry)'));
+    // The stripped comparison should recover most of the title score.
+    expect(junk.score).toBeGreaterThan(70);
+    // And be in the same ballpark as the already-clean candidate.
+    expect(clean.score - junk.score).toBeLessThan(15);
+  });
+
+  it('keeps feat/version info distinct for normal titles (no artist prefix)', () => {
+    // A remix request should NOT be blurred into the original just because both
+    // share a base title — the feat-leniency only applies to rip-style prefixes.
+    const remixReq: ExportableSong = { title: 'Surround Sound (KAYTRANADA Remix)', artist: 'JID', platform: 'spotify' };
+    const remixCand: PlatformSearchResult = { platform: 'navidrome', platformId: 'r', title: 'Surround Sound (KAYTRANADA Remix)', artist: 'JID' };
+    const origCand: PlatformSearchResult = { platform: 'navidrome', platformId: 'o', title: 'Surround Sound (feat. 21 Savage & Baby Tate)', artist: 'JID' };
+    const remixScore = calculateMatchScore(remixReq, remixCand).score;
+    const origScore = calculateMatchScore(remixReq, origCand).score;
+    // The exact remix must score higher than the (feat-only) original.
+    expect(remixScore).toBeGreaterThan(origScore);
+  });
+});

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -9,6 +9,7 @@ import {
   normalizeSearchQuery,
   buildYouTubeSearchUrl,
   verifyDownload,
+  itemLikelyMatchesTrack,
 } from '../youtube-fallback';
 
 describe('normalizeSearchQuery', () => {
@@ -72,5 +73,49 @@ describe('verifyDownload', () => {
     const v = verifyDownload(track, {});
     expect(v.matched).toBe(false);
     expect(v.score).toBe(0);
+  });
+});
+
+describe('itemLikelyMatchesTrack (detection)', () => {
+  // Real cases that the strict id-based detection got wrong: MeTube's resolved
+  // title differs from the request but is clearly the same track.
+  it('matches a multi-artist request against MeTube’s resolved title', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Wax Motif;Taiki Nulight;Scrufizzer', title: 'Skank N Flex (with Scrufizzer)' },
+        { title: 'Wax Motif & Taiki Nulight - Skank n Flex ft. Scrufizzer' }
+      )
+    ).toBe(true);
+  });
+
+  it('matches "Got Bounce" by primary artist + title tokens', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Kumarion;STUCA', title: 'Got Bounce' },
+        { title: 'Kumarion & STUCA - Got Bounce' }
+      )
+    ).toBe(true);
+  });
+
+  it('does not match an unrelated download in a large history', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Kumarion', title: 'Got Bounce' },
+        { title: 'Some Other Artist - A Totally Different Song' }
+      )
+    ).toBe(false);
+  });
+
+  it('falls back to filename', () => {
+    expect(
+      itemLikelyMatchesTrack(
+        { artist: 'Sun Room', title: 'Insincere' },
+        { filename: 'Sun Room - Insincere [Official Audio].mp3' }
+      )
+    ).toBe(true);
+  });
+
+  it('returns false with no title or filename', () => {
+    expect(itemLikelyMatchesTrack({ artist: 'A', title: 'B' }, {})).toBe(false);
   });
 });

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -4,14 +4,24 @@
  * No network / MeTube interaction is exercised here.
  */
 
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import {
   normalizeSearchQuery,
   buildYouTubeSearchUrl,
   verifyDownload,
   itemLikelyMatchesTrack,
   libraryMatch,
+  startYouTubeFallbackJob,
+  getYouTubeFallbackJob,
 } from '../youtube-fallback';
+
+// The batch-runner tests below drive real MeTube interaction, so stub the client.
+vi.mock('../metube', () => ({
+  getQueue: vi.fn(),
+  addDownload: vi.fn().mockResolvedValue({ status: 'ok' }),
+  deleteDownloads: vi.fn().mockResolvedValue({ status: 'ok' }),
+}));
+import * as metube from '../metube';
 
 describe('normalizeSearchQuery', () => {
   it('uses the primary artist and drops collaborators', () => {
@@ -151,5 +161,66 @@ describe('libraryMatch (dedup guard vs Navidrome songs)', () => {
     expect(
       libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'When Did Your Heart Go Missing?', artist: 'Rooney' })
     ).toBe(false);
+  });
+});
+
+describe('batch runner attribution + retry policy', () => {
+  const finishedItem = {
+    id: 'vid1',
+    title: 'Cloonee - Good Girl',
+    url: 'ytsearch1:Cloonee Good Girl',
+    status: 'finished' as const,
+    filename: 'Cloonee - Good Girl.mp3',
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    // Every poll sees exactly the one finished item.
+    (metube.getQueue as ReturnType<typeof vi.fn>).mockResolvedValue({
+      done: { vid1: finishedItem },
+      queue: {},
+    });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // #2: a single MeTube item that loosely matches two near-identical tracks must be
+  // attributed to only the first — the second must not be re-counted as the same file.
+  it('does not attribute one MeTube item to two tracks in a batch', async () => {
+    const track = { artist: 'Cloonee', title: 'Good Girl' };
+    const job = startYouTubeFallbackJob('user-1', [track, { ...track }], {
+      skipInLibrary: false, // don't touch Navidrome in this test
+    });
+
+    await vi.runAllTimersAsync();
+
+    const finished = getYouTubeFallbackJob(job.id, 'user-1');
+    expect(finished?.status).toBe('completed');
+    // First track claims vid1; the second can't reuse it, so it never resolves.
+    expect(finished?.results[0].status).toBe('downloaded');
+    expect(finished?.results[0].metubeId).toBe('vid1');
+    expect(finished?.results[1].status).toBe('failed');
+    expect(finished?.results[1].metubeId).toBeUndefined();
+  });
+
+  // #3: a bare timeout (nothing matching ever appeared) must NOT be retried — the
+  // same query would just re-resolve to the same undetectable video.
+  it('does not retry a track that merely timed out', async () => {
+    const track = { artist: 'Cloonee', title: 'Good Girl' };
+    // Two identical tracks: the first claims vid1, the second times out with nothing
+    // left to match. addDownload is only reachable on the second (the first is served
+    // from the pre-finished item) and must be called exactly once — no retries.
+    const job = startYouTubeFallbackJob('user-1', [track, { ...track }], {
+      skipInLibrary: false,
+      maxAttempts: 3,
+    });
+
+    await vi.runAllTimersAsync();
+
+    expect(getYouTubeFallbackJob(job.id, 'user-1')?.status).toBe('completed');
+    expect(metube.addDownload as ReturnType<typeof vi.fn>).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -1,0 +1,76 @@
+/**
+ * Tests for the YouTube per-song fallback (issue #145) pure helpers:
+ * query normalization, the yt-dlp search URL, and download verification.
+ * No network / MeTube interaction is exercised here.
+ */
+
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeSearchQuery,
+  buildYouTubeSearchUrl,
+  verifyDownload,
+} from '../youtube-fallback';
+
+describe('normalizeSearchQuery', () => {
+  it('uses the primary artist and drops collaborators', () => {
+    const q = normalizeSearchQuery({ artist: 'Flume;SOPHIE;Eprom', title: 'Spring' });
+    expect(q).toBe('Flume Spring');
+  });
+
+  it('strips feat./with qualifiers from the title', () => {
+    const q = normalizeSearchQuery({ artist: 'matt proxy', title: '5 (with fakemink)' });
+    expect(q).toBe('matt proxy 5');
+  });
+
+  it('strips remaster tags', () => {
+    const q = normalizeSearchQuery({ artist: 'Some Artist', title: 'A Song (2011 Remaster)' });
+    expect(q).toBe('Some Artist A Song');
+  });
+
+  it('collapses whitespace and trims', () => {
+    const q = normalizeSearchQuery({ artist: '  Sun Room ', title: '  Insincere  ' });
+    expect(q).toBe('Sun Room Insincere');
+  });
+});
+
+describe('buildYouTubeSearchUrl', () => {
+  it('produces a yt-dlp ytsearch1 pseudo-URL', () => {
+    expect(buildYouTubeSearchUrl('Sun Room Insincere')).toBe('ytsearch1:Sun Room Insincere');
+  });
+});
+
+describe('verifyDownload', () => {
+  const track = { artist: 'Sun Room', title: 'Insincere' };
+
+  it('accepts a clean official-video match', () => {
+    const v = verifyDownload(track, { title: 'Sun Room - Insincere (Official Video)' });
+    expect(v.matched).toBe(true);
+    expect(v.score).toBeGreaterThanOrEqual(0.6);
+  });
+
+  it('accepts a title-only match when artist is present elsewhere', () => {
+    const v = verifyDownload(track, { title: 'Insincere by Sun Room' });
+    expect(v.matched).toBe(true);
+  });
+
+  it('rejects an unrelated video', () => {
+    const v = verifyDownload(track, { title: 'Top 50 Summer House Mix 2024' });
+    expect(v.matched).toBe(false);
+  });
+
+  it('flags a wrong-title result from the same artist', () => {
+    const v = verifyDownload(track, { title: 'Sun Room - Cadillac (Live)' });
+    expect(v.matched).toBe(false);
+  });
+
+  it('falls back to filename when title is missing', () => {
+    const v = verifyDownload(track, { filename: 'Sun Room - Insincere.mp3' });
+    expect(v.matched).toBe(true);
+  });
+
+  it('returns unmatched with no result title', () => {
+    const v = verifyDownload(track, {});
+    expect(v.matched).toBe(false);
+    expect(v.score).toBe(0);
+  });
+});

--- a/src/lib/services/__tests__/youtube-fallback.test.ts
+++ b/src/lib/services/__tests__/youtube-fallback.test.ts
@@ -10,6 +10,7 @@ import {
   buildYouTubeSearchUrl,
   verifyDownload,
   itemLikelyMatchesTrack,
+  libraryMatch,
 } from '../youtube-fallback';
 
 describe('normalizeSearchQuery', () => {
@@ -117,5 +118,38 @@ describe('itemLikelyMatchesTrack (detection)', () => {
 
   it('returns false with no title or filename', () => {
     expect(itemLikelyMatchesTrack({ artist: 'A', title: 'B' }, {})).toBe(false);
+  });
+});
+
+describe('libraryMatch (dedup guard vs Navidrome songs)', () => {
+  it('matches a CLEANLY-stored track (artist in a separate field)', () => {
+    // The bug case: Navidrome title="Calling You", artist="Valexus" (not in title).
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'Calling You', artist: 'Valexus' })
+    ).toBe(true);
+    expect(
+      libraryMatch({ artist: 'Valexus;Beehav3', title: 'Calling You' }, { title: 'Calling You', artist: 'Valexus & Beehav3' })
+    ).toBe(true);
+  });
+
+  it('matches a JUNK-titled copy (whole video title in the title field)', () => {
+    expect(
+      libraryMatch(
+        { artist: 'Wax Motif;Taiki Nulight;Scrufizzer', title: 'Skank N Flex (with Scrufizzer)' },
+        { title: 'Wax Motif & Taiki Nulight - Skank n Flex ft. Scrufizzer', artist: 'Wax Motif' }
+      )
+    ).toBe(true);
+  });
+
+  it('does NOT match a same-title track by a different artist', () => {
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'Calling for You', artist: 'Drake' })
+    ).toBe(false);
+  });
+
+  it('does NOT match an unrelated song', () => {
+    expect(
+      libraryMatch({ artist: 'Valexus', title: 'Calling You' }, { title: 'When Did Your Heart Go Missing?', artist: 'Rooney' })
+    ).toBe(false);
   });
 });

--- a/src/lib/services/library-reconciliation.ts
+++ b/src/lib/services/library-reconciliation.ts
@@ -23,6 +23,7 @@ import {
   recommendationFeedback,
   playlistSongs,
   userPlaylists,
+  libraryReconciliationState,
 } from '@/lib/db/schema';
 import { eq, and } from 'drizzle-orm';
 import {
@@ -35,9 +36,18 @@ import {
   buildSubsonicUrl,
   apiFetch,
 } from './navidrome';
+import type { LibraryReconciliationState } from '@/lib/db/schema';
 import { getNavidromeUserCreds } from './navidrome-users';
 import type { SubsonicCreds } from './navidrome-users';
 import { getConfig } from '@/lib/config/config';
+
+/**
+ * Delay before the first run after (re)initialization. Kept short so a fresh
+ * deploy reconciles soon after boot rather than only after a full frequency
+ * window — and so an overdue persisted schedule fires promptly without a
+ * thundering-herd at the exact moment of boot.
+ */
+const FIRST_RUN_DELAY_MS = 3 * 60 * 1000; // 3 minutes
 
 // ============================================================================
 // Types
@@ -105,19 +115,101 @@ class LibraryReconciliationManager {
   }
 
   async initialize(userId: string, frequencyHours?: number): Promise<void> {
+    // Idempotent: repeated calls (boot hook + status/trigger routes) must not
+    // stack timers or reset the cadence.
+    if (this.userId === userId && this.scheduledTimeoutId) {
+      return;
+    }
+
     this.userId = userId;
     if (frequencyHours !== undefined) this.frequencyHours = frequencyHours;
-    if (this.enabled) {
-      this.scheduleNextRun();
+
+    // Resume cadence from persisted state so it survives restarts/redeploys.
+    const state = await this.loadState();
+    if (state) {
+      this.enabled = state.enabled;
+      this.frequencyHours = frequencyHours ?? state.frequencyHours;
+      this.lastRunAt = state.lastRunAt ?? null;
+      this.lastError = state.lastError ?? null;
+      this.lastResult = (state.lastResult as ReconciliationResult | null) ?? null;
     }
+
+    if (this.enabled) {
+      // If we have a persisted next-run in the future, resume from it.
+      // If it's overdue (or we've never run), kick a first run soon rather
+      // than waiting a full frequency window — this also means a fresh deploy
+      // reconciles shortly after boot instead of only `frequencyHours` later.
+      let delay = FIRST_RUN_DELAY_MS;
+      if (state?.nextRunAt) {
+        const remaining = state.nextRunAt.getTime() - Date.now();
+        delay = remaining > 0 ? remaining : FIRST_RUN_DELAY_MS;
+      }
+      this.scheduleNextRun(delay);
+    }
+
+    // Persist (creates the row on first ever init).
+    await this.saveState();
+
     console.log(
-      `[LibraryReconciliation] Initialized for user ${userId}, every ${this.frequencyHours}h`
+      `[LibraryReconciliation] Initialized for user ${userId}, every ${this.frequencyHours}h` +
+        (this.nextRunAt ? `, next run ${this.nextRunAt.toISOString()}` : ', disabled')
     );
+  }
+
+  private async loadState(): Promise<LibraryReconciliationState | null> {
+    if (!this.userId) return null;
+    try {
+      const rows = await db
+        .select()
+        .from(libraryReconciliationState)
+        .where(eq(libraryReconciliationState.userId, this.userId))
+        .limit(1);
+      return rows[0] ?? null;
+    } catch (err) {
+      console.error('[LibraryReconciliation] loadState failed:', err);
+      return null;
+    }
+  }
+
+  private async saveState(): Promise<void> {
+    if (!this.userId) return;
+    try {
+      const values = {
+        userId: this.userId,
+        enabled: this.enabled,
+        frequencyHours: this.frequencyHours,
+        lastRunAt: this.lastRunAt,
+        nextRunAt: this.nextRunAt,
+        isRunning: this.isRunning,
+        lastError: this.lastError,
+        lastResult: this.lastResult,
+        updatedAt: new Date(),
+      };
+      await db
+        .insert(libraryReconciliationState)
+        .values(values)
+        .onConflictDoUpdate({
+          target: libraryReconciliationState.userId,
+          set: {
+            enabled: values.enabled,
+            frequencyHours: values.frequencyHours,
+            lastRunAt: values.lastRunAt,
+            nextRunAt: values.nextRunAt,
+            isRunning: values.isRunning,
+            lastError: values.lastError,
+            lastResult: values.lastResult,
+            updatedAt: values.updatedAt,
+          },
+        });
+    } catch (err) {
+      console.error('[LibraryReconciliation] saveState failed:', err);
+    }
   }
 
   start(): void {
     this.enabled = true;
     this.scheduleNextRun();
+    void this.saveState();
   }
 
   stop(): void {
@@ -127,6 +219,7 @@ class LibraryReconciliationManager {
       this.scheduledTimeoutId = null;
     }
     this.nextRunAt = null;
+    void this.saveState();
   }
 
   getStatus(): ReconciliationStatus {
@@ -150,6 +243,7 @@ class LibraryReconciliationManager {
     }
 
     this.isRunning = true;
+    void this.saveState();
     try {
       const result = await reconcileLibrary(this.userId);
       this.lastResult = result;
@@ -168,6 +262,9 @@ class LibraryReconciliationManager {
     } finally {
       this.isRunning = false;
       if (this.enabled) this.scheduleNextRun();
+      // Persist run outcome + the freshly computed nextRunAt so cadence and
+      // status survive a restart.
+      await this.saveState();
     }
   }
 

--- a/src/lib/services/song-matcher.ts
+++ b/src/lib/services/song-matcher.ts
@@ -128,6 +128,24 @@ export function normalizeTitle(title: string): string {
 }
 
 /**
+ * Strip a leading "Artist - " prefix from a title when it overlaps the given
+ * artist. YouTube-rip imports frequently store the whole video title as the track
+ * title (e.g. "Cloonee & Prospa - Good Girl (ft. Tristan Henry)"), which tanks the
+ * title-similarity score against the real title ("Good Girl"). Only strips when the
+ * prefix shares a token with the artist, so genuine "A - B" titles are left alone.
+ */
+export function stripLeadingArtistPrefix(title: string, artist: string): string {
+  const m = title.match(/^(.{1,60}?)\s[-—–]\s(.+)$/);
+  if (!m) return title;
+  const prefix = normalizeArtist(m[1]);
+  const art = normalizeArtist(artist);
+  if (!prefix || !art) return title;
+  const artistTokens = new Set(art.split(' ').filter(Boolean));
+  const overlaps = prefix.split(' ').filter(Boolean).some((t) => artistTokens.has(t));
+  return overlaps ? m[2] : title;
+}
+
+/**
  * Calculate match score between two songs
  */
 export function calculateMatchScore(
@@ -142,11 +160,23 @@ export function calculateMatchScore(
     return { score: 100, confidence: 'exact', reason: 'ISRC code match' };
   }
 
-  // Title similarity (40% weight)
-  const titleSimilarity = stringSimilarity(
+  // Title similarity (40% weight). Also try the candidate title with a leading
+  // "Artist - " prefix stripped, so a polluted YouTube-rip title still matches.
+  // Feat/version info is only dropped on THIS recovery path (a candidate that had
+  // an artist prefix) — normal titles keep it, so remix/feat versions stay distinct.
+  const candidateStripped = stripLeadingArtistPrefix(candidate.title, candidate.artist);
+  let titleSimilarity = stringSimilarity(
     normalizeTitle(source.title),
     normalizeTitle(candidate.title)
   );
+  if (candidateStripped !== candidate.title) {
+    const dropFeat = (t: string) =>
+      t.replace(/\s*[([]\s*(feat|ft|featuring|with)\.?\s[^)\]]*[)\]]/gi, '');
+    titleSimilarity = Math.max(
+      titleSimilarity,
+      stringSimilarity(normalizeTitle(dropFeat(source.title)), normalizeTitle(dropFeat(candidateStripped)))
+    );
+  }
   score += titleSimilarity * 40;
   if (titleSimilarity > 0.9) reasons.push('Title matches closely');
   else if (titleSimilarity > 0.7) reasons.push('Title similar');

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -36,7 +36,8 @@ export type FallbackTrackStatus =
   | 'searching' // queued to MeTube, waiting for the download to land
   | 'downloaded' // finished; verification passed (or verification disabled)
   | 'mismatch' // finished, but verification thinks it's likely the wrong track
-  | 'failed'; // MeTube reported an error, or we timed out waiting
+  | 'downloading' // still fetching in MeTube when our window closed (not confirmed, not failed)
+  | 'failed'; // MeTube reported an error, after exhausting retries
 
 export interface FallbackVerification {
   matched: boolean;
@@ -83,8 +84,10 @@ export interface StartFallbackOptions {
 
 /** Poll MeTube this often while waiting for a single download. */
 const POLL_INTERVAL_MS = 3000;
-/** Give up on a single track after this long. */
-const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+/** Confirmation window for a single track. These downloads can take 5–10 min
+ *  under yt-dlp throttling, so this is generous; a slow one that's still fetching
+ *  when it closes is reported `downloading`, not failed. */
+const DOWNLOAD_TIMEOUT_MS = 12 * 60 * 1000;
 /** Small breather between tracks so each is attributable in MeTube/logs. */
 const BETWEEN_TRACKS_MS = 750;
 /** Wait between retry attempts for a track that failed to download. */
@@ -198,13 +201,41 @@ interface DownloadOutcome {
   item?: MeTubeDownload;
   errored?: boolean;
   timedOut?: boolean;
+  stillDownloading?: boolean; // timed out, but MeTube was still actively fetching it
   error?: string;
 }
 
 /**
- * Snapshot MeTube's current ids, queue a single `ytsearch1:` download, then poll
- * until a *new* item reaches a terminal (finished/error) state or we time out.
- * One-at-a-time makes the "new id" detection unambiguous.
+ * Loose "is this MeTube item our track?" check for DETECTION (not verification).
+ * We can't know the resolved video id in advance and MeTube keys by video id, so
+ * matching a *previously downloaded* video would never appear as a "new id".
+ * Instead we match on content: decent title-token overlap plus the primary artist
+ * present. Deliberately looser than `verifyDownload` — a loose-matched item that
+ * turns out to be wrong is still surfaced later as `mismatch` by verification.
+ */
+export function itemLikelyMatchesTrack(
+  track: FallbackTrack,
+  item: Partial<Pick<MeTubeDownload, 'title' | 'filename'>>
+): boolean {
+  const got = normalizeForCompare(item.title || item.filename || '');
+  if (!got) return false;
+  const wantTitle = normalizeForCompare(track.title);
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+  if (!wantTitle) return false;
+
+  const titleOverlap = got.includes(wantTitle) ? 1 : tokenOverlap(wantTitle, got);
+  const artistOk =
+    wantArtist.length < 3 || got.includes(wantArtist) || tokenOverlap(wantArtist, got) >= 0.5;
+
+  return titleOverlap >= 0.5 && artistOk;
+}
+
+/**
+ * Queue a single `ytsearch1:` download and wait for the matching item to reach a
+ * terminal state. Detection is content-based (see `itemLikelyMatchesTrack`) so it
+ * survives MeTube's id-dedup of already-downloaded videos and never gives up on a
+ * download that is simply slow — on timeout it reports `stillDownloading` rather
+ * than a false failure, and never deletes an in-flight item.
  */
 async function queueAndAwaitDownload(
   track: FallbackTrack,
@@ -217,12 +248,24 @@ async function queueAndAwaitDownload(
   } catch {
     before = { done: {}, queue: {} };
   }
-  const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
+
+  // Ignore a pre-existing *errored* entry for this track (a stale prior failure);
+  // but a pre-existing *finished* match means it's already downloaded — done.
+  const staleErrorIds = new Set(
+    Object.values(before.done)
+      .filter((d) => d.status === 'error' && itemLikelyMatchesTrack(track, d))
+      .map((d) => d.id)
+  );
+  const preFinished = Object.values(before.done).find(
+    (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+  );
+  if (preFinished) {
+    return { metubeId: preFinished.id, item: preFinished };
+  }
 
   try {
     // No custom_name_prefix: yt-dlp's own title (usually "Artist - Title …")
-    // already carries the naming, and prefixing it doubled the string
-    // ("Sun Room - Insincere.Sun Room - Insincere [Official Audio]"). Picard
+    // already carries the naming, and prefixing it doubled the string. Picard
     // retags from the audio fingerprint anyway, so the raw title filename is fine.
     await metube.addDownload({
       url: buildYouTubeSearchUrl(query),
@@ -236,7 +279,7 @@ async function queueAndAwaitDownload(
   }
 
   const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
-  let seenId: string | undefined;
+  let sawInFlight = false;
 
   while (Date.now() < deadline) {
     await sleep(POLL_INTERVAL_MS);
@@ -248,42 +291,53 @@ async function queueAndAwaitDownload(
       continue;
     }
 
-    // Terminal first: a new item in `done` is finished or errored.
-    const doneNew = Object.values(q.done).find((d) => !knownIds.has(d.id));
-    if (doneNew) {
-      if (doneNew.status === 'error') {
-        return { metubeId: doneNew.id, item: doneNew, errored: true, error: doneNew.msg || 'MeTube reported error' };
-      }
-      return { metubeId: doneNew.id, item: doneNew };
+    const finished = Object.values(q.done).find(
+      (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+    );
+    if (finished) return { metubeId: finished.id, item: finished };
+
+    const errored = Object.values(q.done).find(
+      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && itemLikelyMatchesTrack(track, d)
+    );
+    if (errored) {
+      return { metubeId: errored.id, item: errored, errored: true, error: errored.msg || 'MeTube reported error' };
     }
 
-    // Still in flight — remember the id so a timeout can still report it.
-    const queueNew = Object.values(q.queue).find((d) => !knownIds.has(d.id));
-    if (queueNew) seenId = queueNew.id;
+    // Actively fetching? These downloads can take 5–10 min, so this matters.
+    if (Object.values(q.queue).some((d) => itemLikelyMatchesTrack(track, d))) {
+      sawInFlight = true;
+    }
   }
 
-  return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
+  // Timed out. If MeTube was still fetching it, it will very likely finish shortly
+  // — report as still-downloading (NOT failed) and never delete it.
+  return {
+    timedOut: true,
+    stillDownloading: sawInFlight,
+    error: sawInFlight
+      ? 'still downloading when the confirmation window closed'
+      : 'no matching download appeared before timeout',
+  };
 }
 
 /**
- * Remove a failed/stuck MeTube entry so a retry can re-add the same id cleanly
- * (MeTube keys downloads by id, and `ytsearch1:` re-resolves to the same video).
+ * Remove a genuinely errored MeTube entry so a retry can re-add the same video
+ * cleanly. Only ever called for confirmed errors — never for in-flight downloads.
  */
-async function cleanupFailedDownload(metubeId?: string): Promise<void> {
+async function cleanupErroredDownload(metubeId?: string): Promise<void> {
   if (!metubeId) return;
-  for (const where of ['done', 'queue'] as const) {
-    try {
-      await metube.deleteDownloads([metubeId], where);
-    } catch {
-      /* best-effort */
-    }
+  try {
+    await metube.deleteDownloads([metubeId], 'done');
+  } catch {
+    /* best-effort */
   }
 }
 
 /**
- * Queue a track and, if it fails or times out, retry up to `maxAttempts` total.
- * YouTube 403 / PO-token errors are frequently transient, so a couple of retries
- * meaningfully lift the success rate. Returns the final outcome plus the attempt count.
+ * Queue a track and, on a *confirmed error*, retry up to `maxAttempts` (YouTube
+ * 403 / PO-token errors are often transient). A slow download that merely timed
+ * out while still fetching is NOT retried — retrying would re-queue a video that
+ * is already downloading. Returns the final outcome plus the attempt count.
  */
 async function queueWithRetries(
   track: FallbackTrack,
@@ -296,12 +350,13 @@ async function queueWithRetries(
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
     outcome = await queueAndAwaitDownload(track, query, folder);
 
-    if (!outcome.errored && !outcome.timedOut) {
+    // Success, or a timeout on a still-in-flight download — don't retry either.
+    if ((!outcome.errored && !outcome.timedOut) || outcome.stillDownloading) {
       return { ...outcome, attempts: attempt };
     }
 
-    // Failed — clean up so the next attempt can re-queue the same id.
-    await cleanupFailedDownload(outcome.metubeId);
+    // Confirmed error (or nothing ever appeared) — clean up and retry.
+    if (outcome.errored) await cleanupErroredDownload(outcome.metubeId);
 
     if (attempt < maxAttempts) {
       console.warn(
@@ -350,7 +405,12 @@ async function runJob(job: FallbackJob): Promise<void> {
       entry.filename = outcome.item.filename;
     }
 
-    if (outcome.errored || outcome.timedOut) {
+    if (outcome.stillDownloading) {
+      // Slow download still fetching when our window closed — not a failure.
+      entry.status = 'downloading';
+      entry.error = outcome.error;
+      console.log(`[YouTubeFallback] STILL DOWNLOADING ${label} (unconfirmed): ${entry.error}`);
+    } else if (outcome.errored || outcome.timedOut) {
       entry.status = 'failed';
       entry.error = outcome.error;
       console.warn(
@@ -378,7 +438,7 @@ async function runJob(job: FallbackJob): Promise<void> {
 
   const summary = summarizeJob(job);
   console.log(
-    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.failed} failed (of ${summary.total})`
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
   );
 }
 
@@ -388,9 +448,10 @@ export function summarizeJob(job: FallbackJob): {
   searching: number;
   downloaded: number;
   mismatch: number;
+  downloading: number;
   failed: number;
 } {
-  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, failed: 0 };
+  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
   for (const r of job.results) summary[r.status]++;
   return summary;
 }

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -53,6 +53,7 @@ export interface FallbackTrackResult {
   filename?: string;
   verification?: FallbackVerification;
   error?: string;
+  attempts?: number; // how many download attempts were made (>=1 once started)
   startedAt?: number;
   finishedAt?: number;
 }
@@ -65,6 +66,7 @@ export interface FallbackJob {
   updatedAt: number;
   verify: boolean;
   folder?: string;
+  maxAttempts: number;
   currentIndex: number;
   results: FallbackTrackResult[];
 }
@@ -72,6 +74,7 @@ export interface FallbackJob {
 export interface StartFallbackOptions {
   verify?: boolean; // default true
   folder?: string; // MeTube subfolder; default = MeTube's configured folder
+  maxAttempts?: number; // download attempts per track before giving up (default 3)
 }
 
 // ---------------------------------------------------------------------------
@@ -84,6 +87,13 @@ const POLL_INTERVAL_MS = 3000;
 const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
 /** Small breather between tracks so each is attributable in MeTube/logs. */
 const BETWEEN_TRACKS_MS = 750;
+/** Wait between retry attempts for a track that failed to download. */
+const RETRY_DELAY_MS = 5000;
+/** Default download attempts per track. YouTube 403 / PO-token errors are often
+ *  transient, so we re-queue a few times before declaring a track failed. */
+export const DEFAULT_MAX_ATTEMPTS = 3;
+/** Ceiling on attempts, whatever the caller asks for. */
+export const MAX_ATTEMPTS_LIMIT = 5;
 /** Hard cap on tracks per job to avoid runaway batches. */
 export const MAX_TRACKS_PER_JOB = 50;
 
@@ -210,12 +220,15 @@ async function queueAndAwaitDownload(
   const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
 
   try {
+    // No custom_name_prefix: yt-dlp's own title (usually "Artist - Title …")
+    // already carries the naming, and prefixing it doubled the string
+    // ("Sun Room - Insincere.Sun Room - Insincere [Official Audio]"). Picard
+    // retags from the audio fingerprint anyway, so the raw title filename is fine.
     await metube.addDownload({
       url: buildYouTubeSearchUrl(query),
       format: 'mp3',
       quality: 'best',
       folder,
-      custom_name_prefix: `${track.artist} - ${track.title}`,
       auto_start: true,
     });
   } catch (err) {
@@ -252,6 +265,54 @@ async function queueAndAwaitDownload(
   return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
 }
 
+/**
+ * Remove a failed/stuck MeTube entry so a retry can re-add the same id cleanly
+ * (MeTube keys downloads by id, and `ytsearch1:` re-resolves to the same video).
+ */
+async function cleanupFailedDownload(metubeId?: string): Promise<void> {
+  if (!metubeId) return;
+  for (const where of ['done', 'queue'] as const) {
+    try {
+      await metube.deleteDownloads([metubeId], where);
+    } catch {
+      /* best-effort */
+    }
+  }
+}
+
+/**
+ * Queue a track and, if it fails or times out, retry up to `maxAttempts` total.
+ * YouTube 403 / PO-token errors are frequently transient, so a couple of retries
+ * meaningfully lift the success rate. Returns the final outcome plus the attempt count.
+ */
+async function queueWithRetries(
+  track: FallbackTrack,
+  query: string,
+  folder: string | undefined,
+  maxAttempts: number,
+  label: string
+): Promise<DownloadOutcome & { attempts: number }> {
+  let outcome: DownloadOutcome = {};
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    outcome = await queueAndAwaitDownload(track, query, folder);
+
+    if (!outcome.errored && !outcome.timedOut) {
+      return { ...outcome, attempts: attempt };
+    }
+
+    // Failed — clean up so the next attempt can re-queue the same id.
+    await cleanupFailedDownload(outcome.metubeId);
+
+    if (attempt < maxAttempts) {
+      console.warn(
+        `[YouTubeFallback] attempt ${attempt}/${maxAttempts} failed for ${label}: ${outcome.error}; retrying in ${RETRY_DELAY_MS}ms`
+      );
+      await sleep(RETRY_DELAY_MS);
+    }
+  }
+  return { ...outcome, attempts: maxAttempts };
+}
+
 // ---------------------------------------------------------------------------
 // In-process job registry + batch runner
 // ---------------------------------------------------------------------------
@@ -276,10 +337,12 @@ async function runJob(job: FallbackJob): Promise<void> {
     entry.startedAt = Date.now();
     job.updatedAt = Date.now();
 
+    const label = `"${entry.track.artist} - ${entry.track.title}"`;
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
-    const outcome = await queueAndAwaitDownload(entry.track, entry.query, job.folder);
+    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
     entry.metubeId = outcome.metubeId;
+    entry.attempts = outcome.attempts;
     entry.finishedAt = Date.now();
 
     if (outcome.item) {
@@ -290,7 +353,9 @@ async function runJob(job: FallbackJob): Promise<void> {
     if (outcome.errored || outcome.timedOut) {
       entry.status = 'failed';
       entry.error = outcome.error;
-      console.warn(`[YouTubeFallback] FAILED "${entry.track.artist} - ${entry.track.title}": ${entry.error}`);
+      console.warn(
+        `[YouTubeFallback] FAILED ${label} after ${outcome.attempts} attempt(s): ${entry.error}`
+      );
     } else if (job.verify && outcome.item) {
       const verification = verifyDownload(entry.track, outcome.item);
       entry.verification = verification;
@@ -349,6 +414,11 @@ export function startYouTubeFallbackJob(
     throw new Error('No valid tracks to download (each needs an artist and title)');
   }
 
+  const maxAttempts = Math.min(
+    MAX_ATTEMPTS_LIMIT,
+    Math.max(1, options.maxAttempts ?? DEFAULT_MAX_ATTEMPTS)
+  );
+
   const now = Date.now();
   const job: FallbackJob = {
     id: crypto.randomUUID(),
@@ -358,6 +428,7 @@ export function startYouTubeFallbackJob(
     updatedAt: now,
     verify: options.verify ?? true,
     folder: options.folder,
+    maxAttempts,
     currentIndex: 0,
     results: cleaned.map((track) => ({
       track,

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -33,6 +33,7 @@ export interface FallbackTrack {
 
 export type FallbackTrackStatus =
   | 'pending' // not yet started
+  | 'skipped' // already in the library (dedup guard) — not downloaded
   | 'searching' // queued to MeTube, waiting for the download to land
   | 'downloaded' // finished; verification passed (or verification disabled)
   | 'mismatch' // finished, but verification thinks it's likely the wrong track
@@ -68,6 +69,7 @@ export interface FallbackJob {
   verify: boolean;
   folder?: string;
   maxAttempts: number;
+  skipInLibrary: boolean;
   currentIndex: number;
   results: FallbackTrackResult[];
 }
@@ -76,6 +78,7 @@ export interface StartFallbackOptions {
   verify?: boolean; // default true
   folder?: string; // MeTube subfolder; default = MeTube's configured folder
   maxAttempts?: number; // download attempts per track before giving up (default 3)
+  skipInLibrary?: boolean; // dedup guard: skip tracks already in Navidrome (default true)
 }
 
 // ---------------------------------------------------------------------------
@@ -321,6 +324,36 @@ async function queueAndAwaitDownload(
 }
 
 /**
+ * Dedup guard: is this track already in the Navidrome library? Uses a loose
+ * content match (same as detection) so it catches copies stored under a polluted
+ * YouTube-rip title that the import matcher scored too low — the exact case that
+ * causes the same track to be re-downloaded. Navidrome import is lazy so this
+ * module stays importable in tests without pulling in the service graph.
+ */
+async function findInLibrary(track: FallbackTrack): Promise<{ title: string } | null> {
+  try {
+    const { search } = await import('./navidrome');
+    const primaryArtist = (track.artist || '').split(/[;,]/)[0].trim();
+    const query = normalizeSearchQuery(track); // "<primary artist> <clean title>"
+    const results = await search(query).catch(() => [] as Array<{ title?: string; name?: string }>);
+    const hit = results.find((s) =>
+      itemLikelyMatchesTrack(track, { title: s.title || s.name || '' })
+    );
+    if (hit) return { title: hit.title || hit.name || '' };
+    // Fallback: an artist-only search catches copies whose stored title is the
+    // full "Artist - Title (ft…)" video title (loose match handles the rest).
+    if (primaryArtist.length > 2) {
+      const r2 = await search(primaryArtist).catch(() => [] as Array<{ title?: string; name?: string }>);
+      const hit2 = r2.find((s) => itemLikelyMatchesTrack(track, { title: s.title || s.name || '' }));
+      if (hit2) return { title: hit2.title || hit2.name || '' };
+    }
+    return null;
+  } catch {
+    return null; // never let a library-check failure block a download
+  }
+}
+
+/**
  * Remove a genuinely errored MeTube entry so a retry can re-add the same video
  * cleanly. Only ever called for confirmed errors — never for in-flight downloads.
  */
@@ -393,6 +426,22 @@ async function runJob(job: FallbackJob): Promise<void> {
     job.updatedAt = Date.now();
 
     const label = `"${entry.track.artist} - ${entry.track.title}"`;
+
+    // Dedup guard: don't re-download something already in the library (even if it
+    // was stored under a junk title the import matcher missed).
+    if (job.skipInLibrary) {
+      const existing = await findInLibrary(entry.track);
+      if (existing) {
+        entry.status = 'skipped';
+        entry.resultTitle = existing.title;
+        entry.finishedAt = Date.now();
+        job.updatedAt = Date.now();
+        console.log(`[YouTubeFallback] SKIP (already in library) ${label} -> "${existing.title}"`);
+        if (i < job.results.length - 1) await sleep(BETWEEN_TRACKS_MS);
+        continue;
+      }
+    }
+
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
     const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
@@ -438,20 +487,21 @@ async function runJob(job: FallbackJob): Promise<void> {
 
   const summary = summarizeJob(job);
   console.log(
-    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.skipped} skipped, ${summary.mismatch} mismatch, ${summary.downloading} still-downloading, ${summary.failed} failed (of ${summary.total})`
   );
 }
 
 export function summarizeJob(job: FallbackJob): {
   total: number;
   pending: number;
+  skipped: number;
   searching: number;
   downloaded: number;
   mismatch: number;
   downloading: number;
   failed: number;
 } {
-  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
+  const summary = { total: job.results.length, pending: 0, skipped: 0, searching: 0, downloaded: 0, mismatch: 0, downloading: 0, failed: 0 };
   for (const r of job.results) summary[r.status]++;
   return summary;
 }
@@ -490,6 +540,7 @@ export function startYouTubeFallbackJob(
     verify: options.verify ?? true,
     folder: options.folder,
     maxAttempts,
+    skipInLibrary: options.skipInLibrary ?? true,
     currentIndex: 0,
     results: cleaned.map((track) => ({
       track,

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -1,0 +1,386 @@
+/**
+ * YouTube per-song fallback download (issue #145)
+ *
+ * When a playlist-import "miss" can't be resolved through Lidarr (commonly the
+ * "artist has 0 albums" dead-end — see issue #144), we can still fetch the track
+ * straight from YouTube via MeTube, **one song at a time**, using yt-dlp's
+ * `ytsearch1:` search syntax (no YouTube API key / OAuth required). Each download
+ * is verified against the requested artist/title so obvious wrong-video / live /
+ * channel-rip results are flagged instead of silently polluting the library.
+ *
+ * The landed file (named `Artist - Title`) drops into MeTube's download folder,
+ * where the existing Picard retag → Lidarr move → Navidrome rescan flow can pick
+ * it up. This module deliberately stops at "file downloaded + verified"; the
+ * reconcile-back-into-playlist step is owned by the Import Manager (issue #132).
+ *
+ * Job state is kept in-process (this is a diagnostic / testing path polled while
+ * the page is open), mirroring the media-flow-manager pattern — no new table.
+ */
+
+import * as metube from './metube';
+import type { MeTubeDownload } from './metube';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface FallbackTrack {
+  artist: string;
+  title: string;
+  album?: string;
+  duration?: number; // seconds, if known
+}
+
+export type FallbackTrackStatus =
+  | 'pending' // not yet started
+  | 'searching' // queued to MeTube, waiting for the download to land
+  | 'downloaded' // finished; verification passed (or verification disabled)
+  | 'mismatch' // finished, but verification thinks it's likely the wrong track
+  | 'failed'; // MeTube reported an error, or we timed out waiting
+
+export interface FallbackVerification {
+  matched: boolean;
+  score: number; // 0..1
+  reason: string;
+}
+
+export interface FallbackTrackResult {
+  track: FallbackTrack;
+  query: string;
+  status: FallbackTrackStatus;
+  metubeId?: string;
+  resultTitle?: string;
+  filename?: string;
+  verification?: FallbackVerification;
+  error?: string;
+  startedAt?: number;
+  finishedAt?: number;
+}
+
+export interface FallbackJob {
+  id: string;
+  userId: string;
+  status: 'running' | 'completed' | 'failed';
+  createdAt: number;
+  updatedAt: number;
+  verify: boolean;
+  folder?: string;
+  currentIndex: number;
+  results: FallbackTrackResult[];
+}
+
+export interface StartFallbackOptions {
+  verify?: boolean; // default true
+  folder?: string; // MeTube subfolder; default = MeTube's configured folder
+}
+
+// ---------------------------------------------------------------------------
+// Tunables
+// ---------------------------------------------------------------------------
+
+/** Poll MeTube this often while waiting for a single download. */
+const POLL_INTERVAL_MS = 3000;
+/** Give up on a single track after this long. */
+const DOWNLOAD_TIMEOUT_MS = 5 * 60 * 1000;
+/** Small breather between tracks so each is attributable in MeTube/logs. */
+const BETWEEN_TRACKS_MS = 750;
+/** Hard cap on tracks per job to avoid runaway batches. */
+export const MAX_TRACKS_PER_JOB = 50;
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+// ---------------------------------------------------------------------------
+// Pure helpers (unit-tested)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a clean YouTube search query from a track. Uses the primary artist
+ * (drops `;`/`,`-joined collaborators, which hurt search) and strips noisy
+ * qualifiers that rarely appear in YouTube titles.
+ */
+export function normalizeSearchQuery(track: FallbackTrack): string {
+  const primaryArtist = (track.artist || '')
+    .split(/[;,]/)[0]
+    .trim();
+
+  const cleanTitle = (track.title || '')
+    .replace(/\s*\((?:with|feat\.?|ft\.?|featuring)\s+[^)]+\)/gi, '')
+    .replace(/\s*\[(?:with|feat\.?|ft\.?|featuring)\s+[^\]]+\]/gi, '')
+    .replace(/\s*\([^)]*\b(?:remaster|remastered|deluxe|anniversary|expanded|bonus)\b[^)]*\)/gi, '')
+    .replace(/\s*\[[^\]]*\b(?:remaster|remastered|deluxe|anniversary|expanded|bonus)\b[^\]]*\]/gi, '')
+    .replace(/\s+-\s*\d{4}\s*remaster(?:ed)?\s*$/gi, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+
+  return `${primaryArtist} ${cleanTitle}`.trim();
+}
+
+/**
+ * yt-dlp search "URL". MeTube passes the `url` field straight to yt-dlp, which
+ * treats `ytsearch1:<query>` as "download the top YouTube result for <query>".
+ */
+export function buildYouTubeSearchUrl(query: string): string {
+  return `ytsearch1:${query}`;
+}
+
+/** Lowercase, strip punctuation, collapse whitespace — for loose comparison. */
+function normalizeForCompare(s: string): string {
+  return (s || '')
+    .toLowerCase()
+    .replace(/\(.*?\)|\[.*?\]/g, ' ') // drop bracketed qualifiers
+    .replace(/\b(official|music|video|audio|lyrics?|visualizer|hd|4k)\b/g, ' ')
+    .replace(/[^\p{L}\p{N}\s]/gu, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function tokenOverlap(want: string, got: string): number {
+  const wantTokens = want.split(' ').filter(Boolean);
+  if (wantTokens.length === 0) return 0;
+  const gotSet = new Set(got.split(' ').filter(Boolean));
+  const hits = wantTokens.filter((t) => gotSet.has(t)).length;
+  return hits / wantTokens.length;
+}
+
+/**
+ * Verify a completed MeTube item is plausibly the requested track. Because
+ * `ytsearch1:` returns whatever YouTube ranks first, this guards against live
+ * versions, remixes, hour-long mixes, and channel rips.
+ */
+export function verifyDownload(
+  track: FallbackTrack,
+  item: Partial<Pick<MeTubeDownload, 'title' | 'filename'>>
+): FallbackVerification {
+  const resultTitle = (item.title || item.filename || '').toString();
+  if (!resultTitle) {
+    return { matched: false, score: 0, reason: 'no result title to verify against' };
+  }
+
+  const got = normalizeForCompare(resultTitle);
+  const wantTitle = normalizeForCompare(track.title);
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+
+  const titleScore = got.includes(wantTitle) && wantTitle.length > 0 ? 1 : tokenOverlap(wantTitle, got);
+  const artistScore =
+    wantArtist.length < 3 // too short to be a reliable signal
+      ? 1
+      : got.includes(wantArtist)
+        ? 1
+        : tokenOverlap(wantArtist, got);
+
+  // Title carries most of the weight; a strong title + present artist passes.
+  const score = titleScore * 0.65 + artistScore * 0.35;
+  const matched = titleScore >= 0.6 && score >= 0.6;
+
+  return {
+    matched,
+    score: Math.round(score * 100) / 100,
+    reason: `title ${(titleScore * 100) | 0}% / artist ${(artistScore * 100) | 0}% vs "${resultTitle}"`,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// MeTube interaction: queue one track and wait for it to land
+// ---------------------------------------------------------------------------
+
+interface DownloadOutcome {
+  metubeId?: string;
+  item?: MeTubeDownload;
+  errored?: boolean;
+  timedOut?: boolean;
+  error?: string;
+}
+
+/**
+ * Snapshot MeTube's current ids, queue a single `ytsearch1:` download, then poll
+ * until a *new* item reaches a terminal (finished/error) state or we time out.
+ * One-at-a-time makes the "new id" detection unambiguous.
+ */
+async function queueAndAwaitDownload(
+  track: FallbackTrack,
+  query: string,
+  folder?: string
+): Promise<DownloadOutcome> {
+  let before: metube.MeTubeQueueResponse;
+  try {
+    before = await metube.getQueue();
+  } catch {
+    before = { done: {}, queue: {} };
+  }
+  const knownIds = new Set([...Object.keys(before.done), ...Object.keys(before.queue)]);
+
+  try {
+    await metube.addDownload({
+      url: buildYouTubeSearchUrl(query),
+      format: 'mp3',
+      quality: 'best',
+      folder,
+      custom_name_prefix: `${track.artist} - ${track.title}`,
+      auto_start: true,
+    });
+  } catch (err) {
+    return { errored: true, error: err instanceof Error ? err.message : 'MeTube add failed' };
+  }
+
+  const deadline = Date.now() + DOWNLOAD_TIMEOUT_MS;
+  let seenId: string | undefined;
+
+  while (Date.now() < deadline) {
+    await sleep(POLL_INTERVAL_MS);
+
+    let q: metube.MeTubeQueueResponse;
+    try {
+      q = await metube.getQueue();
+    } catch {
+      continue;
+    }
+
+    // Terminal first: a new item in `done` is finished or errored.
+    const doneNew = Object.values(q.done).find((d) => !knownIds.has(d.id));
+    if (doneNew) {
+      if (doneNew.status === 'error') {
+        return { metubeId: doneNew.id, item: doneNew, errored: true, error: doneNew.msg || 'MeTube reported error' };
+      }
+      return { metubeId: doneNew.id, item: doneNew };
+    }
+
+    // Still in flight — remember the id so a timeout can still report it.
+    const queueNew = Object.values(q.queue).find((d) => !knownIds.has(d.id));
+    if (queueNew) seenId = queueNew.id;
+  }
+
+  return { metubeId: seenId, timedOut: true, error: 'timed out waiting for download to finish' };
+}
+
+// ---------------------------------------------------------------------------
+// In-process job registry + batch runner
+// ---------------------------------------------------------------------------
+
+const jobs = new Map<string, FallbackJob>();
+
+/** Drop jobs older than this on the next start, so the map can't grow forever. */
+const JOB_TTL_MS = 6 * 60 * 60 * 1000;
+
+function pruneOldJobs() {
+  const cutoff = Date.now() - JOB_TTL_MS;
+  for (const [id, job] of jobs) {
+    if (job.status !== 'running' && job.updatedAt < cutoff) jobs.delete(id);
+  }
+}
+
+async function runJob(job: FallbackJob): Promise<void> {
+  for (let i = 0; i < job.results.length; i++) {
+    job.currentIndex = i;
+    const entry = job.results[i];
+    entry.status = 'searching';
+    entry.startedAt = Date.now();
+    job.updatedAt = Date.now();
+
+    console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
+
+    const outcome = await queueAndAwaitDownload(entry.track, entry.query, job.folder);
+    entry.metubeId = outcome.metubeId;
+    entry.finishedAt = Date.now();
+
+    if (outcome.item) {
+      entry.resultTitle = outcome.item.title;
+      entry.filename = outcome.item.filename;
+    }
+
+    if (outcome.errored || outcome.timedOut) {
+      entry.status = 'failed';
+      entry.error = outcome.error;
+      console.warn(`[YouTubeFallback] FAILED "${entry.track.artist} - ${entry.track.title}": ${entry.error}`);
+    } else if (job.verify && outcome.item) {
+      const verification = verifyDownload(entry.track, outcome.item);
+      entry.verification = verification;
+      entry.status = verification.matched ? 'downloaded' : 'mismatch';
+      console.log(
+        `[YouTubeFallback] ${entry.status.toUpperCase()} "${entry.track.artist} - ${entry.track.title}" (${verification.reason})`
+      );
+    } else {
+      entry.status = 'downloaded';
+      console.log(`[YouTubeFallback] DOWNLOADED "${entry.track.artist} - ${entry.track.title}"`);
+    }
+
+    job.updatedAt = Date.now();
+    if (i < job.results.length - 1) await sleep(BETWEEN_TRACKS_MS);
+  }
+
+  job.status = 'completed';
+  job.currentIndex = job.results.length;
+  job.updatedAt = Date.now();
+
+  const summary = summarizeJob(job);
+  console.log(
+    `[YouTubeFallback] Job ${job.id} complete: ${summary.downloaded} downloaded, ${summary.mismatch} mismatch, ${summary.failed} failed (of ${summary.total})`
+  );
+}
+
+export function summarizeJob(job: FallbackJob): {
+  total: number;
+  pending: number;
+  searching: number;
+  downloaded: number;
+  mismatch: number;
+  failed: number;
+} {
+  const summary = { total: job.results.length, pending: 0, searching: 0, downloaded: 0, mismatch: 0, failed: 0 };
+  for (const r of job.results) summary[r.status]++;
+  return summary;
+}
+
+/**
+ * Create and start a fallback job. Returns immediately with the job id; the
+ * batch runs one track at a time in the background. Throws on empty/oversized input.
+ */
+export function startYouTubeFallbackJob(
+  userId: string,
+  tracks: FallbackTrack[],
+  options: StartFallbackOptions = {}
+): FallbackJob {
+  pruneOldJobs();
+
+  const cleaned = tracks
+    .filter((t) => t && t.title && t.artist)
+    .slice(0, MAX_TRACKS_PER_JOB);
+
+  if (cleaned.length === 0) {
+    throw new Error('No valid tracks to download (each needs an artist and title)');
+  }
+
+  const now = Date.now();
+  const job: FallbackJob = {
+    id: crypto.randomUUID(),
+    userId,
+    status: 'running',
+    createdAt: now,
+    updatedAt: now,
+    verify: options.verify ?? true,
+    folder: options.folder,
+    currentIndex: 0,
+    results: cleaned.map((track) => ({
+      track,
+      query: normalizeSearchQuery(track),
+      status: 'pending' as FallbackTrackStatus,
+    })),
+  };
+
+  jobs.set(job.id, job);
+
+  // Fire-and-forget; a crash marks the job failed but never takes down the server.
+  runJob(job).catch((err) => {
+    job.status = 'failed';
+    job.updatedAt = Date.now();
+    console.error(`[YouTubeFallback] Job ${job.id} crashed:`, err);
+  });
+
+  return job;
+}
+
+/** Fetch a job, scoped to its owner. */
+export function getYouTubeFallbackJob(jobId: string, userId: string): FallbackJob | undefined {
+  const job = jobs.get(jobId);
+  if (!job || job.userId !== userId) return undefined;
+  return job;
+}

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -243,7 +243,8 @@ export function itemLikelyMatchesTrack(
 async function queueAndAwaitDownload(
   track: FallbackTrack,
   query: string,
-  folder?: string
+  folder: string | undefined,
+  claimedIds: Set<string>
 ): Promise<DownloadOutcome> {
   let before: metube.MeTubeQueueResponse;
   try {
@@ -252,15 +253,21 @@ async function queueAndAwaitDownload(
     before = { done: {}, queue: {} };
   }
 
+  // Content detection can't tell "the item I just queued" from some other item
+  // that loosely matches this track — including one already claimed by an earlier
+  // track in the same batch (e.g. "Song" vs "Song (Remix)"). Exclude claimed ids so
+  // each MeTube item is attributed to at most one track.
+  const matches = (d: MeTubeDownload) => !claimedIds.has(d.id) && itemLikelyMatchesTrack(track, d);
+
   // Ignore a pre-existing *errored* entry for this track (a stale prior failure);
   // but a pre-existing *finished* match means it's already downloaded — done.
   const staleErrorIds = new Set(
     Object.values(before.done)
-      .filter((d) => d.status === 'error' && itemLikelyMatchesTrack(track, d))
+      .filter((d) => d.status === 'error' && matches(d))
       .map((d) => d.id)
   );
   const preFinished = Object.values(before.done).find(
-    (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+    (d) => d.status === 'finished' && matches(d)
   );
   if (preFinished) {
     return { metubeId: preFinished.id, item: preFinished };
@@ -295,19 +302,19 @@ async function queueAndAwaitDownload(
     }
 
     const finished = Object.values(q.done).find(
-      (d) => d.status === 'finished' && itemLikelyMatchesTrack(track, d)
+      (d) => d.status === 'finished' && matches(d)
     );
     if (finished) return { metubeId: finished.id, item: finished };
 
     const errored = Object.values(q.done).find(
-      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && itemLikelyMatchesTrack(track, d)
+      (d) => d.status === 'error' && !staleErrorIds.has(d.id) && matches(d)
     );
     if (errored) {
       return { metubeId: errored.id, item: errored, errored: true, error: errored.msg || 'MeTube reported error' };
     }
 
     // Actively fetching? These downloads can take 5–10 min, so this matters.
-    if (Object.values(q.queue).some((d) => itemLikelyMatchesTrack(track, d))) {
+    if (Object.values(q.queue).some((d) => matches(d))) {
       sawInFlight = true;
     }
   }
@@ -397,28 +404,33 @@ async function cleanupErroredDownload(metubeId?: string): Promise<void> {
 
 /**
  * Queue a track and, on a *confirmed error*, retry up to `maxAttempts` (YouTube
- * 403 / PO-token errors are often transient). A slow download that merely timed
- * out while still fetching is NOT retried — retrying would re-queue a video that
- * is already downloading. Returns the final outcome plus the attempt count.
+ * 403 / PO-token errors are often transient). We retry ONLY confirmed errors:
+ * a bare timeout (nothing matching ever appeared) means the same `ytsearch1:`
+ * query would just re-resolve to the same video our content detection couldn't
+ * see — re-queuing it risks a duplicate/orphan file, not a better outcome. A
+ * still-in-flight timeout is likewise left alone (it's probably about to finish).
+ * Returns the final outcome plus the attempt count.
  */
 async function queueWithRetries(
   track: FallbackTrack,
   query: string,
   folder: string | undefined,
   maxAttempts: number,
-  label: string
+  label: string,
+  claimedIds: Set<string>
 ): Promise<DownloadOutcome & { attempts: number }> {
   let outcome: DownloadOutcome = {};
   for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    outcome = await queueAndAwaitDownload(track, query, folder);
+    outcome = await queueAndAwaitDownload(track, query, folder, claimedIds);
 
-    // Success, or a timeout on a still-in-flight download — don't retry either.
-    if ((!outcome.errored && !outcome.timedOut) || outcome.stillDownloading) {
+    // Anything but a confirmed error is terminal — success, mismatch-to-verify,
+    // still-downloading, or a bare timeout all stop here (see docstring).
+    if (!outcome.errored) {
       return { ...outcome, attempts: attempt };
     }
 
-    // Confirmed error (or nothing ever appeared) — clean up and retry.
-    if (outcome.errored) await cleanupErroredDownload(outcome.metubeId);
+    // Confirmed error — clean up the failed entry and retry.
+    await cleanupErroredDownload(outcome.metubeId);
 
     if (attempt < maxAttempts) {
       console.warn(
@@ -447,6 +459,9 @@ function pruneOldJobs() {
 }
 
 async function runJob(job: FallbackJob): Promise<void> {
+  // MeTube ids already attributed to an earlier track in this batch, so a shared
+  // loose-match (e.g. near-duplicate titles) can't be counted twice. See #2.
+  const claimedIds = new Set<string>();
   for (let i = 0; i < job.results.length; i++) {
     job.currentIndex = i;
     const entry = job.results[i];
@@ -473,10 +488,12 @@ async function runJob(job: FallbackJob): Promise<void> {
 
     console.log(`[YouTubeFallback] (${i + 1}/${job.results.length}) searching: ${entry.query}`);
 
-    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label);
+    const outcome = await queueWithRetries(entry.track, entry.query, job.folder, job.maxAttempts, label, claimedIds);
     entry.metubeId = outcome.metubeId;
     entry.attempts = outcome.attempts;
     entry.finishedAt = Date.now();
+    // Claim this MeTube item so a later, similarly-titled track can't reuse it.
+    if (outcome.metubeId) claimedIds.add(outcome.metubeId);
 
     if (outcome.item) {
       entry.resultTitle = outcome.item.title;

--- a/src/lib/services/youtube-fallback.ts
+++ b/src/lib/services/youtube-fallback.ts
@@ -330,21 +330,50 @@ async function queueAndAwaitDownload(
  * causes the same track to be re-downloaded. Navidrome import is lazy so this
  * module stays importable in tests without pulling in the service graph.
  */
+type LibSong = { title?: string; name?: string; artist?: string };
+
+/**
+ * Does a Navidrome song correspond to the requested track? Unlike a MeTube item
+ * (whose title is the full "Artist - Title" video title), a Navidrome song keeps
+ * artist and title in separate fields — AND a junk-titled copy may carry the whole
+ * video title in `title`. So we accept a match on either shape:
+ *  - clean: title matches by containment/overlap AND the artist field matches, or
+ *  - junk:  the stored title contains both the requested title and artist tokens.
+ */
+export function libraryMatch(track: FallbackTrack, song: LibSong): boolean {
+  const gotTitle = normalizeForCompare(song.title || song.name || '');
+  const wantTitle = normalizeForCompare(track.title);
+  if (!gotTitle || !wantTitle) return false;
+  const wantArtist = normalizeForCompare((track.artist || '').split(/[;,]/)[0]);
+
+  const titleOk =
+    gotTitle.includes(wantTitle) || wantTitle.includes(gotTitle) || tokenOverlap(wantTitle, gotTitle) >= 0.6;
+  if (!titleOk) return false;
+
+  const gotArtist = normalizeForCompare(song.artist || '');
+  const artistOk =
+    wantArtist.length < 3 ||
+    gotArtist.includes(wantArtist) ||
+    wantArtist.includes(gotArtist) ||
+    tokenOverlap(wantArtist, gotArtist) >= 0.5 ||
+    // junk copy: artist is baked into the title string
+    gotTitle.includes(wantArtist) ||
+    tokenOverlap(wantArtist, gotTitle) >= 0.5;
+  return artistOk;
+}
+
 async function findInLibrary(track: FallbackTrack): Promise<{ title: string } | null> {
   try {
     const { search } = await import('./navidrome');
     const primaryArtist = (track.artist || '').split(/[;,]/)[0].trim();
     const query = normalizeSearchQuery(track); // "<primary artist> <clean title>"
-    const results = await search(query).catch(() => [] as Array<{ title?: string; name?: string }>);
-    const hit = results.find((s) =>
-      itemLikelyMatchesTrack(track, { title: s.title || s.name || '' })
-    );
+    const results = (await search(query).catch(() => [])) as LibSong[];
+    const hit = results.find((s) => libraryMatch(track, s));
     if (hit) return { title: hit.title || hit.name || '' };
-    // Fallback: an artist-only search catches copies whose stored title is the
-    // full "Artist - Title (ft…)" video title (loose match handles the rest).
+    // Fallback: artist-only search (catches title-mismatch / junk-title copies).
     if (primaryArtist.length > 2) {
-      const r2 = await search(primaryArtist).catch(() => [] as Array<{ title?: string; name?: string }>);
-      const hit2 = r2.find((s) => itemLikelyMatchesTrack(track, { title: s.title || s.name || '' }));
+      const r2 = (await search(primaryArtist).catch(() => [])) as LibSong[];
+      const hit2 = r2.find((s) => libraryMatch(track, s));
       if (hit2) return { title: hit2.title || hit2.name || '' };
     }
     return null;

--- a/src/routeTree.gen.ts
+++ b/src/routeTree.gen.ts
@@ -78,6 +78,7 @@ import { Route as ApiDiscoveryFeedIndexRouteImport } from './routes/api/discover
 import { Route as ApiDiscoveryFeedAnalyticsRouteImport } from './routes/api/discovery-feed/analytics'
 import { Route as ApiDiscoveryFeedInteractionsRouteImport } from './routes/api/discovery-feed/interactions'
 import { Route as ApiDownloadsQueueRouteImport } from './routes/api/downloads/queue'
+import { Route as ApiDownloadsYoutubeFallbackRouteImport } from './routes/api/downloads/youtube-fallback'
 import { Route as ApiLastfmBackfillRouteImport } from './routes/api/lastfm/backfill'
 import { Route as ApiLastfmSearchRouteImport } from './routes/api/lastfm/search'
 import { Route as ApiLastfmSimilarArtistsRouteImport } from './routes/api/lastfm/similar-artists'
@@ -549,6 +550,12 @@ const ApiDownloadsQueueRoute = ApiDownloadsQueueRouteImport.update({
   path: '/api/downloads/queue',
   getParentRoute: () => rootRouteImport,
 } as any)
+const ApiDownloadsYoutubeFallbackRoute =
+  ApiDownloadsYoutubeFallbackRouteImport.update({
+    id: '/api/downloads/youtube-fallback',
+    path: '/api/downloads/youtube-fallback',
+    getParentRoute: () => rootRouteImport,
+  } as any)
 const ApiLastfmBackfillRoute = ApiLastfmBackfillRouteImport.update({
   id: '/api/lastfm/backfill',
   path: '/api/lastfm/backfill',
@@ -1237,6 +1244,7 @@ export interface FileRoutesByFullPath {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1420,6 +1428,7 @@ export interface FileRoutesByTo {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1607,6 +1616,7 @@ export interface FileRoutesById {
   '/api/discovery-feed/analytics': typeof ApiDiscoveryFeedAnalyticsRoute
   '/api/discovery-feed/interactions': typeof ApiDiscoveryFeedInteractionsRoute
   '/api/downloads/queue': typeof ApiDownloadsQueueRoute
+  '/api/downloads/youtube-fallback': typeof ApiDownloadsYoutubeFallbackRoute
   '/api/lastfm/backfill': typeof ApiLastfmBackfillRoute
   '/api/lastfm/search': typeof ApiLastfmSearchRoute
   '/api/lastfm/similar-artists': typeof ApiLastfmSimilarArtistsRoute
@@ -1794,6 +1804,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -1977,6 +1988,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -2163,6 +2175,7 @@ export interface FileRouteTypes {
     | '/api/discovery-feed/analytics'
     | '/api/discovery-feed/interactions'
     | '/api/downloads/queue'
+    | '/api/downloads/youtube-fallback'
     | '/api/lastfm/backfill'
     | '/api/lastfm/search'
     | '/api/lastfm/similar-artists'
@@ -2338,6 +2351,7 @@ export interface RootRouteChildren {
   ApiDiscoveryFeedAnalyticsRoute: typeof ApiDiscoveryFeedAnalyticsRoute
   ApiDiscoveryFeedInteractionsRoute: typeof ApiDiscoveryFeedInteractionsRoute
   ApiDownloadsQueueRoute: typeof ApiDownloadsQueueRoute
+  ApiDownloadsYoutubeFallbackRoute: typeof ApiDownloadsYoutubeFallbackRoute
   ApiLastfmBackfillRoute: typeof ApiLastfmBackfillRoute
   ApiLastfmSearchRoute: typeof ApiLastfmSearchRoute
   ApiLastfmSimilarArtistsRoute: typeof ApiLastfmSimilarArtistsRoute
@@ -2914,6 +2928,13 @@ declare module '@tanstack/react-router' {
       path: '/api/downloads/queue'
       fullPath: '/api/downloads/queue'
       preLoaderRoute: typeof ApiDownloadsQueueRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/api/downloads/youtube-fallback': {
+      id: '/api/downloads/youtube-fallback'
+      path: '/api/downloads/youtube-fallback'
+      fullPath: '/api/downloads/youtube-fallback'
+      preLoaderRoute: typeof ApiDownloadsYoutubeFallbackRouteImport
       parentRoute: typeof rootRouteImport
     }
     '/api/lastfm/backfill': {
@@ -3960,6 +3981,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiDiscoveryFeedAnalyticsRoute: ApiDiscoveryFeedAnalyticsRoute,
   ApiDiscoveryFeedInteractionsRoute: ApiDiscoveryFeedInteractionsRoute,
   ApiDownloadsQueueRoute: ApiDownloadsQueueRoute,
+  ApiDownloadsYoutubeFallbackRoute: ApiDownloadsYoutubeFallbackRoute,
   ApiLastfmBackfillRoute: ApiLastfmBackfillRoute,
   ApiLastfmSearchRoute: ApiLastfmSearchRoute,
   ApiLastfmSimilarArtistsRoute: ApiLastfmSimilarArtistsRoute,

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -43,6 +43,7 @@ const StartSchema = z
     verify: z.boolean().optional(),
     folder: z.string().optional(),
     maxAttempts: z.number().int().min(1).max(5).optional(),
+    skipInLibrary: z.boolean().optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.tracks?.length && !data.importJobId) {
@@ -106,6 +107,7 @@ const POST = withAuthAndErrorHandling(
         verify: data.verify,
         folder: data.folder,
         maxAttempts: data.maxAttempts,
+        skipInLibrary: data.skipInLibrary,
       });
     } catch (err) {
       return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -1,0 +1,185 @@
+import { createFileRoute } from '@tanstack/react-router';
+import { z } from 'zod';
+import { and, eq } from 'drizzle-orm';
+import { db } from '../../../lib/db';
+import { playlistImportJobs } from '../../../lib/db/schema/playlist-export.schema';
+import {
+  withAuthAndErrorHandling,
+  successResponse,
+  errorResponse,
+} from '../../../lib/utils/api-response';
+import {
+  startYouTubeFallbackJob,
+  getYouTubeFallbackJob,
+  summarizeJob,
+  MAX_TRACKS_PER_JOB,
+  type FallbackTrack,
+} from '../../../lib/services/youtube-fallback';
+
+/**
+ * Per-song YouTube (MeTube) fallback download — issue #145.
+ *
+ * POST: start a job. Provide either an explicit `tracks` array, or an
+ * `importJobId` to pull the misses (no_match / pending_review by default) from a
+ * finished playlist import. Downloads run one at a time and are verified against
+ * the requested artist/title. Returns a `jobId` to poll.
+ *
+ * GET ?jobId=…: report per-track status + a summary.
+ */
+
+const TrackSchema = z.object({
+  artist: z.string().min(1),
+  title: z.string().min(1),
+  album: z.string().optional(),
+  duration: z.number().optional(),
+});
+
+const StartSchema = z
+  .object({
+    tracks: z.array(TrackSchema).optional(),
+    importJobId: z.string().uuid().optional(),
+    // Which import statuses to pull when importJobId is used.
+    statuses: z.array(z.enum(['no_match', 'pending_review', 'matched', 'skipped'])).optional(),
+    verify: z.boolean().optional(),
+    folder: z.string().optional(),
+  })
+  .superRefine((data, ctx) => {
+    if (!data.tracks?.length && !data.importJobId) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide either `tracks` or `importJobId`',
+      });
+    }
+  });
+
+const POST = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const body = await request.json();
+    const data = StartSchema.parse(body);
+
+    let tracks: FallbackTrack[];
+
+    if (data.tracks?.length) {
+      tracks = data.tracks;
+    } else {
+      // Pull misses from a finished import job (scoped to this user).
+      const importJob = await db
+        .select()
+        .from(playlistImportJobs)
+        .where(
+          and(
+            eq(playlistImportJobs.id, data.importJobId!),
+            eq(playlistImportJobs.userId, session.user.id)
+          )
+        )
+        .limit(1)
+        .then((rows) => rows[0]);
+
+      if (!importJob) {
+        return errorResponse('NOT_FOUND', 'Import job not found', { status: 404 });
+      }
+
+      const wanted = new Set(data.statuses ?? ['no_match', 'pending_review']);
+      const results = importJob.matchResults ?? [];
+      tracks = results
+        .filter((r) => wanted.has(r.status))
+        .map((r) => ({
+          artist: r.originalSong.artist,
+          title: r.originalSong.title,
+          album: r.originalSong.album,
+          duration: r.originalSong.duration,
+        }));
+
+      if (tracks.length === 0) {
+        return errorResponse(
+          'NO_TRACKS',
+          `Import job has no tracks in status: ${[...wanted].join(', ')}`,
+          { status: 400 }
+        );
+      }
+    }
+
+    let job;
+    try {
+      job = startYouTubeFallbackJob(session.user.id, tracks, {
+        verify: data.verify,
+        folder: data.folder,
+      });
+    } catch (err) {
+      return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {
+        status: 400,
+      });
+    }
+
+    const truncated = tracks.length > MAX_TRACKS_PER_JOB;
+
+    return successResponse(
+      {
+        jobId: job.id,
+        status: job.status,
+        total: job.results.length,
+        verify: job.verify,
+        truncated,
+        message: truncated
+          ? `Started per-song YouTube download for the first ${MAX_TRACKS_PER_JOB} of ${tracks.length} tracks.`
+          : `Started per-song YouTube download for ${job.results.length} track(s).`,
+      },
+      202
+    );
+  },
+  {
+    service: 'downloads/youtube-fallback',
+    operation: 'start',
+    defaultCode: 'YT_FALLBACK_ERROR',
+    defaultMessage: 'Failed to start YouTube fallback download',
+  }
+);
+
+const GET = withAuthAndErrorHandling(
+  async ({ request, session }) => {
+    const url = new URL(request.url);
+    const jobId = url.searchParams.get('jobId');
+    if (!jobId) {
+      return errorResponse('VALIDATION_ERROR', 'jobId is required', { status: 400 });
+    }
+
+    const job = getYouTubeFallbackJob(jobId, session.user.id);
+    if (!job) {
+      return errorResponse('NOT_FOUND', 'Job not found (it may have expired)', { status: 404 });
+    }
+
+    return successResponse({
+      jobId: job.id,
+      status: job.status,
+      verify: job.verify,
+      currentIndex: job.currentIndex,
+      summary: summarizeJob(job),
+      results: job.results.map((r) => ({
+        artist: r.track.artist,
+        title: r.track.title,
+        query: r.query,
+        status: r.status,
+        resultTitle: r.resultTitle,
+        verification: r.verification,
+        error: r.error,
+      })),
+      createdAt: job.createdAt,
+      updatedAt: job.updatedAt,
+    });
+  },
+  {
+    service: 'downloads/youtube-fallback',
+    operation: 'status',
+    defaultCode: 'YT_FALLBACK_STATUS_ERROR',
+    defaultMessage: 'Failed to get YouTube fallback status',
+  }
+);
+
+export const Route = createFileRoute('/api/downloads/youtube-fallback')({
+  server: {
+    handlers: {
+      POST,
+      GET,
+    },
+  },
+});

--- a/src/routes/api/downloads/youtube-fallback.ts
+++ b/src/routes/api/downloads/youtube-fallback.ts
@@ -42,6 +42,7 @@ const StartSchema = z
     statuses: z.array(z.enum(['no_match', 'pending_review', 'matched', 'skipped'])).optional(),
     verify: z.boolean().optional(),
     folder: z.string().optional(),
+    maxAttempts: z.number().int().min(1).max(5).optional(),
   })
   .superRefine((data, ctx) => {
     if (!data.tracks?.length && !data.importJobId) {
@@ -104,6 +105,7 @@ const POST = withAuthAndErrorHandling(
       job = startYouTubeFallbackJob(session.user.id, tracks, {
         verify: data.verify,
         folder: data.folder,
+        maxAttempts: data.maxAttempts,
       });
     } catch (err) {
       return errorResponse('INVALID_TRACKS', err instanceof Error ? err.message : 'Invalid tracks', {
@@ -152,6 +154,7 @@ const GET = withAuthAndErrorHandling(
       jobId: job.id,
       status: job.status,
       verify: job.verify,
+      maxAttempts: job.maxAttempts,
       currentIndex: job.currentIndex,
       summary: summarizeJob(job),
       results: job.results.map((r) => ({
@@ -161,6 +164,7 @@ const GET = withAuthAndErrorHandling(
         status: r.status,
         resultTitle: r.resultTitle,
         verification: r.verification,
+        attempts: r.attempts,
         error: r.error,
       })),
       createdAt: job.createdAt,


### PR DESCRIPTION
Splits the two ready, unrelated features that had been sitting under the `feat/transition-learning` branch out into their own PR, so they can be reviewed and merged independently of the (still-in-progress) transition-learning work.

## 1. Per-song YouTube / MeTube fallback (#145; touches #131, #132, #144, #146)
When a track can't be matched in the library, fall back to a per-song YouTube download via MeTube (`ytsearch1:`).

- Per-song YouTube (MeTube) fallback download path + API route (`/api/downloads/youtube-fallback`)
- Import review can send unmatched songs straight to YouTube/MeTube
- Auto-retry on failure; dropped the doubled name-prefix bug
- Dedup guards so tracks already in the library aren't re-downloaded (#131, #145), incl. the fix for cleanly-stored tracks the guard missed
- Fixed false-failure on slow-but-successful downloads
- Hardened fallback attribution + retry policy (#145, #146)

## 2. Library-reconciliation scheduler bootstrap
- Bootstraps the library-reconciliation scheduler on prod boot (`server.ts`), plus migration `0029_library_reconciliation_state` and its schema/service.
- Stream-verify remains the critical check (metadata-only comparison misses moved files).

## Migrations
Adds `0029_library_reconciliation_state`. (The transition-learning branch's `0030` stacks on top of this — merge this PR first.)

## Testing
- `song-matcher.test.ts`, `youtube-fallback.test.ts` added/green.

## Notes for review
- The two features are independent and could be split into two PRs if preferred — say the word.
- The remaining transition-learning commits stay on `feat/transition-learning`, stacked on this branch; its PR will be opened against this branch (or against main once this merges) so its diff stays clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EssvghF6669EHaTFDwRMDq
