### PR TITLE
fix(ci): make the high/critical npm-audit gate actually enforce

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,7 +62,13 @@ jobs:
         
       - name: Fail on high/critical vulnerabilities
         run: |
-          if npm audit --json --audit-level high | jq -e '.auditReport.vulnerabilities.high > 0 or .auditReport.vulnerabilities.critical > 0' > /dev/null 2>&1; then
+          # npm audit exits non-zero when vulns are present, so `|| true`
+          # lets us capture the JSON and parse the counts ourselves.
+          audit_json=$(npm audit --json || true)
+          high=$(echo "$audit_json" | jq '.metadata.vulnerabilities.high // 0')
+          crit=$(echo "$audit_json" | jq '.metadata.vulnerabilities.critical // 0')
+          echo "npm audit: high=$high critical=$crit"
+          if [ "$high" -gt 0 ] || [ "$crit" -gt 0 ]; then
             echo "High or critical vulnerabilities found!"
             exit 1
           fi


### PR DESCRIPTION
## Problem
The `security` job's **"Fail on high/critical vulnerabilities"** step has been a **silent no-op**. It queried:

```
jq -e '.auditReport.vulnerabilities.high > 0 or .auditReport.vulnerabilities.critical > 0'
```

`.auditReport` **does not exist** in `npm audit --json` output — the real path is `.metadata.vulnerabilities`. `jq -e` on `null` exits non-zero, so the `if` never fired: the gate passed regardless of how many high/critical advisories were present. (This is why main accumulated 6 critical + 14 high unnoticed — see the #195/#197 remediation.)

## Fix
Capture the audit JSON (npm audit exits non-zero when vulns exist, hence `|| true`), read the real counts, and fail on any high/critical:

```bash
audit_json=$(npm audit --json || true)
high=$(echo "$audit_json" | jq '.metadata.vulnerabilities.high // 0')
crit=$(echo "$audit_json" | jq '.metadata.vulnerabilities.critical // 0')
[ "$high" -gt 0 ] || [ "$crit" -gt 0 ] && exit 1
```

## Validation
- Against current main (post #195/#197): `high=0 critical=0` → **passes**. Safe to merge now that main is clean.
- Confirmed the old `.auditReport` path returns `null`, proving the gate never triggered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)