### PR TITLE
fix(playlists): harden Navidrome mirror follow-ups from #178

### DIFF
--- a/src/lib/db/schema/playlists.schema.ts
+++ b/src/lib/db/schema/playlists.schema.ts
@@ -18,13 +18,25 @@ export const userPlaylists = pgTable("user_playlists", {
   songCount: integer("song_count"), // Cached song count for performance
   totalDuration: integer("total_duration"), // Total duration in seconds
   smartPlaylistCriteria: jsonb("smart_playlist_criteria").$type<{
+    // Legacy filter shape (rows created before the Navidrome-native rules path).
     genre?: string[];
     yearFrom?: number;
     yearTo?: number;
     artists?: string[];
     rating?: number;
     recentlyAdded?: '7d' | '30d' | '90d';
-  }>(), // Filter rules for smart playlists
+    // Navidrome-native smart-playlist rules (current shape, see
+    // navidrome-smart-playlists.ts `SmartPlaylistRules`). Conditions are kept as
+    // `unknown[]` here to stay independent of the service layer; the rules module
+    // owns their precise recursive type.
+    name?: string;
+    comment?: string;
+    all?: unknown[];
+    any?: unknown[];
+    sort?: string;
+    order?: 'asc' | 'desc';
+    limit?: number;
+  }>(), // Filter rules for smart playlists (legacy filters or Navidrome rules)
   createdAt: timestamp("created_at")
     .$defaultFn(() => new Date())
     .notNull(),

--- a/src/lib/services/__tests__/playlist-deleted-marker.test.ts
+++ b/src/lib/services/__tests__/playlist-deleted-marker.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect } from 'vitest';
+import {
+  DELETED_FROM_NAVIDROME_PREFIX,
+  hasDeletedFromNavidromeMarker,
+  stripDeletedMarker,
+} from '../playlist-deleted-marker';
+
+describe('playlist-deleted-marker', () => {
+  describe('hasDeletedFromNavidromeMarker', () => {
+    it('detects a soft-deleted description', () => {
+      expect(hasDeletedFromNavidromeMarker(`${DELETED_FROM_NAVIDROME_PREFIX} my list`)).toBe(true);
+      expect(hasDeletedFromNavidromeMarker(`${DELETED_FROM_NAVIDROME_PREFIX} `)).toBe(true);
+      expect(hasDeletedFromNavidromeMarker(DELETED_FROM_NAVIDROME_PREFIX)).toBe(true);
+    });
+
+    it('is false for a normal / empty description', () => {
+      expect(hasDeletedFromNavidromeMarker('road trip mix')).toBe(false);
+      expect(hasDeletedFromNavidromeMarker('')).toBe(false);
+      expect(hasDeletedFromNavidromeMarker(null)).toBe(false);
+      expect(hasDeletedFromNavidromeMarker(undefined)).toBe(false);
+    });
+
+    it('only matches the marker as a prefix, not mid-string', () => {
+      expect(hasDeletedFromNavidromeMarker(`note: ${DELETED_FROM_NAVIDROME_PREFIX}`)).toBe(false);
+    });
+  });
+
+  describe('stripDeletedMarker', () => {
+    it('removes the prefix and surrounding space', () => {
+      expect(stripDeletedMarker(`${DELETED_FROM_NAVIDROME_PREFIX} road trip`)).toBe('road trip');
+    });
+
+    it('returns null when only the marker remains', () => {
+      expect(stripDeletedMarker(`${DELETED_FROM_NAVIDROME_PREFIX} `)).toBeNull();
+      expect(stripDeletedMarker(DELETED_FROM_NAVIDROME_PREFIX)).toBeNull();
+    });
+
+    it('leaves an unmarked description untouched', () => {
+      expect(stripDeletedMarker('road trip')).toBe('road trip');
+      expect(stripDeletedMarker(null)).toBeNull();
+    });
+
+    it('round-trips with the sync soft-delete write shape', () => {
+      // Mirrors playlist-sync.ts: `${PREFIX} ${existing || ''}`
+      const original = 'chill evening';
+      const marked = `${DELETED_FROM_NAVIDROME_PREFIX} ${original}`;
+      expect(hasDeletedFromNavidromeMarker(marked)).toBe(true);
+      expect(stripDeletedMarker(marked)).toBe(original);
+    });
+  });
+});

--- a/src/lib/services/__tests__/playlist-navidrome-mirror.test.ts
+++ b/src/lib/services/__tests__/playlist-navidrome-mirror.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('../navidrome', () => ({
+  createPlaylist: vi.fn(),
+  addSongsToPlaylist: vi.fn(),
+  getPlaylist: vi.fn(),
+  getPlaylists: vi.fn(),
+  removeSongsFromPlaylistByIndex: vi.fn(),
+}));
+
+// The mirror imports db + navidrome-users at module load; stub them so the
+// module can be imported even though these tests only exercise mirrorRemoveSong.
+vi.mock('@/lib/db', () => ({ db: {} }));
+vi.mock('../navidrome-users', () => ({ getNavidromeUserCreds: vi.fn() }));
+
+import { getPlaylist, removeSongsFromPlaylistByIndex } from '../navidrome';
+import { mirrorRemoveSong } from '../playlist-navidrome-mirror';
+import type { SubsonicCreds } from '../navidrome-users';
+
+const creds = { username: 'u', password: 'p' } as unknown as SubsonicCreds;
+
+describe('mirrorRemoveSong', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('does not throw and skips removal when the playlist has no entries (Subsonic omits `entry`)', async () => {
+    // Empty Navidrome playlist: `entry` is absent from the response entirely.
+    vi.mocked(getPlaylist).mockResolvedValue({ id: 'pl1', name: 'x' } as never);
+
+    await expect(mirrorRemoveSong('pl1', 'songA', creds)).resolves.toBeUndefined();
+    expect(removeSongsFromPlaylistByIndex).not.toHaveBeenCalled();
+  });
+
+  it('removes by the matching index when the song is present', async () => {
+    vi.mocked(getPlaylist).mockResolvedValue({
+      id: 'pl1',
+      name: 'x',
+      entry: [{ id: 'songA' }, { id: 'songB' }, { id: 'songA' }],
+    } as never);
+
+    await mirrorRemoveSong('pl1', 'songA', creds);
+
+    expect(removeSongsFromPlaylistByIndex).toHaveBeenCalledWith('pl1', [0, 2], creds);
+  });
+
+  it('is a no-op when the song is not on the server', async () => {
+    vi.mocked(getPlaylist).mockResolvedValue({
+      id: 'pl1',
+      name: 'x',
+      entry: [{ id: 'songB' }],
+    } as never);
+
+    await mirrorRemoveSong('pl1', 'songA', creds);
+
+    expect(removeSongsFromPlaylistByIndex).not.toHaveBeenCalled();
+  });
+
+  it('never throws even if Navidrome errors', async () => {
+    vi.mocked(getPlaylist).mockRejectedValue(new Error('navidrome down'));
+
+    await expect(mirrorRemoveSong('pl1', 'songA', creds)).resolves.toBeUndefined();
+    expect(removeSongsFromPlaylistByIndex).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/services/playlist-deleted-marker.ts
+++ b/src/lib/services/playlist-deleted-marker.ts
@@ -1,0 +1,30 @@
+/**
+ * Soft-delete marker for playlists removed on Navidrome.
+ *
+ * When a playlist is deleted on Navidrome, `syncNavidromePlaylists` soft-deletes
+ * the local row: it nulls `navidromeId` AND prefixes `description` with this
+ * marker (see playlist-sync.ts, step 4). The marker is the ONLY signal that
+ * distinguishes a *deliberately deleted* playlist from one that was simply never
+ * pushed to Navidrome — both end up with `navidromeId === null`.
+ *
+ * Anything that heals a local-only playlist forward to Navidrome MUST consult
+ * this before (re)creating it, or it will resurrect a list the user intentionally
+ * deleted — the fail-closed authoritative-remote-delete design from PR #175 (#160).
+ */
+export const DELETED_FROM_NAVIDROME_PREFIX = '[Deleted from Navidrome]';
+
+const MARKER_RE = /^\[Deleted from Navidrome\]\s*/;
+
+/** True if a playlist row's description carries the soft-delete marker. */
+export function hasDeletedFromNavidromeMarker(
+  description: string | null | undefined,
+): boolean {
+  return !!description && MARKER_RE.test(description);
+}
+
+/** Strip the "[Deleted from Navidrome] " prefix a prior soft delete may have added. */
+export function stripDeletedMarker(description: string | null): string | null {
+  if (!description) return description;
+  const cleaned = description.replace(MARKER_RE, '');
+  return cleaned.length > 0 ? cleaned : null;
+}

--- a/src/lib/services/playlist-navidrome-mirror.ts
+++ b/src/lib/services/playlist-navidrome-mirror.ts
@@ -23,10 +23,11 @@ import {
   createPlaylist,
   addSongsToPlaylist,
   getPlaylist,
+  getPlaylists,
   removeSongsFromPlaylistByIndex,
 } from './navidrome';
 import { getNavidromeUserCreds, type SubsonicCreds } from './navidrome-users';
-import { isCanonicalLikedPlaylist } from './liked-songs-sync';
+import { hasDeletedFromNavidromeMarker } from './playlist-deleted-marker';
 
 type PlaylistRow = typeof userPlaylists.$inferSelect;
 
@@ -34,11 +35,39 @@ type PlaylistRow = typeof userPlaylists.$inferSelect;
  * Basic playlists only. Skip smart playlists (their own path) and the canonical
  * Liked Songs list (a mirror of Navidrome stars — intentionally navidromeId=null
  * and must never be pushed as a standalone Navidrome playlist).
+ *
+ * The canonical-liked check uses the explicit `isLikedSongs` flag, NOT a name
+ * match: a name fallback (e.g. /liked/i) would misclassify ordinary user
+ * playlists like "Songs I Liked in 2020" and silently never mirror them.
  */
 function isMirrorable(pl: PlaylistRow): boolean {
   if (pl.smartPlaylistCriteria) return false;
-  if (isCanonicalLikedPlaylist(pl)) return false;
+  if (pl.isLikedSongs) return false;
   return true;
+}
+
+/**
+ * Serializes `ensurePlaylistOnNavidrome` calls per playlist within this process.
+ * Two concurrent edits to a still-local-only playlist would otherwise each run
+ * the create path and produce a duplicate Navidrome playlist with the same name.
+ *
+ * NOTE (multi-instance deploys): this map is in-memory and per process, so it
+ * only dedups within one instance. The `findRemotePlaylistIdByName` adopt guard
+ * below narrows the cross-process window but does not close it — two instances
+ * can both read "no remote playlist" before either `createPlaylist` returns and
+ * still produce a duplicate (TOCTOU). Safe while we run a single instance; if we
+ * ever scale out, move this serialization to a shared lock (e.g. a Postgres
+ * advisory lock keyed on playlistId) or a unique constraint on the remote side.
+ */
+const ensureInFlight = new Map<string, Promise<string | null>>();
+
+/** Find an existing Navidrome playlist id with this exact name, or null. */
+async function findRemotePlaylistIdByName(
+  name: string,
+  creds: SubsonicCreds,
+): Promise<string | null> {
+  const remote = await getPlaylists(creds);
+  return remote.find((p) => p.name === name)?.id ?? null;
 }
 
 async function orderedSongIds(playlistId: string): Promise<string[]> {
@@ -61,9 +90,33 @@ async function resolveCreds(
  * Ensure a local basic playlist exists on Navidrome. If it has no navidromeId
  * yet, create it there with its current songs (in local order) and persist the
  * returned id back onto the row. Returns the navidromeId, or null if it could
- * not be created (no creds, smart playlist, or a Navidrome error). Never throws.
+ * not be created (no creds, smart playlist, deliberately deleted, or a Navidrome
+ * error). Never throws.
+ *
+ * Guards:
+ *  - Deleted playlists are NOT resurrected. A row soft-deleted by sync (navidromeId
+ *    nulled + "[Deleted from Navidrome]" marker) is left alone — healing it forward
+ *    would recreate a list the user intentionally deleted (PR #175 / #160).
+ *  - Duplicates are avoided. Before creating, we adopt any existing same-name
+ *    Navidrome playlist (the unique-name dedup that #127/#163 enforce in sync),
+ *    and concurrent calls for one playlist are serialized so they can't both create.
  */
 export async function ensurePlaylistOnNavidrome(
+  playlistId: string,
+  userId: string,
+  creds?: SubsonicCreds | null,
+): Promise<string | null> {
+  const inFlight = ensureInFlight.get(playlistId);
+  if (inFlight) return inFlight;
+
+  const run = ensurePlaylistOnNavidromeInner(playlistId, userId, creds).finally(() => {
+    ensureInFlight.delete(playlistId);
+  });
+  ensureInFlight.set(playlistId, run);
+  return run;
+}
+
+async function ensurePlaylistOnNavidromeInner(
   playlistId: string,
   userId: string,
   creds?: SubsonicCreds | null,
@@ -78,6 +131,14 @@ export async function ensurePlaylistOnNavidrome(
     if (!pl || !isMirrorable(pl)) return null;
     if (pl.navidromeId) return pl.navidromeId;
 
+    // Do not resurrect a deliberately-deleted playlist. Sync soft-deletes such
+    // rows (navidromeId=null + marker); both a deleted list and a never-synced
+    // local-only list have navidromeId=null, so the marker is the only signal.
+    if (hasDeletedFromNavidromeMarker(pl.description)) {
+      console.log(`[playlist-mirror] "${pl.name}" was deleted on Navidrome; not resurrecting`);
+      return null;
+    }
+
     const c = await resolveCreds(userId, creds);
     if (!c) {
       console.warn(`[playlist-mirror] no Navidrome creds for user ${userId}; leaving "${pl.name}" local-only (will back-fill later)`);
@@ -85,15 +146,31 @@ export async function ensurePlaylistOnNavidrome(
     }
 
     const songIds = await orderedSongIds(playlistId);
-    const created = await createPlaylist(pl.name, songIds.length ? songIds : undefined, c);
+
+    // Dedup: adopt an existing same-name Navidrome playlist rather than creating
+    // a second one. Push only the local songs it is missing (Subsonic appends
+    // songIdToAdd unconditionally, so blindly re-adding would duplicate entries).
+    let navidromeId = await findRemotePlaylistIdByName(pl.name, c);
+    if (navidromeId) {
+      if (songIds.length) {
+        const remote = await getPlaylist(navidromeId, c);
+        const present = new Set((remote.entry ?? []).map((s) => s.id));
+        const missing = songIds.filter((id) => !present.has(id));
+        if (missing.length) await addSongsToPlaylist(navidromeId, missing, c);
+      }
+      console.log(`🔗 [playlist-mirror] adopted existing Navidrome playlist "${pl.name}" (${navidromeId})`);
+    } else {
+      const created = await createPlaylist(pl.name, songIds.length ? songIds : undefined, c);
+      navidromeId = created.id;
+      console.log(`✅ [playlist-mirror] created "${pl.name}" on Navidrome (${navidromeId}) with ${songIds.length} songs`);
+    }
 
     await db
       .update(userPlaylists)
-      .set({ navidromeId: created.id, lastSynced: new Date(), updatedAt: new Date() })
+      .set({ navidromeId, lastSynced: new Date(), updatedAt: new Date() })
       .where(eq(userPlaylists.id, playlistId));
 
-    console.log(`✅ [playlist-mirror] created "${pl.name}" on Navidrome (${created.id}) with ${songIds.length} songs`);
-    return created.id;
+    return navidromeId;
   } catch (err) {
     console.warn(`[playlist-mirror] ensurePlaylistOnNavidrome failed for ${playlistId}:`, err instanceof Error ? err.message : err);
     return null;
@@ -149,7 +226,9 @@ export async function mirrorRemoveSong(
 ): Promise<void> {
   try {
     const remote = await getPlaylist(navidromeId, creds);
-    const indices = remote.entry
+    // Subsonic omits `entry` for an empty playlist (the type declares it
+    // non-optional but the wire format leaves it out), so default to [].
+    const indices = (remote.entry ?? [])
       .map((s, i) => (s.id === songId ? i : -1))
       .filter((i) => i >= 0);
     if (indices.length === 0) return; // not on server = already consistent

--- a/src/lib/services/playlist-sync.ts
+++ b/src/lib/services/playlist-sync.ts
@@ -3,6 +3,7 @@ import { db } from '@/lib/db';
 import { userPlaylists, playlistSongs } from '@/lib/db/schema/playlists.schema';
 import { getPlaylists, getPlaylist, type NavidromePlaylist, type NavidromePlaylistWithSongs } from './navidrome';
 import { getNavidromeUserCreds } from './navidrome-users';
+import { DELETED_FROM_NAVIDROME_PREFIX, stripDeletedMarker } from './playlist-deleted-marker';
 import { ServiceError } from '../utils';
 
 /**
@@ -152,7 +153,7 @@ export async function syncNavidromePlaylists(userId: string): Promise<SyncResult
           .set({
             navidromeId: null,
             lastSynced: new Date(),
-            description: `[Deleted from Navidrome] ${localPlaylist.description || ''}`,
+            description: `${DELETED_FROM_NAVIDROME_PREFIX} ${localPlaylist.description || ''}`,
             updatedAt: new Date(),
           })
           .where(eq(userPlaylists.id, localPlaylist.id));
@@ -173,13 +174,6 @@ export async function syncNavidromePlaylists(userId: string): Promise<SyncResult
     console.error(errorMsg);
     throw new ServiceError('PLAYLIST_SYNC_ERROR', errorMsg);
   }
-}
-
-/** Strip the "[Deleted from Navidrome] " prefix a prior soft delete may have added. */
-function stripDeletedMarker(description: string | null): string | null {
-  if (!description) return description;
-  const cleaned = description.replace(/^\[Deleted from Navidrome\]\s*/, '');
-  return cleaned.length > 0 ? cleaned : null;
 }
 
 /**

--- a/src/routes/api/playlists/$id/songs/$songId.ts
+++ b/src/routes/api/playlists/$id/songs/$songId.ts
@@ -110,12 +110,15 @@ export const Route = createFileRoute("/api/playlists/$id/songs/$songId")({
         .where(eq(userPlaylists.id, playlistId));
 
       // Mirror the removal to Navidrome so the server copy doesn't keep the song
-      // (which would re-appear locally on the next sync). Best-effort.
+      // (which would re-appear locally on the next sync). Fire-and-forget: the
+      // local delete is the source of truth, so we don't block the response on
+      // the creds lookup + Navidrome round-trips whose result we discard.
       if (playlist.navidromeId) {
-        const creds = await getNavidromeUserCreds(session.user.id);
-        if (creds) {
-          await mirrorRemoveSong(playlist.navidromeId, songId, creds);
-        }
+        const navidromeId = playlist.navidromeId;
+        void (async () => {
+          const creds = await getNavidromeUserCreds(session.user.id);
+          if (creds) await mirrorRemoveSong(navidromeId, songId, creds);
+        })().catch(() => {});
       }
 
       return new Response(JSON.stringify({ data: { success: true } }), {

--- a/src/routes/api/playlists/$id/songs/index.ts
+++ b/src/routes/api/playlists/$id/songs/index.ts
@@ -107,8 +107,10 @@ export const Route = createFileRoute("/api/playlists/$id/songs/")({
         .where(eq(userPlaylists.id, playlistId));
 
       // Mirror the add to Navidrome (back-fills the playlist if it was still
-      // local-only). Best-effort — never fails the local add.
-      await mirrorAddSong(playlistId, session.user.id, validatedData.songId);
+      // local-only). Fire-and-forget — the local add is the source of truth, so
+      // we don't block the response on a best-effort Navidrome round-trip whose
+      // result we discard. mirrorAddSong never throws; guard anyway.
+      void mirrorAddSong(playlistId, session.user.id, validatedData.songId).catch(() => {});
 
       return new Response(JSON.stringify({
         data: {

--- a/src/routes/api/playlists/index.ts
+++ b/src/routes/api/playlists/index.ts
@@ -1,7 +1,7 @@
 import { createFileRoute } from "@tanstack/react-router";
 import { db } from '../../../lib/db';
 import { userPlaylists, playlistSongs } from '../../../lib/db/schema/playlists.schema';
-import { eq, sql, desc } from 'drizzle-orm';
+import { and, eq, sql, desc } from 'drizzle-orm';
 import { z } from 'zod';
 import { checkNavidromeConnectivity } from '../../../lib/services/navidrome';
 import { ensurePlaylistOnNavidrome } from '../../../lib/services/playlist-navidrome-mirror';
@@ -25,12 +25,18 @@ const POST = withAuthAndErrorHandling(
     const body = await request.json();
     const validatedData = CreatePlaylistSchema.parse(body);
 
-    // Check for duplicate playlist name
+    // Check for duplicate playlist name (scoped to this user). Must be a single
+    // combined predicate: chaining `.where().where()` makes drizzle keep only the
+    // last clause, which would drop the userId filter and match any user's name.
     const existingPlaylist = await db
       .select()
       .from(userPlaylists)
-      .where(eq(userPlaylists.userId, session.user.id))
-      .where(eq(userPlaylists.name, validatedData.name))
+      .where(
+        and(
+          eq(userPlaylists.userId, session.user.id),
+          eq(userPlaylists.name, validatedData.name),
+        ),
+      )
       .limit(1)
       .then(rows => rows[0]);
 
@@ -54,12 +60,14 @@ const POST = withAuthAndErrorHandling(
     console.log(`✅ Playlist "${newPlaylist.name}" created (empty)`);
 
     // Mirror to Navidrome so it becomes a real (syncable) playlist, not a
-    // local-only row. Best-effort: if it can't be created now (offline, no
-    // creds), the row stays local and is back-filled on the next edit / by the
-    // back-fill script.
-    const navidromeId = await ensurePlaylistOnNavidrome(newPlaylist.id, session.user.id);
+    // local-only row. Fire-and-forget: the local write is the source of truth,
+    // so we don't block the response on a best-effort Navidrome round-trip. The
+    // row's navidromeId is populated in the background (and by the next edit /
+    // the back-fill script if this attempt fails). ensurePlaylistOnNavidrome
+    // never throws, but guard anyway so the promise can't reject unhandled.
+    void ensurePlaylistOnNavidrome(newPlaylist.id, session.user.id).catch(() => {});
 
-    return successResponse({ ...newPlaylist, navidromeId }, 201);
+    return successResponse({ ...newPlaylist, navidromeId: null }, 201);
   },
   {
     service: 'playlists',

--- a/src/routes/api/playlists/smart/index.ts
+++ b/src/routes/api/playlists/smart/index.ts
@@ -2,7 +2,7 @@ import { createFileRoute } from "@tanstack/react-router";
 import { auth } from '../../../../lib/auth/auth';
 import { db } from '../../../../lib/db';
 import { userPlaylists, playlistSongs } from '../../../../lib/db/schema/playlists.schema';
-import { eq } from 'drizzle-orm';
+import { and, eq } from 'drizzle-orm';
 import {
   createSmartPlaylist,
   listSmartPlaylists,
@@ -60,8 +60,12 @@ export const Route = createFileRoute("/api/playlists/smart/")({
       const existingPlaylist = await db
         .select()
         .from(userPlaylists)
-        .where(eq(userPlaylists.userId, session.user.id))
-        .where(eq(userPlaylists.name, validatedData.name))
+        .where(
+          and(
+            eq(userPlaylists.userId, session.user.id),
+            eq(userPlaylists.name, validatedData.name),
+          ),
+        )
         .limit(1)
         .then(rows => rows[0]);
 

--- a/src/routes/api/playlists/smart/index.ts
+++ b/src/routes/api/playlists/smart/index.ts
@@ -147,7 +147,7 @@ export const Route = createFileRoute("/api/playlists/smart/")({
         return new Response(JSON.stringify({
           code: 'VALIDATION_ERROR',
           message: 'Invalid smart playlist data',
-          errors: error.errors,
+          errors: error.issues,
         }), {
           status: 400,
           headers: { 'Content-Type': 'application/json' }


### PR DESCRIPTION
Post-merge review of #178 (mirror basic playlists to Navidrome) surfaced six issues in the playlist → Navidrome mirror. This fixes all six, plus one adjacent duplicate-name bug found next to the change.

## Fixes

| Issue | Fix |
|-------|-----|
| **Liked Songs misclassification** — name fallback (`/liked/i`) tagged user lists like "Songs I Liked in 2020" as canonical and never mirrored them | `isMirrorable` keys off the explicit `isLikedSongs` flag |
| **Resurrection** — healing a soft-deleted row forward recreated a list the user deleted on Navidrome | New `playlist-deleted-marker.ts` module; `ensurePlaylistOnNavidrome` consults the `[Deleted from Navidrome]` marker before (re)creating (fail-closed, #175/#160) |
| **Concurrent duplicate create** | Per-`playlistId` in-flight promise map serializes calls within the process |
| **Same-name duplicate** | Adopt an existing same-name remote playlist and push only the songs it's missing (Subsonic appends unconditionally) |
| **Crash on empty playlist** — Subsonic omits `entry`, type lies | `remote.entry ?? []` in `mirrorRemoveSong` + adopt path |
| **Blocking response** — awaited best-effort Navidrome round-trips | Fire-and-forget on create/add/remove; local write is the source of truth. POST returns `navidromeId: null` (no client reads it off the create response) |
| **Adjacent bug** — `POST /api/playlists` + `/smart` duplicate-name check chained `.where().where()`, which drops the userId filter (drizzle keeps only the last clause), so any user's name blocked creation | Combined into a single `and(...)` predicate |

## Tests
- New `playlist-deleted-marker.test.ts` (7) — marker detect/strip + round-trip with the sync write shape
- New `playlist-navidrome-mirror.test.ts` (4) — `mirrorRemoveSong` empty/present/absent/error paths
- 28/28 green across the playlist suites; no new type errors on changed lines

## Notes / follow-ups
- The per-process in-flight dedup is documented as a single-instance-only guarantee; a code comment records the shared-lock path for future multi-instance deploys.
- Editing a *soft-deleted* playlist is currently a silent local-only dead-end (by the fail-closed design). UX decision tracked in #199.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQj7kfXYU9jy1L9ByWw8r