### PR TITLE
fix(playlists): recognize Chosic CSV exports in playlist import

### DIFF
--- a/src/components/playlists/import/playlist-import-dialog.tsx
+++ b/src/components/playlists/import/playlist-import-dialog.tsx
@@ -61,14 +61,29 @@ interface ImportResult {
   matchResults?: SongMatchResult[];
 }
 
-// Detect if content looks like CSV (Spotify Exportify format)
+// Detect if content looks like CSV (Spotify Exportify or Chosic playlist export)
 function looksLikeCSV(content: string): boolean {
   const firstLine = content.split(/\r?\n/)[0]?.toLowerCase() || '';
   return (
     (firstLine.includes('track') && firstLine.includes('artist')) ||
     firstLine.includes('track uri') ||
-    firstLine.includes('track name')
+    firstLine.includes('track name') ||
+    // Chosic's export header has no "track" word: Title,Artist,Album,Spotify URL
+    (firstLine.includes('title') && firstLine.includes('artist'))
   );
+}
+
+// Distinguish Chosic's minimal export (Title,Artist,Album,Spotify URL) from
+// Spotify Exportify's fuller one (Track URI,Track Name,...,Danceability,...)
+function detectCsvSourceLabel(headerLine: string): 'Chosic' | 'Spotify' {
+  const lower = headerLine.toLowerCase();
+  if (lower.includes('track uri') || lower.includes('track name') || lower.includes('danceability')) {
+    return 'Spotify';
+  }
+  if (lower.includes('title') && lower.includes('artist')) {
+    return 'Chosic';
+  }
+  return 'Spotify';
 }
 
 // Client-side playlist validation
@@ -165,8 +180,9 @@ function validatePlaylistClient(content: string, format?: ExportFormat): Validat
       if (lines.length >= 2) {
         // Count data rows (excluding header)
         songCount = lines.length - 1;
-        playlistName = 'Spotify Import';
-        description = `Imported from Spotify CSV (${songCount} tracks)`;
+        const sourceLabel = detectCsvSourceLabel(lines[0]);
+        playlistName = `${sourceLabel} Import`;
+        description = `Imported from ${sourceLabel} CSV (${songCount} tracks)`;
       }
     }
 

--- a/src/components/playlists/import/steps/file-upload-step.tsx
+++ b/src/components/playlists/import/steps/file-upload-step.tsx
@@ -70,7 +70,9 @@ export function FileUploadStep({
     if (
       (firstLine.includes('track') && firstLine.includes('artist')) ||
       firstLine.includes('track uri') ||
-      firstLine.includes('track name')
+      firstLine.includes('track name') ||
+      // Chosic's export header has no "track" word: Title,Artist,Album,Spotify URL
+      (firstLine.includes('title') && firstLine.includes('artist'))
     ) {
       return 'csv';
     }

--- a/src/lib/services/__tests__/playlist-export.test.ts
+++ b/src/lib/services/__tests__/playlist-export.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { parsePlaylist, parseCSV, detectCsvSource } from '../playlist-export';
+
+const CHOSIC_CSV = `Title,Artist,Album,Spotify URL
+"The Impostor","AiramFM","The Impostor",https://open.spotify.com/track/4giXujhQsXo9f41u7MPIhI
+"Нормальная музыка","UBEL","Нормальная музыка",https://open.spotify.com/track/5q6mJIesSR9mEzOeDFRGdt
+"rumination","Study Sloane","rumination",https://open.spotify.com/track/0gPWRUedBRHCch1mmKSkPs`;
+
+const EXPORTIFY_CSV = `Track URI,Track Name,Album Name,Artist Name(s),Release Date,Duration (ms),Popularity,Explicit,Added By,Added At,Genres,Record Label,Danceability,Energy,Key,Loudness,Mode,Speechiness,Acousticness,Instrumentalness,Liveness,Valence,Tempo,Time Signature
+spotify:track:5IlRYF58hRv5E0D2fykZXX,"August Dub","August Dub","Sharam",2015-09-18,219047,0,false,juenr,2026-07-13T05:39:30Z,"","Spinnin' Remixes",0.668,0.759,3,-6.61,1,0.0341,0.0518,0.894,0.1,0.672,125.97,4`;
+
+describe('detectCsvSource', () => {
+  it('recognizes the Chosic minimal header', () => {
+    expect(detectCsvSource(['title', 'artist', 'album', 'spotify url'])).toBe('chosic');
+  });
+
+  it('recognizes the Exportify header', () => {
+    expect(detectCsvSource(['track uri', 'track name', 'album name', 'artist name(s)'])).toBe('spotify_exportify');
+  });
+});
+
+describe('parsePlaylist auto-detection with a Chosic export', () => {
+  it('detects CSV format without an explicit format hint', () => {
+    // Chosic's header has no "track" substring anywhere, which previously
+    // caused looksLikeCSV() to reject it and throw IMPORT_FORMAT_ERROR.
+    const result = parsePlaylist(CHOSIC_CSV);
+    expect(result.format).toBe('csv');
+    expect(result.playlist.songs).toHaveLength(3);
+  });
+});
+
+describe('parseCSV', () => {
+  it('parses Chosic playlist export rows (Title,Artist,Album,Spotify URL)', () => {
+    const result = parseCSV(CHOSIC_CSV);
+
+    expect(result.playlist.songs).toHaveLength(3);
+    expect(result.playlist.description).toContain('Chosic');
+
+    const [first] = result.playlist.songs;
+    expect(first.title).toBe('The Impostor');
+    expect(first.artist).toBe('AiramFM');
+    expect(first.album).toBe('The Impostor');
+    expect(first.platform).toBe('spotify');
+    expect(first.platformId).toBe('4giXujhQsXo9f41u7MPIhI');
+    expect(first.url).toBe('https://open.spotify.com/track/4giXujhQsXo9f41u7MPIhI');
+  });
+
+  it('still labels Exportify CSVs as Spotify', () => {
+    const result = parseCSV(EXPORTIFY_CSV);
+    expect(result.playlist.description).toContain('Spotify');
+    expect(result.playlist.songs[0].platformId).toBe('5IlRYF58hRv5E0D2fykZXX');
+  });
+});

--- a/src/lib/services/playlist-export.ts
+++ b/src/lib/services/playlist-export.ts
@@ -591,7 +591,31 @@ export function parseJSON(content: string): ImportResult {
 }
 
 /**
- * Parse CSV playlist content (Spotify Exportify format)
+ * CSV source, inferred from header shape — drives the playlist name/description
+ * and which platform we tag matched songs with.
+ */
+export type CsvSource = 'chosic' | 'spotify_exportify' | 'generic';
+
+/**
+ * Detect which tool produced a playlist CSV, from its header row alone.
+ * - Chosic's playlist export/analyzer: `Title,Artist,Album,Spotify URL` (minimal, no audio-feature columns)
+ * - Exportify (Spotify): `Track URI,Track Name,Album Name,Artist Name(s),...,Danceability,Energy,...`
+ */
+export function detectCsvSource(headers: string[]): CsvSource {
+  const has = (name: string) => headers.includes(name);
+  if (has('track uri') || has('danceability') || has('track name')) {
+    return 'spotify_exportify';
+  }
+  if (has('title') && has('artist') && (has('spotify url') || headers.length <= 5)) {
+    return 'chosic';
+  }
+  return 'generic';
+}
+
+/**
+ * Parse CSV playlist content. Recognizes Chosic's playlist export
+ * (`Title,Artist,Album,Spotify URL`) and Spotify Exportify's fuller export;
+ * falls back to a generic title/artist/album column match otherwise.
  */
 export function parseCSV(content: string): ImportResult {
   const warnings: string[] = [];
@@ -606,6 +630,7 @@ export function parseCSV(content: string): ImportResult {
     // Parse header row to find column indices
     const headerRow = parseCSVRow(lines[0]);
     const headers = headerRow.map(h => h.toLowerCase().trim());
+    const source = detectCsvSource(headers);
 
     // Map common column names
     const columnMap: Record<string, number> = {};
@@ -614,7 +639,7 @@ export function parseCSV(content: string): ImportResult {
       artistName: ['artist name(s)', 'artist name', 'artistname', 'artist', 'artists'],
       albumName: ['album name', 'albumname', 'album'],
       duration: ['duration (ms)', 'duration_ms', 'duration'],
-      trackUri: ['track uri', 'trackuri', 'uri', 'spotify uri'],
+      trackUri: ['track uri', 'trackuri', 'uri', 'spotify uri', 'spotify url'],
       genres: ['genres', 'genre'],
     };
 
@@ -671,8 +696,10 @@ export function parseCSV(content: string): ImportResult {
 
         if (columnMap.trackUri !== undefined && row[columnMap.trackUri]) {
           const uri = row[columnMap.trackUri].trim();
-          // Extract Spotify track ID from URI (spotify:track:xxx)
-          const match = uri.match(/spotify:track:([a-zA-Z0-9]+)/);
+          // Extract Spotify track ID from either a URI (spotify:track:xxx) or a
+          // full share URL (https://open.spotify.com/track/xxx), which is what
+          // Chosic exports use.
+          const match = uri.match(/spotify(?::track:|\.com\/track\/)([a-zA-Z0-9]+)/);
           if (match) {
             song.platform = 'spotify';
             song.platformId = match[1];
@@ -690,10 +717,12 @@ export function parseCSV(content: string): ImportResult {
       throw new Error('No valid songs found in CSV');
     }
 
+    const sourceLabel = source === 'chosic' ? 'Chosic' : 'Spotify';
+
     return {
       playlist: {
         name: 'Imported Playlist',
-        description: `Imported from Spotify CSV (${songs.length} tracks)`,
+        description: `Imported from ${sourceLabel} CSV (${songs.length} tracks)`,
         platform: 'spotify',
         songs,
       },
@@ -777,15 +806,16 @@ export function parsePlaylist(content: string, format?: PlaylistExportFormat): I
 }
 
 /**
- * Detect if content looks like CSV (Spotify Exportify format)
+ * Detect if content looks like CSV (Spotify Exportify or Chosic playlist export)
  */
 function looksLikeCSV(content: string): boolean {
   const firstLine = content.split(/\r?\n/)[0]?.toLowerCase() || '';
-  // Check for common Spotify CSV headers
   return (
     (firstLine.includes('track') && firstLine.includes('artist')) ||
     firstLine.includes('track uri') ||
-    firstLine.includes('track name')
+    firstLine.includes('track name') ||
+    // Chosic's export header has no "track" word: Title,Artist,Album,Spotify URL
+    (firstLine.includes('title') && firstLine.includes('artist'))
   );
 }
 


### PR DESCRIPTION
## Summary
- Chosic's playlist export CSV (`Title,Artist,Album,Spotify URL`) has no `"track"` substring anywhere in its header, so the existing `looksLikeCSV()` auto-detection (duplicated across the server parser and two client components) silently rejected it as an unrecognized format before parsing ever ran.
- Broadened detection to also match on a `title` + `artist` header shape, and extended the Spotify-URL extraction regex to handle Chosic's full `https://open.spotify.com/track/…` links, not just Exportify's `spotify:track:…` URI scheme.
- The playlist name/description no longer hardcodes "Spotify CSV" for every CSV import — it's now labeled by actual detected source (Chosic vs. Spotify Exportify).
- Verified end-to-end against a real Chosic export (100 tracks, 0 warnings, all rows resolve a Spotify track ID) — this reuses the existing Navidrome-matching/review/confirm pipeline in `/api/playlists/import` unchanged.

## Test plan
- [x] `npx vitest run src/lib/services/__tests__/playlist-export.test.ts` — new coverage for Chosic vs. Exportify header detection and parsing
- [x] Parsed the actual downloaded Chosic CSV end-to-end via a script — 100/100 tracks parsed, correct title/artist/album/platformId, 0 warnings
- [x] `npx tsc --noEmit` — no new errors introduced (one pre-existing unrelated `ValidationResult` duplicate-type error confirmed present on `main` before this change)
- [x] `npx eslint` on changed files — no new errors, only pre-existing warnings
- [ ] Manual UI smoke test of the "Import Playlist" dialog with a Chosic CSV upload

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LAQj7kfXYU9jy1L9ByWw8r