### PR TITLE
fix: recover "unpaused but frozen clock" playback deadlock (#170)

### DIFF
--- a/src/lib/hooks/usePlaybackStateSync.ts
+++ b/src/lib/hooks/usePlaybackStateSync.ts
@@ -238,15 +238,35 @@ export function usePlaybackStateSync({
           return 0;
         };
         const bufferedEnd = getBufferedEnd(activeDeck);
-        const isStalled = audioHadProgress && activeDeck.currentTime >= bufferedEnd - 0.5;
+        const bufferStalled = audioHadProgress && activeDeck.currentTime >= bufferedEnd - 0.5;
 
-        console.log(`👁️ [VISIBILITY] State check: store=${storeIsPlaying}, audio=${audioIsActuallyPlaying ? 'playing' : 'paused'}, progress=${activeDeck.currentTime.toFixed(1)}s, stalled=${isStalled}`);
+        console.log(`👁️ [VISIBILITY] State check: store=${storeIsPlaying}, audio=${audioIsActuallyPlaying ? 'playing' : 'paused'}, progress=${activeDeck.currentTime.toFixed(1)}s, bufferStalled=${bufferStalled}`);
 
-        // STALL RECOVERY
-        if (isStalled && storeIsPlaying) {
-          console.log('👁️ [VISIBILITY] Audio stalled - delegating to recovery system');
+        // STALL RECOVERY — buffer exhausted (playhead caught up to buffered data)
+        if (bufferStalled && storeIsPlaying) {
+          console.log('👁️ [VISIBILITY] Audio buffer-stalled - delegating to recovery system');
           attemptStallRecovery(activeDeck, 'visibility-stall');
           return;
+        }
+
+        // FROZEN-CLOCK PROBE (#170): the element can report paused=false +
+        // readyState ENOUGH yet have a dead playback clock (currentTime frozen)
+        // after an OS audio-focus blip. A buffer check can't see this (the buffer
+        // is full), which is why the old buffer-only check logged stalled=false on
+        // a clock frozen for minutes. Re-sample currentTime shortly after resume:
+        // if it hasn't advanced while "playing", the clock is frozen — delegate to
+        // recovery (seek/reload restarts it where a bare play() cannot).
+        if (storeIsPlaying && audioIsActuallyPlaying && audioHadProgress && activeDeck.readyState >= 2) {
+          const probeStart = activeDeck.currentTime;
+          // eslint-disable-next-line @eslint-react/web-api-no-leaked-timeout -- one-shot probe, no cleanup needed
+          setTimeout(() => {
+            const d = activeDeckRef.current === 'A' ? deckA : deckB;
+            if (!d) return;
+            if (useAudioStore.getState().isPlaying && !d.paused && d.currentTime <= probeStart + 0.1) {
+              console.log(`👁️ [VISIBILITY] Frozen clock: currentTime stuck at ${probeStart.toFixed(1)}s while playing — delegating to recovery`);
+              attemptStallRecovery(d, 'visibility-frozen-clock');
+            }
+          }, 1200);
         }
 
         // OPTION B: next song stuck loading. If the active deck has a real

--- a/src/lib/hooks/useStallRecovery.ts
+++ b/src/lib/hooks/useStallRecovery.ts
@@ -38,6 +38,10 @@ export function useStallRecovery({
   const lastProgressTimeRef = useRef<number>(Date.now());
   const lastProgressValueRef = useRef<number>(0);
   const stallWatchdogIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  // Reactive so the watchdog effect (re)creates its interval when playback
+  // starts/stops. Reading isPlaying via getState() alone left it out of the
+  // effect deps, so the interval could fail to start for a whole session.
+  const isPlaying = useAudioStore((s) => s.isPlaying);
 
   // Helper to play with timeout - iOS play() can hang
   const playWithTimeout = useCallback(async (audio: HTMLAudioElement, timeoutMs: number = 3000): Promise<void> => {
@@ -154,8 +158,6 @@ export function useStallRecovery({
 
   // Stall watchdog effect - monitors playback progress
   useEffect(() => {
-    const isPlaying = useAudioStore.getState().isPlaying;
-
     const STALL_THRESHOLD_MS = 5000; // 5 seconds no progress = stall
     const CHECK_INTERVAL_MS = 2000;  // Check every 2 seconds
     const MIN_PROGRESS_DELTA = 0.5;  // Minimum progress to consider "advancing"
@@ -180,14 +182,23 @@ export function useStallRecovery({
       // Skip during crossfade
       if (crossfadeInProgressRef.current) return;
 
-      // Skip when page is hidden
-      if (document.visibilityState === 'hidden') return;
+      // NOTE: we intentionally do NOT bail out wholesale when the page is
+      // hidden. The "unpaused but frozen clock" deadlock (#170) happens while
+      // the screen is locked/backgrounded, so the no-progress check below must
+      // run even when hidden. We only avoid issuing an *unsolicited* play() in
+      // the paused-desync branch while hidden (iOS rejects play() without a
+      // user gesture in the background), deferring that to the visibility handler.
+      const pageHidden = document.visibilityState === 'hidden';
 
       const storeIsPlaying = useAudioStore.getState().isPlaying;
 
       // DESYNC DETECTION: store says playing but audio is paused
       if (audio.paused) {
         if (audio.duration > 0 && audio.currentTime >= audio.duration - 0.5) return;
+
+        // Backgrounded: don't attempt an unsolicited resume here — wait for the
+        // visibility handler when the user returns.
+        if (pageHidden) return;
 
         if (storeIsPlaying && hasRealSong(audio)) {
           if (audio.readyState >= 2) {
@@ -249,7 +260,7 @@ export function useStallRecovery({
         console.log('🐕 [WATCHDOG] Stopped stall watchdog');
       }
     };
-  }, [getActiveDeck, crossfadeInProgressRef, attemptStallRecovery]);
+  }, [getActiveDeck, crossfadeInProgressRef, attemptStallRecovery, isPlaying]);
 
   return {
     recoveryAttemptRef,


### PR DESCRIPTION
Fixes #170.

Cherry-pick of the single `#170` fix onto a clean base off `main` (the original `fix/frozen-clock-stall-recovery` branch had diverged and carried 7 commits already in main under different SHAs — this PR is just the one real commit).

## Problem
The stall watchdog was structurally blind to the "unpaused but frozen clock" deadlock: after an OS audio-focus blip on lock/background, the element reports `paused=false` + `readyState=ENOUGH` yet `currentTime` never advances. A buffer-exhaustion check can't see this (the buffer is full), so playback sat frozen for minutes with `stalled=false`.

## Fix (3 parts)
1. **`useStallRecovery`** — `isPlaying` made a reactive effect dep (was read via `getState()` only, so the watchdog interval could fail to start for a whole session). Now (re)starts on play/stop.
2. **`useStallRecovery`** — stop bailing wholesale when the page is hidden; the deadlock happens *while* backgrounded, so the no-progress check must run then. Only the unsolicited background `play()` is deferred to the visibility handler (iOS rejects background play without a gesture).
3. **`usePlaybackStateSync`** — add a frozen-clock re-probe on resume: re-sample `currentTime` ~1.2s after becoming visible and, if it hasn't advanced while "playing," delegate to recovery (seek/reload restarts the clock where a bare `play()` cannot). Renames the buffer-only `isStalled` → `bufferStalled` for clarity.

## Scope / notes
- JS-only, two hook files. **No schema/migration.**
- Already validated live in prod (deployed on the feature branch; captured via the PWA debug toggle — see #170 for the client trace).
- Known follow-up overlap: background recovery can run the destructive full-reload while locked, which is also the harmful step in the OS-interruption case (#176) — watch, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQj7kfXYU9jy1L9ByWw8r
