### PR TITLE
fix: stop playlist sync dupes via name re-link (#127)

### DIFF
--- a/src/lib/services/__tests__/playlist-sync.test.ts
+++ b/src/lib/services/__tests__/playlist-sync.test.ts
@@ -152,6 +152,72 @@ describe('Playlist Sync Service', () => {
       expect(result.errors).toHaveLength(0);
     });
 
+    it('should re-link by name instead of inserting when the Navidrome id changed (#127)', async () => {
+      const userId = 'user-123';
+      // Navidrome returns "Short Tracks" under a NEW id (playlist was recreated).
+      const mockNavidromePlaylists = [
+        {
+          id: 'nav-pl-NEW',
+          name: 'Short Tracks',
+          songCount: 12,
+          duration: 720,
+          owner: 'testuser',
+          public: false,
+          created: '2024-01-01T00:00:00Z',
+          changed: '2024-01-02T00:00:00Z',
+        },
+      ];
+
+      // Local row for "Short Tracks" is soft-deleted (navidromeId nulled by a
+      // prior sync) — so it is NOT matched by id and would otherwise be inserted,
+      // colliding on the unique (user_id, name) constraint.
+      const mockLocalPlaylists = [
+        {
+          id: 'local-short',
+          userId,
+          name: 'Short Tracks',
+          navidromeId: null,
+          songCount: 10,
+          totalDuration: 600,
+          description: '[Deleted from Navidrome] short songs',
+          lastSynced: new Date('2024-01-01T00:00:00Z'),
+        },
+      ];
+
+      vi.mocked(navidrome.getPlaylists).mockResolvedValue(mockNavidromePlaylists);
+      vi.mocked(navidrome.getPlaylist).mockResolvedValue({
+        ...mockNavidromePlaylists[0],
+        entry: [{ id: 's1', title: 'Song 1', artist: 'Artist 1', albumId: 'a1', duration: '60', track: '1' }],
+      });
+
+      (db.select as ReturnType<typeof vi.fn>).mockReturnValue({
+        from: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue(mockLocalPlaylists),
+        }),
+      });
+
+      const setWhere = vi.fn().mockResolvedValue(undefined);
+      const updateSet = vi.fn().mockReturnValue({ where: setWhere });
+      (db.update as ReturnType<typeof vi.fn>).mockReturnValue({ set: updateSet });
+      (db.delete as ReturnType<typeof vi.fn>).mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      });
+      (db.insert as ReturnType<typeof vi.fn>).mockReturnValue({
+        values: vi.fn().mockResolvedValue(undefined),
+      });
+
+      const result = await syncNavidromePlaylists(userId);
+
+      // Re-linked, not inserted → counts as an update, no crash on the name constraint.
+      expect(result.updated).toBe(1);
+      expect(result.added).toBe(0);
+      expect(result.errors).toHaveLength(0);
+      // The re-link update adopts the new Navidrome id and strips the deleted marker.
+      expect(updateSet).toHaveBeenCalledWith(
+        expect.objectContaining({ navidromeId: 'nav-pl-NEW', description: 'short songs' }),
+      );
+    });
+
     it('should mark playlists as deleted when removed from Navidrome', async () => {
       const userId = 'user-123';
       const mockNavidromePlaylists: never[] = []; // No playlists in Navidrome

--- a/src/lib/services/navidrome-smart-playlists.ts
+++ b/src/lib/services/navidrome-smart-playlists.ts
@@ -216,7 +216,10 @@ export async function deleteSmartPlaylist(playlistId: string): Promise<void> {
     },
   });
 
-  if (!response.ok) {
+  // Treat "already gone" as success — deleting a playlist that no longer exists
+  // on Navidrome is the desired end state, and must not block the local delete
+  // (see the authoritative-delete handling in playlists/$id.ts, #160).
+  if (!response.ok && response.status !== 404) {
     const errorText = await response.text();
     throw new ServiceError(
       'NAVIDROME_API_ERROR',

--- a/src/lib/services/playlist-sync.ts
+++ b/src/lib/services/playlist-sync.ts
@@ -46,12 +46,22 @@ export async function syncNavidromePlaylists(userId: string): Promise<SyncResult
         .map(p => [p.navidromeId!, p])
     );
 
+    // Name-keyed index used as a fallback match. A local playlist can exist under
+    // a name whose Navidrome id no longer matches — because the Navidrome playlist
+    // was deleted+recreated (new id) or was previously soft-deleted here (its
+    // navidromeId nulled by step 4 below). Inserting in that case would violate the
+    // unique (user_id, name) constraint on every sync (#127), so we re-link instead.
+    const localPlaylistsByName = new Map(localPlaylists.map(p => [p.name, p]));
+    // Local rows already handled this run, so a name-match can't re-claim them.
+    const claimedLocalIds = new Set<string>();
+
     // 3. Process each Navidrome playlist
     for (const navidromePlaylist of navidromePlaylists) {
       try {
         const localPlaylist = localPlaylistsByNavidromeId.get(navidromePlaylist.id);
 
         if (localPlaylist) {
+          claimedLocalIds.add(localPlaylist.id);
           // Playlist exists locally - check if it needs updating
           if (
             localPlaylist.songCount !== navidromePlaylist.songCount ||
@@ -84,12 +94,43 @@ export async function syncNavidromePlaylists(userId: string): Promise<SyncResult
               .where(eq(userPlaylists.id, localPlaylist.id));
           }
         } else {
-          // New playlist - add to local database
-          const newPlaylistId = await addNavidromePlaylist(userId, navidromePlaylist);
-          if (newPlaylistId) {
-            await syncPlaylistSongs(newPlaylistId, navidromePlaylist.id, userCreds ?? undefined);
-            result.added++;
-            console.log(`➕ Added new playlist "${navidromePlaylist.name}"`);
+          // No match by Navidrome id. Fall back to a name match before inserting,
+          // so a recreated/soft-deleted playlist re-links to its existing local row
+          // instead of colliding on the unique (user_id, name) constraint (#127).
+          const existingByName = localPlaylistsByName.get(navidromePlaylist.name);
+
+          if (existingByName && !claimedLocalIds.has(existingByName.id)) {
+            // Re-link: adopt the new Navidrome id, refresh metadata, and clear any
+            // stale "[Deleted from Navidrome]" marker left by a prior soft delete.
+            if (existingByName.navidromeId) {
+              // Drop the stale id so step 4 doesn't then treat this row as deleted.
+              localPlaylistsByNavidromeId.delete(existingByName.navidromeId);
+            }
+            await db
+              .update(userPlaylists)
+              .set({
+                navidromeId: navidromePlaylist.id,
+                name: navidromePlaylist.name,
+                songCount: navidromePlaylist.songCount,
+                totalDuration: navidromePlaylist.duration,
+                description: stripDeletedMarker(existingByName.description),
+                lastSynced: new Date(),
+                updatedAt: new Date(),
+              })
+              .where(eq(userPlaylists.id, existingByName.id));
+
+            await syncPlaylistSongs(existingByName.id, navidromePlaylist.id, userCreds ?? undefined);
+            claimedLocalIds.add(existingByName.id);
+            result.updated++;
+            console.log(`🔗 Re-linked playlist "${navidromePlaylist.name}" to Navidrome id ${navidromePlaylist.id}`);
+          } else {
+            // Genuinely new playlist - add to local database
+            const newPlaylistId = await addNavidromePlaylist(userId, navidromePlaylist);
+            if (newPlaylistId) {
+              await syncPlaylistSongs(newPlaylistId, navidromePlaylist.id, userCreds ?? undefined);
+              result.added++;
+              console.log(`➕ Added new playlist "${navidromePlaylist.name}"`);
+            }
           }
         }
 
@@ -132,6 +173,13 @@ export async function syncNavidromePlaylists(userId: string): Promise<SyncResult
     console.error(errorMsg);
     throw new ServiceError('PLAYLIST_SYNC_ERROR', errorMsg);
   }
+}
+
+/** Strip the "[Deleted from Navidrome] " prefix a prior soft delete may have added. */
+function stripDeletedMarker(description: string | null): string | null {
+  if (!description) return description;
+  const cleaned = description.replace(/^\[Deleted from Navidrome\]\s*/, '');
+  return cleaned.length > 0 ? cleaned : null;
 }
 
 /**

--- a/src/routes/playlists/$id.tsx
+++ b/src/routes/playlists/$id.tsx
@@ -736,7 +736,8 @@ function PlaylistDetailPage() {
         method: 'DELETE',
       });
       if (!response.ok) {
-        throw new Error('Failed to delete playlist');
+        const err = await response.json().catch(() => null);
+        throw new Error(err?.message || 'Failed to delete playlist');
       }
       return response.json();
     },


### PR DESCRIPTION
## What
Fixes duplicate/constraint-crash on playlist sync (#127). When a Navidrome playlist was deleted+recreated (new id) or previously soft-deleted here (its `navidromeId` nulled), sync found no id match and **inserted** a new local row — colliding on the unique `(user_id, name)` constraint on every sync. Now sync falls back to a **name-keyed match and re-links** the existing row: adopts the new Navidrome id, refreshes metadata, and strips any stale `[Deleted from Navidrome]` marker.

Also:
- `deleteSmartPlaylist` treats a **404 as success** (deleting an already-gone remote playlist is the desired end state).
- The playlist-detail delete flow now surfaces the **server's error message** (complements the 502 from #175's authoritative delete).

## Scope note (rebased)
Originally this PR also rewrote `api/playlists/$id.ts` for the #160 delete-resurrection issue. **That fix already landed via #175** (a stronger multi-path authoritative delete with present/absent verification), so this PR has been rebased to **drop the `$id.ts` changes entirely** and keep main's version. It now contains only the #127 dedup + 404 handling + the frontend message.

## Validation
- `playlist-sync.test.ts`: **11 passed** (incl. the new re-link-by-name case).
- Lint clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)