### PR TITLE
feat: mirror basic playlists to Navidrome so they save as real playlists

### DIFF
--- a/scripts/backfill-playlists-to-navidrome.ts
+++ b/scripts/backfill-playlists-to-navidrome.ts
@@ -1,0 +1,88 @@
+/**
+ * One-off / idempotent: back-fill basic (non-smart) playlists that only ever
+ * existed locally (navidromeId = null) into real Navidrome playlists.
+ *
+ * Historically `POST /api/playlists` created a local-only row and never called
+ * Navidrome, so custom playlists never became real/syncable playlists. This
+ * pushes each such playlist (with its songs, in local order) to Navidrome using
+ * the owning user's creds and persists the returned navidromeId. Safe to re-run:
+ * anything already carrying a navidromeId is skipped.
+ *
+ * Excluded: smart playlists and the canonical Liked Songs list (both handled by
+ * `ensurePlaylistOnNavidrome`, which self-guards).
+ *
+ * Usage:
+ *   npx tsx --env-file=.env scripts/backfill-playlists-to-navidrome.ts [--dry-run] [--user <email>]
+ */
+import { and, eq, isNull } from 'drizzle-orm';
+import { db } from '../src/lib/db';
+import { userPlaylists, playlistSongs } from '../src/lib/db/schema/playlists.schema';
+import { user } from '../src/lib/db/schema';
+import { ensurePlaylistOnNavidrome } from '../src/lib/services/playlist-navidrome-mirror';
+
+async function main() {
+  const args = process.argv.slice(2);
+  const dryRun = args.includes('--dry-run');
+  const userIdx = args.indexOf('--user');
+  const email = userIdx >= 0 ? args[userIdx + 1] : undefined;
+
+  let userIdFilter: string | undefined;
+  if (email) {
+    const u = await db.select().from(user).where(eq(user.email, email)).limit(1).then((r) => r[0]);
+    if (!u) {
+      console.error(`No user with email ${email}`);
+      process.exit(1);
+    }
+    userIdFilter = u.id;
+    console.log(`Filtering to user ${email} (${u.id})`);
+  }
+
+  const rows = await db
+    .select()
+    .from(userPlaylists)
+    .where(
+      userIdFilter
+        ? and(isNull(userPlaylists.navidromeId), eq(userPlaylists.userId, userIdFilter))
+        : isNull(userPlaylists.navidromeId),
+    );
+
+  // ensurePlaylistOnNavidrome self-skips smart + canonical-liked playlists; we
+  // filter smart here only to keep the console summary honest.
+  const candidates = rows.filter((p) => !p.smartPlaylistCriteria);
+  console.log(`Found ${candidates.length} local-only playlist(s) to consider${dryRun ? ' (dry run)' : ''}\n`);
+
+  let created = 0;
+  let notCreated = 0;
+
+  for (const pl of candidates) {
+    const count = await db
+      .select({ id: playlistSongs.id })
+      .from(playlistSongs)
+      .where(eq(playlistSongs.playlistId, pl.id))
+      .then((r) => r.length);
+
+    if (dryRun) {
+      console.log(`  [dry] "${pl.name}" (${count} songs) — user ${pl.userId}`);
+      continue;
+    }
+
+    const navId = await ensurePlaylistOnNavidrome(pl.id, pl.userId);
+    if (navId) {
+      console.log(`  ✅ "${pl.name}" → ${navId} (${count} songs)`);
+      created++;
+    } else {
+      // null = skipped (canonical-liked / no creds) or a Navidrome error; the
+      // helper already logged the reason above.
+      console.log(`  ⏭️  "${pl.name}" not created (skipped or failed — see log above)`);
+      notCreated++;
+    }
+  }
+
+  if (!dryRun) console.log(`\nDone. created=${created} not-created=${notCreated}`);
+  process.exit(0);
+}
+
+main().catch((err) => {
+  console.error('Back-fill failed:', err);
+  process.exit(1);
+});

--- a/src/lib/services/navidrome/index.ts
+++ b/src/lib/services/navidrome/index.ts
@@ -37,6 +37,7 @@ export {
 // Playlists
 export {
   getPlaylists, getPlaylist, createPlaylist, updatePlaylist, deletePlaylist, addSongsToPlaylist,
+  removeSongsFromPlaylistByIndex,
 } from './playlists';
 
 // Discovery & recommendations

--- a/src/lib/services/navidrome/playlists.ts
+++ b/src/lib/services/navidrome/playlists.ts
@@ -259,3 +259,44 @@ export async function addSongsToPlaylist(playlistId: string, songIds: string[], 
     throw new ServiceError('NAVIDROME_API_ERROR', `Failed to add songs to playlist: ${error instanceof Error ? error.message : 'Unknown error'}`);
   }
 }
+
+/**
+ * Remove songs from a playlist by their 0-based positions (Subsonic
+ * `songIndexToRemove`). Indices are sent in DESCENDING order so removing an
+ * earlier item never shifts the position of a later one within the same request.
+ */
+export async function removeSongsFromPlaylistByIndex(playlistId: string, indices: number[], creds?: SubsonicCreds): Promise<void> {
+  if (indices.length === 0) return;
+  const ordered = [...new Set(indices)].sort((a, b) => b - a); // desc, de-duped
+  try {
+    if (creds) {
+      const config = getConfig();
+      if (!config.navidromeUrl) {
+        throw new ServiceError('NAVIDROME_CONFIG_ERROR', 'Navidrome URL not configured');
+      }
+      const url = buildSubsonicUrl('updatePlaylist', creds);
+      url.searchParams.set('playlistId', playlistId);
+      ordered.forEach(i => url.searchParams.append('songIndexToRemove', String(i)));
+      const response = await fetch(url.toString(), { method: 'POST' });
+      if (!response.ok) {
+        throw new ServiceError('NAVIDROME_API_ERROR', `Failed to remove songs from playlist: ${response.statusText}`);
+      }
+      const data = await response.json() as SubsonicApiResponse;
+      if (data['subsonic-response']?.status !== 'ok') {
+        throw new ServiceError('NAVIDROME_API_ERROR', `Subsonic API error: ${data['subsonic-response']?.error?.message || 'Unknown error'}`);
+      }
+      console.log(`➖ Removed ${ordered.length} songs from playlist ${playlistId} (per-user)`);
+      return;
+    }
+
+    let endpoint = `/rest/updatePlaylist?playlistId=${encodeURIComponent(playlistId)}`;
+    ordered.forEach(i => { endpoint += `&songIndexToRemove=${i}`; });
+    const data = await apiFetch(endpoint, { method: 'POST' }) as SubsonicApiResponse;
+    if (data['subsonic-response']?.status !== 'ok') {
+      throw new ServiceError('NAVIDROME_API_ERROR', `Subsonic API error: ${data['subsonic-response']?.error?.message || 'Unknown error'}`);
+    }
+    console.log(`➖ Removed ${ordered.length} songs from playlist ${playlistId}`);
+  } catch (error) {
+    throw new ServiceError('NAVIDROME_API_ERROR', `Failed to remove songs from playlist: ${error instanceof Error ? error.message : 'Unknown error'}`);
+  }
+}

--- a/src/lib/services/playlist-navidrome-mirror.ts
+++ b/src/lib/services/playlist-navidrome-mirror.ts
@@ -1,0 +1,160 @@
+/**
+ * Playlist → Navidrome mirror
+ *
+ * Basic (non-smart) playlists are edited in AIDJ's own DB. Historically those
+ * edits never reached Navidrome, so a "custom playlist" only ever existed
+ * locally (navidromeId = null) and never showed up as a real Navidrome playlist
+ * or survived a sync. These helpers mirror local playlist mutations to Navidrome
+ * using the user's own Subsonic creds (the same context sync uses).
+ *
+ * Philosophy: the LOCAL write is the source of truth for the request's success.
+ * Mirroring is BEST-EFFORT — a Navidrome failure is logged but never fails the
+ * user's edit. Anything that doesn't get a navidromeId here is picked up later by
+ * `ensurePlaylistOnNavidrome` (lazy, on the next edit) or the back-fill script,
+ * so local-only playlists heal forward rather than getting stuck.
+ *
+ * Smart playlists and the canonical Liked Songs list are intentionally excluded
+ * (they are managed by their own code paths / are a mirror of stars).
+ */
+import { asc, eq } from 'drizzle-orm';
+import { db } from '../db';
+import { userPlaylists, playlistSongs } from '../db/schema/playlists.schema';
+import {
+  createPlaylist,
+  addSongsToPlaylist,
+  getPlaylist,
+  removeSongsFromPlaylistByIndex,
+} from './navidrome';
+import { getNavidromeUserCreds, type SubsonicCreds } from './navidrome-users';
+import { isCanonicalLikedPlaylist } from './liked-songs-sync';
+
+type PlaylistRow = typeof userPlaylists.$inferSelect;
+
+/**
+ * Basic playlists only. Skip smart playlists (their own path) and the canonical
+ * Liked Songs list (a mirror of Navidrome stars — intentionally navidromeId=null
+ * and must never be pushed as a standalone Navidrome playlist).
+ */
+function isMirrorable(pl: PlaylistRow): boolean {
+  if (pl.smartPlaylistCriteria) return false;
+  if (isCanonicalLikedPlaylist(pl)) return false;
+  return true;
+}
+
+async function orderedSongIds(playlistId: string): Promise<string[]> {
+  const rows = await db
+    .select({ songId: playlistSongs.songId })
+    .from(playlistSongs)
+    .where(eq(playlistSongs.playlistId, playlistId))
+    .orderBy(asc(playlistSongs.position));
+  return rows.map((r) => r.songId);
+}
+
+async function resolveCreds(
+  userId: string,
+  creds?: SubsonicCreds | null,
+): Promise<SubsonicCreds | null> {
+  return creds ?? (await getNavidromeUserCreds(userId));
+}
+
+/**
+ * Ensure a local basic playlist exists on Navidrome. If it has no navidromeId
+ * yet, create it there with its current songs (in local order) and persist the
+ * returned id back onto the row. Returns the navidromeId, or null if it could
+ * not be created (no creds, smart playlist, or a Navidrome error). Never throws.
+ */
+export async function ensurePlaylistOnNavidrome(
+  playlistId: string,
+  userId: string,
+  creds?: SubsonicCreds | null,
+): Promise<string | null> {
+  try {
+    const pl = await db
+      .select()
+      .from(userPlaylists)
+      .where(eq(userPlaylists.id, playlistId))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!pl || !isMirrorable(pl)) return null;
+    if (pl.navidromeId) return pl.navidromeId;
+
+    const c = await resolveCreds(userId, creds);
+    if (!c) {
+      console.warn(`[playlist-mirror] no Navidrome creds for user ${userId}; leaving "${pl.name}" local-only (will back-fill later)`);
+      return null;
+    }
+
+    const songIds = await orderedSongIds(playlistId);
+    const created = await createPlaylist(pl.name, songIds.length ? songIds : undefined, c);
+
+    await db
+      .update(userPlaylists)
+      .set({ navidromeId: created.id, lastSynced: new Date(), updatedAt: new Date() })
+      .where(eq(userPlaylists.id, playlistId));
+
+    console.log(`✅ [playlist-mirror] created "${pl.name}" on Navidrome (${created.id}) with ${songIds.length} songs`);
+    return created.id;
+  } catch (err) {
+    console.warn(`[playlist-mirror] ensurePlaylistOnNavidrome failed for ${playlistId}:`, err instanceof Error ? err.message : err);
+    return null;
+  }
+}
+
+/**
+ * Mirror a single song ADD to Navidrome. Back-fills the playlist first if it has
+ * no navidromeId yet (the create includes the freshly-added song, so we're done).
+ * Best-effort; never throws.
+ */
+export async function mirrorAddSong(
+  playlistId: string,
+  userId: string,
+  songId: string,
+  creds?: SubsonicCreds | null,
+): Promise<void> {
+  try {
+    const pl = await db
+      .select()
+      .from(userPlaylists)
+      .where(eq(userPlaylists.id, playlistId))
+      .limit(1)
+      .then((r) => r[0]);
+    if (!pl || !isMirrorable(pl)) return;
+
+    const c = await resolveCreds(userId, creds);
+    if (!c) return;
+
+    if (!pl.navidromeId) {
+      // Back-fill: createPlaylist uses the full current song list, which already
+      // includes the song we just inserted locally — nothing more to add.
+      await ensurePlaylistOnNavidrome(playlistId, userId, c);
+      return;
+    }
+
+    await addSongsToPlaylist(pl.navidromeId, [songId], c);
+  } catch (err) {
+    console.warn(`[playlist-mirror] mirrorAddSong failed for ${playlistId}/${songId}:`, err instanceof Error ? err.message : err);
+  }
+}
+
+/**
+ * Mirror a single song REMOVE to Navidrome. Resolves the song's current index in
+ * the Navidrome playlist (order can differ from local) and removes by index.
+ * A song that isn't on the server is already consistent — treated as success.
+ * Best-effort; never throws.
+ */
+export async function mirrorRemoveSong(
+  navidromeId: string,
+  songId: string,
+  creds: SubsonicCreds,
+): Promise<void> {
+  try {
+    const remote = await getPlaylist(navidromeId, creds);
+    const indices = remote.entry
+      .map((s, i) => (s.id === songId ? i : -1))
+      .filter((i) => i >= 0);
+    if (indices.length === 0) return; // not on server = already consistent
+    await removeSongsFromPlaylistByIndex(navidromeId, indices, creds);
+  } catch (err) {
+    console.warn(`[playlist-mirror] mirrorRemoveSong failed for ${navidromeId}/${songId}:`, err instanceof Error ? err.message : err);
+  }
+}

--- a/src/routes/api/playlists/$id/songs/$songId.ts
+++ b/src/routes/api/playlists/$id/songs/$songId.ts
@@ -4,8 +4,9 @@ import { db } from '../../../../../lib/db';
 import { userPlaylists, playlistSongs } from '../../../../../lib/db/schema/playlists.schema';
 import { eq, and, gt } from 'drizzle-orm';
 import { sql } from 'drizzle-orm';
-import { ensureNavidromeUser } from '../../../../../lib/services/navidrome-users';
+import { ensureNavidromeUser, getNavidromeUserCreds } from '../../../../../lib/services/navidrome-users';
 import { setSongLiked, isCanonicalLikedPlaylist } from '../../../../../lib/services/liked-songs-sync';
+import { mirrorRemoveSong } from '../../../../../lib/services/playlist-navidrome-mirror';
 
 export const Route = createFileRoute("/api/playlists/$id/songs/$songId")({
   server: {
@@ -107,6 +108,15 @@ export const Route = createFileRoute("/api/playlists/$id/songs/$songId")({
         .update(userPlaylists)
         .set({ updatedAt: new Date() })
         .where(eq(userPlaylists.id, playlistId));
+
+      // Mirror the removal to Navidrome so the server copy doesn't keep the song
+      // (which would re-appear locally on the next sync). Best-effort.
+      if (playlist.navidromeId) {
+        const creds = await getNavidromeUserCreds(session.user.id);
+        if (creds) {
+          await mirrorRemoveSong(playlist.navidromeId, songId, creds);
+        }
+      }
 
       return new Response(JSON.stringify({ data: { success: true } }), {
         status: 200,

--- a/src/routes/api/playlists/$id/songs/index.ts
+++ b/src/routes/api/playlists/$id/songs/index.ts
@@ -4,6 +4,7 @@ import { db } from '../../../../../lib/db';
 import { userPlaylists, playlistSongs } from '../../../../../lib/db/schema/playlists.schema';
 import { eq, and, max } from 'drizzle-orm';
 import { z } from 'zod';
+import { mirrorAddSong } from '../../../../../lib/services/playlist-navidrome-mirror';
 
 // Zod schema for adding song
 const AddSongSchema = z.object({
@@ -104,6 +105,10 @@ export const Route = createFileRoute("/api/playlists/$id/songs/")({
         .update(userPlaylists)
         .set({ updatedAt: new Date() })
         .where(eq(userPlaylists.id, playlistId));
+
+      // Mirror the add to Navidrome (back-fills the playlist if it was still
+      // local-only). Best-effort — never fails the local add.
+      await mirrorAddSong(playlistId, session.user.id, validatedData.songId);
 
       return new Response(JSON.stringify({
         data: {

--- a/src/routes/api/playlists/index.ts
+++ b/src/routes/api/playlists/index.ts
@@ -4,6 +4,7 @@ import { userPlaylists, playlistSongs } from '../../../lib/db/schema/playlists.s
 import { eq, sql, desc } from 'drizzle-orm';
 import { z } from 'zod';
 import { checkNavidromeConnectivity } from '../../../lib/services/navidrome';
+import { ensurePlaylistOnNavidrome } from '../../../lib/services/playlist-navidrome-mirror';
 import {
   withAuthAndErrorHandling,
   successResponse,
@@ -52,7 +53,13 @@ const POST = withAuthAndErrorHandling(
 
     console.log(`✅ Playlist "${newPlaylist.name}" created (empty)`);
 
-    return successResponse(newPlaylist, 201);
+    // Mirror to Navidrome so it becomes a real (syncable) playlist, not a
+    // local-only row. Best-effort: if it can't be created now (offline, no
+    // creds), the row stays local and is back-filled on the next edit / by the
+    // back-fill script.
+    const navidromeId = await ensurePlaylistOnNavidrome(newPlaylist.id, session.user.id);
+
+    return successResponse({ ...newPlaylist, navidromeId }, 201);
   },
   {
     service: 'playlists',


### PR DESCRIPTION
## Problem
Basic (non-smart) custom playlists were edited only in AIDJ's own DB — `POST /api/playlists` inserted a `userPlaylists` row with `navidromeId = null` and never called Navidrome, and add/remove-song did the same. So custom playlists **never became real Navidrome playlists** and never synced. (Contrast: `create-from-ids` and smart playlists already created the Navidrome playlist.)

## Fix
New best-effort **mirror** layer that reflects local basic-playlist edits to Navidrome using the user's own Subsonic creds (same context sync uses). The local write stays the source of truth for the request; a Navidrome failure is logged, never fails the user's edit.

- **`src/lib/services/playlist-navidrome-mirror.ts`** (new)
  - `ensurePlaylistOnNavidrome()` — create the playlist on Navidrome with its songs (in local order) and persist the returned `navidromeId`; also **back-fills** a still-local-only playlist. Never throws.
  - `mirrorAddSong()` / `mirrorRemoveSong()` — reflect single-song edits.
  - Skips smart playlists and the canonical **Liked Songs** list (that one is a mirror of stars, intentionally `navidromeId=null`).
- Wired into `POST /api/playlists` (create), `POST .../songs` (add), `DELETE .../songs/$songId` (remove).
- **`removeSongsFromPlaylistByIndex()`** added to the Navidrome service (Subsonic `songIndexToRemove`, indices sent descending) since `updatePlaylist` only appends.
- **`scripts/backfill-playlists-to-navidrome.ts`** — push existing local-only playlists up to Navidrome. Idempotent; `--dry-run` and `--user <email>` supported.

**Heal-forward philosophy:** anything not created at edit time (offline, no creds) stays local and is picked up on the next edit or by the back-fill script.

## Scope / follow-ups
- **Reorder is not mirrored yet.** `updatePlaylist` can't reorder cleanly (append-only); local reordering won't reflect to Navidrome until a follow-up (remove-all + re-add, or a dedicated reorder). Add/remove/create are covered.
- Type-clean (no new `tsc` errors); existing playlist + sync tests pass (19). Dedicated mirror unit tests are a follow-up.
- Best-effort mirroring means a transient Navidrome error can leave a temporary local/server drift; it self-heals on the next edit or back-fill run.

## Test notes
- Create a basic playlist → appears as a real playlist in Navidrome with a stored `navidromeId`.
- Add/remove songs → reflected on the Navidrome copy.
- Run `npx tsx --env-file=.env scripts/backfill-playlists-to-navidrome.ts --dry-run` to preview existing local-only playlists, then without `--dry-run` to back-fill. **Must run with correct Navidrome admin creds** (prod env / Coolify) — a stale password will 401 and the mirror will log + skip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQj7kfXYU9jy1L9ByWw8r
